### PR TITLE
Add assertions correct instructions are generated

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+
+install:
+  # Install rust, x86_64-pc-windows-msvc host
+  - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%
+  - rustc -vV
+  - cargo -vV
+
+build: false
+
+test_script:
+  - cargo test --target %TARGET%
+  - cargo test --target %TARGET% --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: rust
+sudo: false
+
+matrix:
+  include:
+    - rust: nightly
+    - rust: nightly
+      os: osx
+
+script:
+  - cargo test
+  - cargo test --release
+
+notifications:
+  email:
+    on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ license = "MIT"
 [profile.release]
 debug = true
 opt-level = 3
+
+[profile.bench]
+debug = 1
+opt-level = 3
+
+[dev-dependencies]
+assert-instr = { path = "assert-instr" }

--- a/assert-instr/Cargo.toml
+++ b/assert-instr/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "assert-instr"
+version = "0.1.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+
+[dependencies]
+assert-instr-macro = { path = "assert-instr-macro" }
+backtrace = "0.3"
+cc = "1.0"
+lazy_static = "0.2"
+rustc-demangle = "0.1"

--- a/assert-instr/assert-instr-macro/Cargo.toml
+++ b/assert-instr/assert-instr-macro/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "assert-instr-macro"
+version = "0.1.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+
+[lib]
+proc-macro = true

--- a/assert-instr/assert-instr-macro/build.rs
+++ b/assert-instr/assert-instr-macro/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let opt_level = env::var("OPT_LEVEL").ok().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let profile = env::var("PROFILE").unwrap_or(String::new());
+    if profile == "release" || opt_level >= 2 {
+        println!("cargo:rustc-cfg=optimized");
+    }
+}

--- a/assert-instr/src/lib.rs
+++ b/assert-instr/src/lib.rs
@@ -1,0 +1,247 @@
+#![feature(proc_macro)]
+
+extern crate assert_instr_macro;
+extern crate backtrace;
+extern crate cc;
+extern crate rustc_demangle;
+#[macro_use]
+extern crate lazy_static;
+
+use std::collections::HashMap;
+use std::env;
+use std::process::Command;
+use std::str;
+
+pub use assert_instr_macro::*;
+
+lazy_static! {
+    static ref DISASSEMBLY: HashMap<String, Vec<Function>> = disassemble_myself();
+}
+
+struct Function {
+    instrs: Vec<Instruction>,
+}
+
+struct Instruction {
+    parts: Vec<String>,
+}
+
+fn disassemble_myself() -> HashMap<String, Vec<Function>> {
+    let me = env::current_exe().expect("failed to get current exe");
+
+    if cfg!(target_arch = "x86_64") &&
+        cfg!(target_os = "windows") &&
+        cfg!(target_env = "msvc") {
+        let mut cmd = cc::windows_registry::find("x86_64-pc-windows-msvc", "dumpbin.exe")
+            .expect("failed to find `dumpbin` tool");
+        let output = cmd.arg("/DISASM").arg(&me).output()
+            .expect("failed to execute dumpbin");
+        println!("{}\n{}", output.status, String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+        parse_dumpbin(&String::from_utf8_lossy(&output.stdout))
+    } else if cfg!(target_os = "windows") {
+        panic!("disassembly unimplemented")
+    } else if cfg!(target_os = "macos") {
+        let output = Command::new("otool")
+            .arg("-vt")
+            .arg(&me)
+            .output()
+            .expect("failed to execute otool");
+        println!("{}\n{}", output.status, String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+
+        parse_otool(&str::from_utf8(&output.stdout).expect("stdout not utf8"))
+    } else {
+        let output = Command::new("objdump")
+            .arg("--disassemble")
+            .arg(&me)
+            .output()
+            .expect("failed to execute objdump");
+        println!("{}\n{}", output.status, String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+
+        parse_objdump(&str::from_utf8(&output.stdout).expect("stdout not utf8"))
+    }
+}
+
+fn parse_objdump(output: &str) -> HashMap<String, Vec<Function>> {
+    let mut lines = output.lines();
+
+    for line in output.lines().take(100) {
+        println!("{}", line);
+    }
+
+    let mut ret = HashMap::new();
+    while let Some(header) = lines.next() {
+        // symbols should start with `$hex_addr <$name>:`
+        if !header.ends_with(">:") {
+            continue
+        }
+        let start = header.find("<").unwrap();
+        let symbol = &header[start + 1..header.len() - 2];
+
+        let mut instructions = Vec::new();
+        while let Some(instruction) = lines.next() {
+            if instruction.is_empty() {
+                break
+            }
+            // Each line of instructions should look like:
+            //
+            //      $rel_offset: ab cd ef 00    $instruction...
+            let parts = instruction.split_whitespace()
+                .skip(1)
+                .skip_while(|s| {
+                    s.len() == 2 && usize::from_str_radix(s, 16).is_ok()
+                })
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>();
+            instructions.push(Instruction { parts });
+        }
+
+        ret.entry(normalize(symbol))
+            .or_insert(Vec::new())
+            .push(Function { instrs: instructions });
+    }
+
+    return ret
+}
+
+fn parse_otool(output: &str) -> HashMap<String, Vec<Function>> {
+    let mut lines = output.lines();
+
+    for line in output.lines().take(100) {
+        println!("{}", line);
+    }
+
+    let mut ret = HashMap::new();
+    let mut cached_header = None;
+    loop {
+        let header = match cached_header.take().or_else(|| lines.next()) {
+            Some(header) => header,
+            None => break,
+        };
+        // symbols should start with `$symbol:`
+        if !header.ends_with(":") {
+            continue
+        }
+        // strip the leading underscore and the trailing colon
+        let symbol = &header[1..header.len() - 1];
+
+        let mut instructions = Vec::new();
+        while let Some(instruction) = lines.next() {
+            if instruction.ends_with(":") {
+                cached_header = Some(instruction);
+                break
+            }
+            // Each line of instructions should look like:
+            //
+            //      $addr    $instruction...
+            let parts = instruction.split_whitespace()
+                .skip(1)
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>();
+            instructions.push(Instruction { parts });
+        }
+
+        ret.entry(normalize(symbol))
+            .or_insert(Vec::new())
+            .push(Function { instrs: instructions });
+    }
+
+    return ret
+}
+
+fn parse_dumpbin(output: &str) -> HashMap<String, Vec<Function>> {
+    let mut lines = output.lines();
+
+    for line in output.lines().take(100) {
+        println!("{}", line);
+    }
+
+    let mut ret = HashMap::new();
+    let mut cached_header = None;
+    loop {
+        let header = match cached_header.take().or_else(|| lines.next()) {
+            Some(header) => header,
+            None => break,
+        };
+        // symbols should start with `$symbol:`
+        if !header.ends_with(":") {
+            continue
+        }
+        // strip the trailing colon
+        let symbol = &header[..header.len() - 1];
+
+        let mut instructions = Vec::new();
+        while let Some(instruction) = lines.next() {
+            if !instruction.starts_with("  ") {
+                cached_header = Some(instruction);
+                break
+            }
+            // Each line looks like:
+            //
+            // >  $addr: ab cd ef     $instr..
+            // >         00 12          # this line os optional
+            if instruction.starts_with("       ") {
+                continue
+            }
+            let parts = instruction.split_whitespace()
+                .skip(1)
+                .skip_while(|s| {
+                    s.len() == 2 && usize::from_str_radix(s, 16).is_ok()
+                })
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>();
+            instructions.push(Instruction { parts });
+        }
+
+        ret.entry(normalize(symbol))
+            .or_insert(Vec::new())
+            .push(Function { instrs: instructions });
+    }
+
+    return ret
+}
+
+fn normalize(symbol: &str) -> String {
+    let symbol = rustc_demangle::demangle(symbol).to_string();
+    match symbol.rfind("::h") {
+        Some(i) => symbol[..i].to_string(),
+        None => symbol.to_string(),
+    }
+}
+
+pub fn assert(fnptr: usize, expected: &str) {
+    let mut sym = None;
+    backtrace::resolve(fnptr as *mut _, |name| {
+        sym = name.name().and_then(|s| s.as_str()).map(normalize);
+    });
+
+    let sym = match sym {
+        Some(s) => s,
+        None => panic!("failed to get symbol of function pointer: {}", fnptr),
+    };
+
+    let functions = &DISASSEMBLY.get(&sym)
+        .expect(&format!("failed to find disassembly of {}", sym));
+    assert_eq!(functions.len(), 1);
+    let function = &functions[0];
+    for instr in function.instrs.iter() {
+        if let Some(part) = instr.parts.get(0) {
+            if part == expected {
+                return
+            }
+        }
+    }
+
+    println!("disassembly for {}: ", sym);
+    for (i, instr) in function.instrs.iter().enumerate() {
+        print!("\t{:2}: ", i);
+        for part in instr.parts.iter() {
+            print!("{} ", part);
+        }
+        println!("");
+    }
+    panic!("failed to find instruction `{}` in the disassembly", expected);
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,10 @@
     const_fn, link_llvm_intrinsics, platform_intrinsics, repr_simd, simd_ffi,
     target_feature, cfg_target_feature, i128_type
 )]
+#![cfg_attr(test, feature(proc_macro))]
+
+#[cfg(test)]
+extern crate assert_instr;
 
 /// Platform independent SIMD vector types and operations.
 pub mod simd {

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -1,9 +1,13 @@
 use v128::*;
 
+#[cfg(test)]
+use assert_instr::assert_instr;
+
 /// Return the square root of packed single-precision (32-bit) floating-point
 /// elements in `a`.
 #[inline(always)]
 #[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(sqrtps))]
 pub fn _mm_sqrt_ps(a: f32x4) -> f32x4 {
     unsafe { sqrtps(a) }
 }
@@ -12,6 +16,7 @@ pub fn _mm_sqrt_ps(a: f32x4) -> f32x4 {
 /// floating-point elements in `a`.
 #[inline(always)]
 #[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(rcpps))]
 pub fn _mm_rcp_ps(a: f32x4) -> f32x4 {
     unsafe { rcpps(a) }
 }
@@ -20,6 +25,7 @@ pub fn _mm_rcp_ps(a: f32x4) -> f32x4 {
 /// (32-bit) floating-point elements in `a`.
 #[inline(always)]
 #[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(rsqrtps))]
 pub fn _mm_rsqrt_ps(a: f32x4) -> f32x4 {
     unsafe { rsqrtps(a) }
 }
@@ -28,6 +34,7 @@ pub fn _mm_rsqrt_ps(a: f32x4) -> f32x4 {
 /// `b`, and return the corresponding minimum values.
 #[inline(always)]
 #[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(minps))]
 pub fn _mm_min_ps(a: f32x4, b: f32x4) -> f32x4 {
     unsafe { minps(a, b) }
 }
@@ -36,6 +43,7 @@ pub fn _mm_min_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// `b`, and return the corresponding maximum values.
 #[inline(always)]
 #[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(maxps))]
 pub fn _mm_max_ps(a: f32x4, b: f32x4) -> f32x4 {
     unsafe { maxps(a, b) }
 }
@@ -46,6 +54,7 @@ pub fn _mm_max_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// All other bits are set to `0`.
 #[inline(always)]
 #[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(movmskps))]
 pub fn _mm_movemask_ps(a: f32x4) -> i32 {
     unsafe { movmskps(a) }
 }


### PR DESCRIPTION
This commit adds a procedural macro which can be used to test instruction
generation in a lightweight way. The intention is that all functions are
annotated with:

    #[cfg_attr(test, assert_instr(maxps))]
    fn foo(...) {
        // ...
    }

and then during `cargo test --release` it'll assert the function `foo` does
indeed generate the instruction `maxps`. This only activates tests in optimized
mode to avoid debug mode inefficiencies, and it uses a literal invocation of
`objdump` and some parsing to figure out what instructions are inside each
function. Finally it also uses the `backtrace` crate to figure out the symbol
name of the relevant function and hook that up to the output of `objdump`.

I added a few assertions in the `sse` module to get some feedback, but curious
what y'all think of this!