### PR TITLE
Assert that diassembly is "small"

### DIFF
--- a/assert-instr/src/lib.rs
+++ b/assert-instr/src/lib.rs
@@ -256,15 +256,23 @@ pub fn assert(fnptr: usize, fnname: &str, expected: &str) {
 
     // Look for `expected` as the first part of any instruction in this
     // function, returning if we do indeed find it.
+    let mut found = false;
     for instr in function.instrs.iter() {
         // Gets the first instruction, e.g. tzcntl in tzcntl %rax,%rax
         if let Some(part) = instr.parts.get(0) {
             // Truncates the instruction with the length of the expected
             // instruction: tzcntl => tzcnt and compares that.
             if part.starts_with(expected) {
-                return
+                found = true;
+                break
             }
         }
+    }
+
+    let probably_only_one_instruction = function.instrs.len() < 20;
+
+    if found && probably_only_one_instruction {
+        return
     }
 
     // Help debug by printing out the found disassembly, and then panic as we
@@ -277,5 +285,10 @@ pub fn assert(fnptr: usize, fnname: &str, expected: &str) {
         }
         println!("");
     }
-    panic!("failed to find instruction `{}` in the disassembly", expected);
+
+    if !found {
+        panic!("failed to find instruction `{}` in the disassembly", expected);
+    } else if !probably_only_one_instruction {
+        panic!("too many instructions in the disassembly");
+    }
 }


### PR DESCRIPTION
There's a lot of trickery in this crate which expands to a lot of code, so in
addition to asserting that we find the right instruction, let's assert we find
a small function as well (as these should all be just one or so instructions
anyway).