### PR TITLE
Enhance `#[assert_instr]` with constant arguments

### DIFF
--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -84,18 +84,12 @@ pub unsafe fn _mm256_sub_ps(a: f32x8, b: f32x8) -> f32x8 {
 /// ```
 #[inline(always)]
 #[target_feature = "+avx"]
+#[cfg_attr(test, assert_instr(vroundpd, b = 0x3))]
 pub unsafe fn _mm256_round_pd(a: f64x4, b: i32) -> f64x4 {
     macro_rules! call {
         ($imm8:expr) => { roundpd256(a, $imm8) }
     }
     constify_imm8!(b, call)
-}
-
-#[cfg(test)]
-#[cfg_attr(test, assert_instr(vroundpd))]
-#[target_feature = "+avx"]
-fn test_mm256_round_pd(a: f64x4) -> f64x4 {
-    unsafe { _mm256_round_pd(a, 0x3) }
 }
 
 /// Round packed double-precision (64-bit) floating point elements in `a` toward

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -171,6 +171,7 @@ pub unsafe fn _mm_max_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// `b`. Mask is split to 2 control bits each to index the element from inputs.
 #[inline(always)]
 #[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(shufps, mask = 3))]
 pub unsafe fn _mm_shuffle_ps(a: f32x4, b: f32x4, mask: i32) -> f32x4 {
     let mask = (mask & 0xFF) as u8;
 
@@ -215,13 +216,6 @@ pub unsafe fn _mm_shuffle_ps(a: f32x4, b: f32x4, mask: i32) -> f32x4 {
         0b10 => shuffle_x23!(2),
         _ => shuffle_x23!(3),
     }
-}
-
-#[cfg(test)]
-#[target_feature = "+sse"]
-#[cfg_attr(test, assert_instr(shufps))]
-fn _test_mm_shuffle_ps(a: f32x4, b: f32x4) -> f32x4 {
-    unsafe { _mm_shuffle_ps(a, b, 3) }
 }
 
 /// Unpack and interleave single-precision (32-bit) floating-point elements

--- a/stdsimd-test/assert-instr-macro/Cargo.toml
+++ b/stdsimd-test/assert-instr-macro/Cargo.toml
@@ -5,3 +5,9 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 
 [lib]
 proc-macro = true
+
+[dependencies]
+proc-macro2 = { version = "0.1", features = ["unstable"] }
+quote = { git = 'https://github.com/dtolnay/quote' }
+syn = { git = 'https://github.com/dtolnay/syn', features = ["full"] }
+synom = { git = 'https://github.com/dtolnay/syn' }


### PR DESCRIPTION
Some intrinsics need to be invoked with constant arguments to get the right
instruction to get generated, so this commit enhances the `assert_instr` macro
to enable this ability. Namely you pass constant arguments like:

    #[assert_instr(foo, a = b)]

where this will assert that the intrinsic, when invoked with argument `a` equal
to the value `b` and all other arguments passed from the outside, will generate
the instruction `foo`.

Closes #49