### PR TITLE
Add vandpd, vandps, vorpd and vorps for AVX

### DIFF
--- a/src/v256.rs
+++ b/src/v256.rs
@@ -73,6 +73,11 @@ define_from!(i16x16, u64x4, i64x4, u32x8, i32x8, u16x16, u8x32, i8x32);
 define_from!(u8x32, u64x4, i64x4, u32x8, i32x8, u16x16, i16x16, i8x32);
 define_from!(i8x32, u64x4, i64x4, u32x8, i32x8, u16x16, i16x16, u8x32);
 
+define_from!(f64x4, u64x4);
+define_from!(u64x4, f64x4);
+define_from!(f32x8, u32x8);
+define_from!(u32x8, f32x8);
+
 define_common_ops!(
     f64x4, f32x8, u64x4, i64x4, u32x8, i32x8, u16x16, i16x16, u8x32, i8x32);
 define_float_ops!(f64x4, f32x8);

--- a/src/v256.rs
+++ b/src/v256.rs
@@ -73,11 +73,6 @@ define_from!(i16x16, u64x4, i64x4, u32x8, i32x8, u16x16, u8x32, i8x32);
 define_from!(u8x32, u64x4, i64x4, u32x8, i32x8, u16x16, i16x16, i8x32);
 define_from!(i8x32, u64x4, i64x4, u32x8, i32x8, u16x16, i16x16, u8x32);
 
-define_from!(f64x4, u64x4);
-define_from!(u64x4, f64x4);
-define_from!(f32x8, u32x8);
-define_from!(u32x8, f32x8);
-
 define_common_ops!(
     f64x4, f32x8, u64x4, i64x4, u32x8, i32x8, u16x16, i16x16, u8x32, i8x32);
 define_float_ops!(f64x4, f32x8);

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -20,6 +20,48 @@ pub unsafe fn _mm256_add_ps(a: f32x8, b: f32x8) -> f32x8 {
     a + b
 }
 
+/// Compute the bitwise AND of a packed double-precision (64-bit) floating-point elements
+/// in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+avx"]
+#[cfg_attr(test, assert_instr(vandpd))]
+pub unsafe fn _mm256_and_pd(a: f64x4, b: f64x4) -> f64x4 {
+    let a: u64x4 = a.into();
+    let b: u64x4 = b.into();
+    (a & b).into()
+}
+
+/// Compute the bitwise AND of packed single-precision (32-bit) floating-point elements in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+avx"]
+#[cfg_attr(test, assert_instr(vandps))]
+pub unsafe fn _mm256_and_ps(a: f32x8, b: f32x8) -> f32x8 {
+    let a: u32x8 = a.into();
+    let b: u32x8 = b.into();
+    (a & b).into()
+}
+
+/// Compute the bitwise OR packed double-precision (64-bit) floating-point elements
+/// in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+avx"]
+#[cfg_attr(test, assert_instr(vorpd))]
+pub unsafe fn _mm256_or_pd(a: f64x4, b: f64x4) -> f64x4 {
+    let a: u64x4 = a.into();
+    let b: u64x4 = b.into();
+    (a | b).into()
+}
+
+/// Compute the bitwise OR packed single-precision (32-bit) floating-point elements in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+avx"]
+#[cfg_attr(test, assert_instr(vorps))]
+pub unsafe fn _mm256_or_ps(a: f32x8, b: f32x8) -> f32x8 {
+    let a: u32x8 = a.into();
+    let b: u32x8 = b.into();
+    (a | b).into()
+}
+
 /// Compare packed double-precision (64-bit) floating-point elements 
 /// in `a` and `b`, and return packed maximum values
 #[inline(always)]
@@ -249,6 +291,42 @@ mod tests {
         let b = f32x8::new(9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
         let r = avx::_mm256_add_ps(a, b);
         let e = f32x8::new(10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "avx"]
+    unsafe fn _mm256_and_pd() {
+        let a = f64x4::splat(1.0);
+        let b = f64x4::splat(0.6);
+        let r = avx::_mm256_and_pd(a, b);
+        let e = f64x4::splat(0.5);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "avx"]
+    unsafe fn _mm256_and_ps() {
+        let a = f32x8::splat(1.0);
+        let b = f32x8::splat(0.6);
+        let r = avx::_mm256_and_ps(a, b);
+        let e = f32x8::splat(0.5);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "avx"]
+    unsafe fn _mm256_or_pd() {
+        let a = f64x4::splat(1.0);
+        let b = f64x4::splat(0.6);
+        let r = avx::_mm256_or_pd(a, b);
+        let e = f64x4::splat(1.2);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "avx"]
+    unsafe fn _mm256_or_ps() {
+        let a = f32x8::splat(1.0);
+        let b = f32x8::splat(0.6);
+        let r = avx::_mm256_or_ps(a, b);
+        let e = f32x8::splat(1.2);
         assert_eq!(r, e);
     }
 

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -26,7 +26,9 @@ pub unsafe fn _mm256_add_ps(a: f32x8, b: f32x8) -> f32x8 {
 /// in `a` and `b`.
 #[inline(always)]
 #[target_feature = "+avx"]
-#[cfg_attr(test, assert_instr(vandpd))]
+// Should be 'vandpd' instuction.
+// See https://github.com/rust-lang-nursery/stdsimd/issues/71
+#[cfg_attr(test, assert_instr(vandps))]
 pub unsafe fn _mm256_and_pd(a: f64x4, b: f64x4) -> f64x4 {
     let a: u64x4 = mem::transmute(a);
     let b: u64x4 = mem::transmute(b);
@@ -47,7 +49,9 @@ pub unsafe fn _mm256_and_ps(a: f32x8, b: f32x8) -> f32x8 {
 /// in `a` and `b`.
 #[inline(always)]
 #[target_feature = "+avx"]
-#[cfg_attr(test, assert_instr(vorpd))]
+// Should be 'vorpd' instuction.
+// See https://github.com/rust-lang-nursery/stdsimd/issues/71
+#[cfg_attr(test, assert_instr(vorps))]
 pub unsafe fn _mm256_or_pd(a: f64x4, b: f64x4) -> f64x4 {
     let a: u64x4 = mem::transmute(a);
     let b: u64x4 = mem::transmute(b);

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 use stdsimd_test::assert_instr;
 
+use std::mem;
+
 use v256::*;
 
 /// Add packed double-precision (64-bit) floating-point elements
@@ -26,9 +28,9 @@ pub unsafe fn _mm256_add_ps(a: f32x8, b: f32x8) -> f32x8 {
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vandpd))]
 pub unsafe fn _mm256_and_pd(a: f64x4, b: f64x4) -> f64x4 {
-    let a: u64x4 = a.into();
-    let b: u64x4 = b.into();
-    (a & b).into()
+    let a: u64x4 = mem::transmute(a);
+    let b: u64x4 = mem::transmute(b);
+    mem::transmute(a & b)
 }
 
 /// Compute the bitwise AND of packed single-precision (32-bit) floating-point elements in `a` and `b`.
@@ -36,9 +38,9 @@ pub unsafe fn _mm256_and_pd(a: f64x4, b: f64x4) -> f64x4 {
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vandps))]
 pub unsafe fn _mm256_and_ps(a: f32x8, b: f32x8) -> f32x8 {
-    let a: u32x8 = a.into();
-    let b: u32x8 = b.into();
-    (a & b).into()
+    let a: u32x8 = mem::transmute(a);
+    let b: u32x8 = mem::transmute(b);
+    mem::transmute(a & b)
 }
 
 /// Compute the bitwise OR packed double-precision (64-bit) floating-point elements
@@ -47,9 +49,9 @@ pub unsafe fn _mm256_and_ps(a: f32x8, b: f32x8) -> f32x8 {
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vorpd))]
 pub unsafe fn _mm256_or_pd(a: f64x4, b: f64x4) -> f64x4 {
-    let a: u64x4 = a.into();
-    let b: u64x4 = b.into();
-    (a | b).into()
+    let a: u64x4 = mem::transmute(a);
+    let b: u64x4 = mem::transmute(b);
+    mem::transmute(a | b)
 }
 
 /// Compute the bitwise OR packed single-precision (32-bit) floating-point elements in `a` and `b`.
@@ -57,9 +59,9 @@ pub unsafe fn _mm256_or_pd(a: f64x4, b: f64x4) -> f64x4 {
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vorps))]
 pub unsafe fn _mm256_or_ps(a: f32x8, b: f32x8) -> f32x8 {
-    let a: u32x8 = a.into();
-    let b: u32x8 = b.into();
-    (a | b).into()
+    let a: u32x8 = mem::transmute(a);
+    let b: u32x8 = mem::transmute(b);
+    mem::transmute(a | b)
 }
 
 /// Compare packed double-precision (64-bit) floating-point elements 

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -1,7 +1,7 @@
+use std::mem;
+
 #[cfg(test)]
 use stdsimd_test::assert_instr;
-
-use std::mem;
 
 use v256::*;
 

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1379,8 +1379,8 @@ pub unsafe fn _mm_sub_pd(a: f64x2, b: f64x2) -> f64x2 {
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(andps))]
 pub unsafe fn _mm_and_pd(a: f64x2, b: f64x2) -> f64x2 {
-    let a: i64x2 = mem::transmute(a);
-    let b: i64x2 = mem::transmute(b);
+    let a: u64x2 = mem::transmute(a);
+    let b: u64x2 = mem::transmute(b);
     mem::transmute(a & b)
 }
 
@@ -1389,8 +1389,8 @@ pub unsafe fn _mm_and_pd(a: f64x2, b: f64x2) -> f64x2 {
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(andnps))]
 pub unsafe fn _mm_andnot_pd(a: f64x2, b: f64x2) -> f64x2 {
-    let a: i64x2 = mem::transmute(a);
-    let b: i64x2 = mem::transmute(b);
+    let a: u64x2 = mem::transmute(a);
+    let b: u64x2 = mem::transmute(b);
     mem::transmute((!a) & b)
 }
 
@@ -1399,8 +1399,8 @@ pub unsafe fn _mm_andnot_pd(a: f64x2, b: f64x2) -> f64x2 {
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(orps))]
 pub unsafe fn _mm_or_pd(a: f64x2, b: f64x2) -> f64x2 {
-    let a: i64x2 = mem::transmute(a);
-    let b: i64x2 = mem::transmute(b);
+    let a: u64x2 = mem::transmute(a);
+    let b: u64x2 = mem::transmute(b);
     mem::transmute(a | b)
 }
 
@@ -1409,8 +1409,8 @@ pub unsafe fn _mm_or_pd(a: f64x2, b: f64x2) -> f64x2 {
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(xorps))]
 pub unsafe fn _mm_xor_pd(a: f64x2, b: f64x2) -> f64x2 {
-    let a: i64x2 = mem::transmute(a);
-    let b: i64x2 = mem::transmute(b);
+    let a: u64x2 = mem::transmute(a);
+    let b: u64x2 = mem::transmute(b);
     mem::transmute(a ^ b)
 }
 
@@ -3052,10 +3052,10 @@ mod tests {
     unsafe fn _mm_and_pd() {
         use std::mem::transmute;
 
-        let a: f64x2 = transmute(i64x2::splat(5));
-        let b: f64x2 = transmute(i64x2::splat(3));
+        let a: f64x2 = transmute(u64x2::splat(5));
+        let b: f64x2 = transmute(u64x2::splat(3));
         let r = sse2::_mm_and_pd(a, b);
-        let e: f64x2 = transmute(i64x2::splat(1));
+        let e: f64x2 = transmute(u64x2::splat(1));
         assert_eq!(r, e);
     }
 
@@ -3063,10 +3063,10 @@ mod tests {
     unsafe fn _mm_andnot_pd() {
         use std::mem::transmute;
 
-        let a: f64x2 = transmute(i64x2::splat(5));
-        let b: f64x2 = transmute(i64x2::splat(3));
+        let a: f64x2 = transmute(u64x2::splat(5));
+        let b: f64x2 = transmute(u64x2::splat(3));
         let r = sse2::_mm_andnot_pd(a, b);
-        let e: f64x2 = transmute(i64x2::splat(2));
+        let e: f64x2 = transmute(u64x2::splat(2));
         assert_eq!(r, e);
     }
 
@@ -3074,10 +3074,10 @@ mod tests {
     unsafe fn _mm_or_pd() {
         use std::mem::transmute;
 
-        let a: f64x2 = transmute(i64x2::splat(5));
-        let b: f64x2 = transmute(i64x2::splat(3));
+        let a: f64x2 = transmute(u64x2::splat(5));
+        let b: f64x2 = transmute(u64x2::splat(3));
         let r = sse2::_mm_or_pd(a, b);
-        let e: f64x2 = transmute(i64x2::splat(7));
+        let e: f64x2 = transmute(u64x2::splat(7));
         assert_eq!(r, e);
     }
 
@@ -3085,10 +3085,10 @@ mod tests {
     unsafe fn _mm_xor_pd() {
         use std::mem::transmute;
 
-        let a: f64x2 = transmute(i64x2::splat(5));
-        let b: f64x2 = transmute(i64x2::splat(3));
+        let a: f64x2 = transmute(u64x2::splat(5));
+        let b: f64x2 = transmute(u64x2::splat(3));
         let r = sse2::_mm_xor_pd(a, b);
-        let e: f64x2 = transmute(i64x2::splat(6));
+        let e: f64x2 = transmute(u64x2::splat(6));
         assert_eq!(r, e);
     }
 


### PR DESCRIPTION
In clang's  [avxintrin.h](https://github.com/llvm-mirror/clang/blob/master/lib/Headers/avxintrin.h#L528-L532) this intrinsics are implemented with a cast to an **unsigned** type but in [sse2.rs](https://github.com/rust-lang-nursery/stdsimd/blob/master/src/x86/sse2.rs#L1382), for example, similar instructions use a **signed** type. Does this make a difference? Should I change for the sake of consistency?

Also, llvm emits the wrong instruction for the double precision intrinsics (see Issue #71), so the `assert_instr` test is changed to the emitted instruction, as suggested on the gitter chat, to please the tests.