### PR TITLE
avx: add _mm256_div_pd, _mm256_div_ps

### DIFF
--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -109,6 +109,25 @@ pub unsafe fn _mm256_sub_ps(a: f32x8, b: f32x8) -> f32x8 {
     a - b
 }
 
+/// Compute the division of each of the 8 packed 32-bit floating-point elements
+/// in `a` by the corresponding packed elements in `b`.
+#[inline(always)]
+#[target_feature = "+avx"]
+#[cfg_attr(test, assert_instr(vdivps))]
+pub unsafe fn _mm256_div_ps(a: f32x8, b: f32x8) -> f32x8 {
+    a / b
+}
+
+/// Compute the division of each of the 4 packed 64-bit floating-point elements
+/// in `a` by the corresponding packed elements in `b`.
+#[inline(always)]
+#[target_feature = "+avx"]
+#[cfg_attr(test, assert_instr(vdivpd))]
+pub unsafe fn _mm256_div_pd(a: f64x4, b: f64x4) -> f64x4 {
+    a / b
+}
+
+
 /// Round packed double-precision (64-bit) floating point elements in `a`
 /// according to the flag `b`. The value of `b` may be as follows:
 ///
@@ -415,6 +434,24 @@ mod tests {
         let a = f32x8::new(4.0, 9.0, 16.0, 25.0, 4.0, 9.0, 16.0, 25.0);
         let r = avx::_mm256_sqrt_ps(a);
         let e = f32x8::new(2.0, 3.0, 4.0, 5.0, 2.0, 3.0, 4.0, 5.0);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "avx"]
+    unsafe fn _mm256_div_ps() {
+        let a = f32x8::new(4.0, 9.0, 16.0, 25.0, 4.0, 9.0, 16.0, 25.0);
+        let b = f32x8::new(4.0, 3.0, 2.0, 5.0, 8.0, 9.0, 64.0, 50.0);
+        let r = avx::_mm256_div_ps(a, b);
+        let e = f32x8::new(1.0, 3.0, 8.0, 5.0, 0.5, 1.0, 0.25, 0.5);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "avx"]
+    unsafe fn _mm256_div_pd() {
+        let a = f64x4::new(4.0, 9.0, 16.0, 25.0);
+        let b = f64x4::new(4.0, 3.0, 2.0, 5.0);
+        let r = avx::_mm256_div_pd(a, b);
+        let e = f64x4::new(1.0, 3.0, 8.0, 5.0);
         assert_eq!(r, e);
     }
 }


### PR DESCRIPTION
It looks like there is no llvm compiler intrinsic for these isntructions, so I mimicked the implementation in https://github.com/llvm-mirror/clang/blob/master/lib/Headers/avxintrin.h#L166-L201

I have inspected the resulting binary with `objdump -d`, and I get

```
0000000000028eb0 <_ZN7stdsimd3x863avx13_mm256_div_pd17hfb622e668096388cE>:
   28eb0:       55                      push   %rbp
   28eb1:       48 89 e5                mov    %rsp,%rbp
   28eb4:       c5 fd 5e c1             vdivpd %ymm1,%ymm0,%ymm0
   28eb8:       5d                      pop    %rbp
   28eb9:       c3                      retq   
   28eba:       66 0f 1f 44 00 00       nopw   0x0(%rax,%rax,1)
```

which seems ok.