### PR TITLE
adding _mm_cvtsd_si32, _mm_cvtsd_si64, _mm_cvtsd_ss

### DIFF
--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1739,7 +1739,7 @@ pub unsafe fn _mm_cvtpd_epi32(a: f64x2) -> i32x4 {
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(cvtpd2dq))]
 pub unsafe fn _mm_cvtsd_si32(a: f64x2) -> i32 {
-    cvtsd2si32(a)
+    cvtsd2si(a)
 }
 
 /// Convert the lower double-precision (64-bit) floating-point element in a to a 64-bit integer.
@@ -1929,7 +1929,7 @@ extern {
     #[link_name = "llvm.x86.sse2.cvtpd2dq"]
     fn cvtpd2dq(a: f64x2) -> i32x4;
     #[link_name = "llvm.x86.sse2.cvtsd2si"]
-    fn cvtsd2si32(a: f64x2) -> i32;
+    fn cvtsd2si(a: f64x2) -> i32;
     #[link_name = "llvm.x86.sse2.cvtsd2si64"]
     fn cvtsd2si64(a: f64x2) -> i64;
     #[link_name = "llvm.x86.sse2.cvtsd2ss"]

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1739,7 +1739,15 @@ pub unsafe fn _mm_cvtpd_epi32(a: f64x2) -> i32x4 {
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(cvtpd2dq))]
 pub unsafe fn _mm_cvtsd_si32(a: f64x2) -> i32 {
-    cvtsd2si(a)
+    cvtsd2si32(a)
+}
+
+/// Convert the lower double-precision (64-bit) floating-point element in a to a 64-bit integer.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(cvtpd2dq))]
+pub unsafe fn _mm_cvtsd_si64(a: f64x2) -> i64 {
+    cvtsd2si64(a)
 }
 
 /// Return a mask of the most significant bit of each element in `a`.
@@ -1911,7 +1919,9 @@ extern {
     #[link_name = "llvm.x86.sse2.cvtpd2dq"]
     fn cvtpd2dq(a: f64x2) -> i32x4;
     #[link_name = "llvm.x86.sse2.cvtsd2si"]
-    fn cvtsd2si(a: f64x2) -> i32;
+    fn cvtsd2si32(a: f64x2) -> i32;
+    #[link_name = "llvm.x86.sse2.cvtsd2si64"]
+    fn cvtsd2si64(a: f64x2) -> i64;
 
 }
 
@@ -3489,4 +3499,17 @@ mod tests {
         assert_eq!(r, i32::MIN);
     }
 
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsd_si64() {
+        use std::{f64, i64};
+
+        let r = sse2::_mm_cvtsd_si64(f64x2::new(-2.0, 5.0));
+        assert_eq!(r, -2_i64);
+
+        let r = sse2::_mm_cvtsd_si64(f64x2::new(f64::MAX, f64::MIN));
+        assert_eq!(r, i64::MIN);
+
+        let r = sse2::_mm_cvtsd_si64(f64x2::new(f64::NAN, f64::NAN));
+        assert_eq!(r, i64::MIN);
+    }
 }

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1734,6 +1734,14 @@ pub unsafe fn _mm_cvtpd_epi32(a: f64x2) -> i32x4 {
     cvtpd2dq(a)
 }
 
+/// Convert the lower double-precision (64-bit) floating-point element in a to a 32-bit integer.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(cvtpd2dq))]
+pub unsafe fn _mm_cvtsd_si32(a: f64x2) -> i32 {
+    cvtsd2si(a)
+}
+
 /// Return a mask of the most significant bit of each element in `a`.
 ///
 /// The mask is stored in the 2 least significant bits of the return value.
@@ -1902,6 +1910,9 @@ extern {
     fn cvtpd2ps(a: f64x2) -> f32x4;
     #[link_name = "llvm.x86.sse2.cvtpd2dq"]
     fn cvtpd2dq(a: f64x2) -> i32x4;
+    #[link_name = "llvm.x86.sse2.cvtsd2si"]
+    fn cvtsd2si(a: f64x2) -> i32;
+
 }
 
 #[cfg(test)]
@@ -3463,4 +3474,19 @@ mod tests {
         let r = sse2::_mm_cvtpd_epi32(f64x2::new(f64::NAN, f64::NAN));
         assert_eq!(r, i32x4::new(i32::MIN, i32::MIN, 0, 0));
     }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsd_si32() {
+        use std::{f64, i32};
+
+        let r = sse2::_mm_cvtsd_si32(f64x2::new(-2.0, 5.0));
+        assert_eq!(r, -2);
+
+        let r = sse2::_mm_cvtsd_si32(f64x2::new(f64::MAX, f64::MIN));
+        assert_eq!(r, i32::MIN);
+
+        let r = sse2::_mm_cvtsd_si32(f64x2::new(f64::NAN, f64::NAN));
+        assert_eq!(r, i32::MIN);
+    }
+
 }


### PR DESCRIPTION
please take a look at 

```
#[link_name = "llvm.x86.sse2.cvtsd2si"]
fn cvtsd2si32(a: f64x2) -> i32;
```
i named it `cvtsd2si32` because there is also a 64 bit version(one line below) despite the naming in llvm, is this ok?