### PR TITLE
AVX: vandnpd, vandnps, vblendvpd and vblendvps

### DIFF
--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -45,6 +45,30 @@ pub unsafe fn _mm256_and_ps(a: f32x8, b: f32x8) -> f32x8 {
     mem::transmute(a & b)
 }
 
+/// Compute the bitwise NOT of a packed double-precision (64-bit) floating-point elements in `a` 
+/// and then AND with `b`.
+#[inline(always)]
+#[target_feature = "+avx"]
+// Should be 'vandnpd' instuction.
+// See https://github.com/rust-lang-nursery/stdsimd/issues/71
+#[cfg_attr(test, assert_instr(vandnps))]
+pub unsafe fn _mm256_andnot_pd(a: f64x4, b: f64x4) -> f64x4 {
+    let a: u64x4 = mem::transmute(a);
+    let b: u64x4 = mem::transmute(b);
+    mem::transmute(!a & b)
+}
+
+/// Compute the bitwise NOT of a packed single-precision (32-bit) floating-point elements in `a` 
+/// and then AND with `b`.
+#[inline(always)]
+#[target_feature = "+avx"]
+#[cfg_attr(test, assert_instr(vandnps))]
+pub unsafe fn _mm256_andnot_ps(a: f32x8, b: f32x8) -> f32x8 {
+    let a: u32x8 = mem::transmute(a);
+    let b: u32x8 = mem::transmute(b);
+    mem::transmute(!a & b)
+}
+
 /// Compute the bitwise OR packed double-precision (64-bit) floating-point elements
 /// in `a` and `b`.
 #[inline(always)]
@@ -356,6 +380,24 @@ mod tests {
         let b = f32x8::splat(0.6);
         let r = avx::_mm256_and_ps(a, b);
         let e = f32x8::splat(0.5);
+        assert_eq!(r, e);
+    }
+
+ #[simd_test = "avx"]
+    unsafe fn _mm256_andnot_pd() {
+        let a = f64x4::splat(1.0);
+        let b = f64x4::splat(1.0);
+        let r = avx::_mm256_andnot_pd(a, b);
+        let e = f64x4::splat(0.0);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "avx"]
+    unsafe fn _mm256_andnot_ps() {
+        let a = f32x8::splat(1.0);
+        let b = f32x8::splat(1.0);
+        let r = avx::_mm256_andnot_ps(a, b);
+        let e = f32x8::splat(0.0);
         assert_eq!(r, e);
     }
 


### PR DESCRIPTION
`_mm256_andnot_pd` also generates a single-precision instruction, so I added the intrinsic to #71
