### PR TITLE
Improve _mm256_round_* docs

### DIFF
--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -179,12 +179,14 @@ pub unsafe fn _mm256_div_pd(a: f64x4, b: f64x4) -> f64x4 {
 /// Round packed double-precision (64-bit) floating point elements in `a`
 /// according to the flag `b`. The value of `b` may be as follows:
 ///
-/// ```ignore
-/// 0x00: Round to the nearest whole number.
-/// 0x01: Round down, toward negative infinity.
-/// 0x02: Round up, toward positive infinity.
-/// 0x03: Truncate the values.
-/// ```
+/// - `0x00`: Round to the nearest whole number.
+/// - `0x01`: Round down, toward negative infinity.
+/// - `0x02`: Round up, toward positive infinity.
+/// - `0x03`: Truncate the values.
+///
+/// For a complete list of options, check the LLVM docs:
+///
+/// https://github.com/llvm-mirror/clang/blob/dcd8d797b20291f1a6b3e0ddda085aa2bbb382a8/lib/Headers/avxintrin.h#L382
 #[inline(always)]
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vroundpd, b = 0x3))]
@@ -215,11 +217,14 @@ pub unsafe fn _mm256_floor_pd(a: f64x4) -> f64x4 {
 
 /// Round packed single-precision (32-bit) floating point elements in `a`
 /// according to the flag `b`. The value of `b` may be as follows:
-/// 0x00: Round to the nearest whole number.
-/// 0x01: Round down, toward negative infinity.
-/// 0x02: Round up, toward positive infinity.
-/// 0x03: Truncate the values.
-/// For a few additional values options, check the LLVM docs:
+///
+/// - `0x00`: Round to the nearest whole number.
+/// - `0x01`: Round down, toward negative infinity.
+/// - `0x02`: Round up, toward positive infinity.
+/// - `0x03`: Truncate the values.
+///
+/// For a complete list of options, check the LLVM docs:
+///
 /// https://github.com/llvm-mirror/clang/blob/dcd8d797b20291f1a6b3e0ddda085aa2bbb382a8/lib/Headers/avxintrin.h#L382
 #[inline(always)]
 #[target_feature = "+avx"]


### PR DESCRIPTION
Fix a grammatical error, use a list instead of using a code block or nothing,
and add the LLVM immediate reference.