### PR TITLE
Enable multiple #[assert_instr] attributes

### DIFF
--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -321,9 +321,9 @@ pub const _MM_HINT_NTA: i8 = 0;
 #[inline(always)]
 #[target_feature = "+sse"]
 #[cfg_attr(test, assert_instr(prefetcht0, strategy = _MM_HINT_T0))]
-// #[cfg_attr(test, assert_instr(prefetcht1, strategy = _MM_HINT_T1))]
-// #[cfg_attr(test, assert_instr(prefetcht2, strategy = _MM_HINT_T2))]
-// #[cfg_attr(test, assert_instr(prefetchnta, strategy = _MM_HINT_NTA))]
+#[cfg_attr(test, assert_instr(prefetcht1, strategy = _MM_HINT_T1))]
+#[cfg_attr(test, assert_instr(prefetcht2, strategy = _MM_HINT_T2))]
+#[cfg_attr(test, assert_instr(prefetchnta, strategy = _MM_HINT_NTA))]
 pub unsafe fn _mm_prefetch(p: *const c_void, strategy: i8) {
     // The `strategy` must be a compile-time constant, so we use a short form of
     // `constify_imm8!` for now.

--- a/stdsimd-test/assert-instr-macro/src/lib.rs
+++ b/stdsimd-test/assert-instr-macro/src/lib.rs
@@ -40,7 +40,9 @@ pub fn assert_instr(attr: proc_macro::TokenStream,
         (quote! { #[ignore] }).into()
     };
     let name = &func.ident;
-    let assert_name = syn::Ident::from(&format!("assert_{}", name.sym.as_str())[..]);
+    let assert_name = syn::Ident::from(&format!("assert_{}_{}", 
+                                                name.sym.as_str(), 
+                                                instr.sym.as_str())[..]);
     let shim_name = syn::Ident::from(&format!("{}_shim", name.sym.as_str())[..]);
     let (to_test, test_name) = if invoc.args.len() == 0 {
         (TokenStream::empty(), &func.ident)

--- a/stdsimd-test/assert-instr-macro/src/lib.rs
+++ b/stdsimd-test/assert-instr-macro/src/lib.rs
@@ -40,8 +40,8 @@ pub fn assert_instr(attr: proc_macro::TokenStream,
         (quote! { #[ignore] }).into()
     };
     let name = &func.ident;
-    let assert_name = syn::Ident::from(&format!("assert_{}_{}", 
-                                                name.sym.as_str(), 
+    let assert_name = syn::Ident::from(&format!("assert_{}_{}",
+                                                name.sym.as_str(),
                                                 instr.sym.as_str())[..]);
     let shim_name = syn::Ident::from(&format!("{}_shim", name.sym.as_str())[..]);
     let (to_test, test_name) = if invoc.args.len() == 0 {
@@ -69,7 +69,10 @@ pub fn assert_instr(attr: proc_macro::TokenStream,
                 }
             };
         }
-        let attrs = Append(&item.attrs);
+        let attrs = item.attrs.iter().filter(|attr| {
+            attr.path.segments.get(0).item().ident.sym.as_str().starts_with("target")
+        }).collect::<Vec<_>>();
+        let attrs = Append(&attrs);
         (quote! {
             #attrs
             unsafe fn #shim_name(#(#inputs),*) #ret {


### PR DESCRIPTION
Looks like all we needed to do was generate new function names!