### PR TITLE
Implement SSE _mm_load* instructions

### DIFF
--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -361,6 +361,17 @@ pub unsafe fn _mm_loadl_pi(a: f32x4, p: *const f32) -> f32x4 {
     simd_shuffle4(a, bb, [4, 5, 2, 3])
 }
 
+/// Construct a `f32x4` with the lowest element read from `p` and the other
+/// elements set to zero.
+///
+/// This corresponds to instructions `VMOVSS` / `MOVSS`.
+#[inline(always)]
+#[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(movss))]
+pub unsafe fn _mm_load_ss(p: *const f32) -> f32x4 {
+    f32x4::new(*p, 0.0, 0.0, 0.0)
+}
+
 /// Perform a serializing operation on all store-to-memory instructions that
 /// were issued prior to this instruction.
 ///
@@ -938,6 +949,13 @@ mod tests {
         let p = x[..].as_ptr();
         let r = sse::_mm_loadl_pi(a, p);
         assert_eq!(r, f32x4::new(5.0, 6.0, 3.0, 4.0));
+    }
+
+    #[simd_test = "sse"]
+    unsafe fn _mm_load_ss() {
+        let a = 42.0f32;
+        let r = sse::_mm_load_ss(&a as *const f32);
+        assert_eq!(r, f32x4::new(42.0, 0.0, 0.0, 0.0));
     }
 
     #[simd_test = "sse"]

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -426,7 +426,7 @@ pub unsafe fn _mm_load_ps(p: *const f32) -> f32x4 {
 pub unsafe fn _mm_loadu_ps(p: *const f32) -> f32x4 {
     // Note: Using `*p` would require `f32` alignment, but `movups` has no
     // alignment restrictions.
-    let mut dst = mem::uninitialized();
+    let mut dst = f32x4::splat(mem::uninitialized());
     ptr::copy_nonoverlapping(
         p as *const u8,
         &mut dst as *mut f32x4 as *mut u8,

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -308,7 +308,10 @@ pub unsafe fn _mm_movemask_ps(a: f32x4) -> i32 {
 #[target_feature = "+sse"]
 // TODO: generates MOVHPD if the CPU supports SSE2.
 // #[cfg_attr(test, assert_instr(movhps))]
-#[cfg_attr(test, assert_instr(movhpd))]
+#[cfg_attr(all(test, target_arch = "x86_64"), assert_instr(movhpd))]
+// 32-bit codegen does not generate `movhps` or `movhpd`, but instead
+// `movsd` followed by `unpcklpd`.
+#[cfg_attr(all(test, target_arch = "x86"), assert_instr(unpcklpd))]
 // TODO: This function is actually not limited to floats, but that's what
 // what matches the C type most closely: (__m128, *const __m64) -> __m128
 pub unsafe fn _mm_loadh_pi(a: f32x4, p: *const f32) -> f32x4 {
@@ -354,7 +357,9 @@ pub unsafe fn _mm_loadh_pi(a: f32x4, p: *const f32) -> f32x4 {
 #[target_feature = "+sse"]
 // TODO: generates MOVLPD if the CPU supports SSE2.
 // #[cfg_attr(test, assert_instr(movlps))]
-#[cfg_attr(test, assert_instr(movlpd))]
+#[cfg_attr(all(test, target_arch = "x86_64"), assert_instr(movlpd))]
+// On 32-bit targets, it just generates two `movsd`.
+#[cfg_attr(all(test, target_arch = "x86"), assert_instr(movsd))]
 // TODO: Like _mm_loadh_pi, this also isn't limited to floats.
 pub unsafe fn _mm_loadl_pi(a: f32x4, p: *const f32) -> f32x4 {
     let q = p as *const f32x2;

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -418,9 +418,8 @@ pub unsafe fn _mm_load_ps(p: *const f32) -> f32x4 {
 #[target_feature = "+sse"]
 #[cfg_attr(test, assert_instr(movups))]
 pub unsafe fn _mm_loadu_ps(p: *const f32) -> f32x4 {
-    // TODO: This also seems to generate the same code. Don't know which one
-    // will behave better when inlined into other code.
-    // f32x4::new(*p, *p.offset(1), *p.offset(2), *p.offset(3))
+    // Note: Using `*p` would require `f32` alignment, but `movups` has no
+    // alignment restrictions.
     let mut dst = mem::uninitialized();
     ptr::copy_nonoverlapping(
         p as *const u8,

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -372,6 +372,27 @@ pub unsafe fn _mm_load_ss(p: *const f32) -> f32x4 {
     f32x4::new(*p, 0.0, 0.0, 0.0)
 }
 
+/// Construct a `f32x4` by duplicating the value read from `p` into all
+/// elements.
+///
+/// This corresponds to instructions `VMOVSS` / `MOVSS` followed by some
+/// shuffling.
+#[inline(always)]
+#[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(movss))]
+pub unsafe fn _mm_load1_ps(p: *const f32) -> f32x4 {
+    let a = *p;
+    f32x4::new(a, a, a, a)
+}
+
+/// Alias for [`_mm_load1_ps`](fn._mm_load1_ps.html)
+#[inline(always)]
+#[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(movss))]
+pub unsafe fn _mm_load_ps1(p: *const f32) -> f32x4 {
+    _mm_load1_ps(p)
+}
+
 /// Perform a serializing operation on all store-to-memory instructions that
 /// were issued prior to this instruction.
 ///
@@ -956,6 +977,13 @@ mod tests {
         let a = 42.0f32;
         let r = sse::_mm_load_ss(&a as *const f32);
         assert_eq!(r, f32x4::new(42.0, 0.0, 0.0, 0.0));
+    }
+
+    #[simd_test = "sse"]
+    unsafe fn _mm_load1_ps() {
+        let a = 42.0f32;
+        let r = sse::_mm_load1_ps(&a as *const f32);
+        assert_eq!(r, f32x4::new(42.0, 42.0, 42.0, 42.0));
     }
 
     #[simd_test = "sse"]

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -272,11 +272,43 @@ pub unsafe fn _mm_movemask_ps(a: f32x4) -> i32 {
 /// Set the upper two single-precision floating-point values with 64 bits of
 /// data loaded from the address `p`; the lower two values are passed through
 /// from `a`.
+///
+/// This corresponds to the `MOVHPS` / `MOVHPD` / `VMOVHPD` instructions.
+///
+/// ```rust
+/// # #![feature(cfg_target_feature)]
+/// # #![feature(target_feature)]
+/// #
+/// # #[macro_use] extern crate stdsimd;
+/// #
+/// # // The real main function
+/// # fn main() {
+/// #     if cfg_feature_enabled!("sse") {
+/// #         #[target_feature = "+sse"]
+/// #         fn worker() {
+/// #
+/// #   use stdsimd::simd::f32x4;
+/// #   use stdsimd::vendor::_mm_loadh_pi;
+/// #
+/// let a = f32x4::new(1.0, 2.0, 3.0, 4.0);
+/// let data: [f32; 4] = [5.0, 6.0, 7.0, 8.0];
+///
+/// let r = unsafe { _mm_loadh_pi(a, data[..].as_ptr()) };
+///
+/// assert_eq!(r, f32x4::new(1.0, 2.0, 5.0, 6.0));
+/// #
+/// #         }
+/// #         worker();
+/// #     }
+/// # }
+/// ```
 #[inline(always)]
 #[target_feature = "+sse"]
 // TODO: generates MOVHPD if the CPU supports SSE2.
 // #[cfg_attr(test, assert_instr(movhps))]
 #[cfg_attr(test, assert_instr(movhpd))]
+// TODO: This function is actually not limited to floats, but that's what
+// what matches the C type most closely: (__m128, *const __m64) -> __m128
 pub unsafe fn _mm_loadh_pi(a: f32x4, p: *const f32) -> f32x4 {
     let q = p as *const f32x2;
     let b: f32x2 = *q;


### PR DESCRIPTION
This implements SSE instructions:

- `_mm_loadh_pi`
- `_mm_loadl_pi`
- `_mm_load_ss`
- `_mm_load1_ps`
- `_mm_load_ps1`
- `_mm_load_ps`
- `_mm_loadu_ps`
- `_mm_loadr_ps`

I also added some experimental doctests, but I can't get them to run. (That is, I can't get them to fail by adding `assert!(false)`. They are being compiled, though)