### PR TITLE
Add _MM_TRANSPOSE4_PS pseudo-macro.

### DIFF
--- a/stdsimd-test/simd-test-macro/src/lib.rs
+++ b/stdsimd-test/simd-test-macro/src/lib.rs
@@ -46,6 +46,7 @@ pub fn simd_test(attr: proc_macro::TokenStream,
     let name: TokenStream = name.as_str().parse().unwrap();
 
     let ret: TokenStream = quote! {
+        #[allow(non_snake_case)]
         #[test]
         fn #name() {
             if cfg_feature_enabled!(#target_feature) {


### PR DESCRIPTION
This adds a strange macro, which I've replaced with a function, because it
seems there are not many better alternatives.

Also adds a test, and `#[allow(non_snake_case)]` to `#[simd_test]`.