### PR TITLE
Add CI in Intel's instruction emulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - env: TARGET=i586-unknown-linux-gnu
     - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-gnu NO_ADD=1
+    - env: TARGET=x86_64-unknown-linux-gnu-emulated NO_ADD=1 STDSIMD_TEST_EVERYTHING=1
     - env: TARGET=arm-unknown-linux-gnueabihf
     - env: TARGET=armv7-unknown-linux-gnueabihf
     - env: TARGET=aarch64-unknown-linux-gnu

--- a/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:17.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  gcc \
+  libc6-dev \
+  file \
+  make \
+  ca-certificates \
+  curl \
+  bzip2
+
+RUN curl https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/sde-external-8.9.0-2017-08-06-lin.tar.bz2 | \
+  tar xjf -
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/sde-external-8.9.0-2017-08-06-lin/sde64 --"

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -7,6 +7,7 @@ run() {
     echo $1
     docker build -t stdsimd ci/docker/$1
     mkdir -p target
+    target=$(echo $1 | sed 's/-emulated//')
     docker run \
       --user `id -u`:`id -g` \
       --rm \
@@ -14,13 +15,15 @@ run() {
       --volume $HOME/.cargo:/cargo \
       --env CARGO_HOME=/cargo \
       --volume `rustc --print sysroot`:/rust:ro \
-      --env TARGET=$1 \
+      --env TARGET=$target \
+      --env STDSIMD_TEST_EVERYTHING \
       --volume `pwd`:/checkout:ro \
       --volume `pwd`/target:/checkout/target \
       --workdir /checkout \
+      --privileged \
       stdsimd \
       bash \
-      -c 'PATH=$PATH:/rust/bin exec ci/run.sh $1'
+      -c 'PATH=$PATH:/rust/bin exec ci/run.sh'
 }
 
 if [ -z "$1" ]; then

--- a/stdsimd-test/simd-test-macro/src/lib.rs
+++ b/stdsimd-test/simd-test-macro/src/lib.rs
@@ -51,6 +51,8 @@ pub fn simd_test(attr: proc_macro::TokenStream,
         fn #name() {
             if cfg_feature_enabled!(#target_feature) {
                 return unsafe { #name() };
+            } else {
+                ::stdsimd_test::assert_skip_test_ok(stringify!(#name));
             }
 
             #[target_feature = #enable_feature]

--- a/stdsimd-test/src/lib.rs
+++ b/stdsimd-test/src/lib.rs
@@ -294,3 +294,10 @@ pub fn assert(fnptr: usize, fnname: &str, expected: &str) {
         panic!("too many instructions in the disassembly");
     }
 }
+
+pub fn assert_skip_test_ok(name: &str) {
+    if env::var("STDSIMD_TEST_EVERYTHING").is_err() {
+        return
+    }
+    panic!("skipped test `{}` when it shouldn't be skipped", name);
+}


### PR DESCRIPTION
This commit adds a new builder on CI for running tests in Intel's own emulator
and also adds an assertion that on this emulator no tests are skipped due to
missing CPU features by accident.

Closes #92