### PR TITLE
fixed _mm_set_pd and _mm_setr_pd by reversing order

### DIFF
--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1842,7 +1842,7 @@ pub unsafe fn _mm_set_pd1(a: f64) -> f64x2 {
 #[inline(always)]
 #[target_feature = "+sse2"]
 pub unsafe fn _mm_set_pd(a: f64, b: f64) -> f64x2 {
-    f64x2::new(a, b)
+    f64x2::new(b, a)
 }
 
 /// Set packed double-precision (64-bit) floating-point elements in the return value with the
@@ -1850,7 +1850,7 @@ pub unsafe fn _mm_set_pd(a: f64, b: f64) -> f64x2 {
 #[inline(always)]
 #[target_feature = "+sse2"]
 pub unsafe fn _mm_setr_pd(a: f64, b: f64) -> f64x2 {
-    f64x2::new(b, a)
+    f64x2::new(a, b)
 }
 
 /// returns packed double-precision (64-bit) floating-point elements with all zeros.
@@ -3774,13 +3774,13 @@ mod tests {
     #[simd_test = "sse2"]
     unsafe fn _mm_set_pd() {
         let r = sse2::_mm_set_pd(1.0_f64, 5.0_f64);
-        assert_eq!(r, f64x2::new(1.0_f64, 5.0_f64));
+        assert_eq!(r, f64x2::new(5.0_f64, 1.0_f64));
     }
 
     #[simd_test = "sse2"]
     unsafe fn _mm_setr_pd() {
         let r = sse2::_mm_setr_pd(1.0_f64, -5.0_f64);
-        assert_eq!(r, f64x2::new(-5.0_f64, 1.0_f64));
+        assert_eq!(r, f64x2::new(1.0_f64, -5.0_f64));
     }
 
     #[simd_test = "sse2"]


### PR DESCRIPTION
please take a closer look at  [_mm_set_pd](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_set_pd&expand=4625) and 
[_mm_setr_pd](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_setr_pd&expand=4625,4703)  i am really not a 100% sure and that was the result of the supposedly first mistake [here '_mm_set_pd'](https://github.com/rust-lang-nursery/stdsimd/pull/122/commits/db9cf0d3bcee06a12985971137809a96bc1f91fc) and [here '_mm_setr_pd'](https://github.com/rust-lang-nursery/stdsimd/pull/122/commits/49659a6991b01bbe407d8d42816d8f61ce551eee).
