### PR TITLE
x86: fixed testing equality of floating point numbers

### DIFF
--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -3114,7 +3114,10 @@ mod tests {
         let r = avx::_mm256_rcp_ps(a);
         let e = f32x8::new(0.99975586, 0.49987793, 0.33325195, 0.24993896,
                            0.19995117, 0.16662598, 0.14282227, 0.12496948);
-        assert_eq!(r, e);
+        let rel_err = 0.00048828125;
+        for i in 0..8 {
+            assert_approx_eq!(r.extract(i), e.extract(i), 2. * rel_err);
+        }
     }
 
     #[simd_test = "avx"]
@@ -3123,7 +3126,10 @@ mod tests {
         let r = avx::_mm256_rsqrt_ps(a);
         let e = f32x8::new(0.99975586, 0.7069092, 0.5772705, 0.49987793,
                            0.44714355, 0.40820313, 0.3779297, 0.3534546);
-        assert_eq!(r, e);
+        let rel_err = 0.00048828125;
+        for i in 0..8 {
+            assert_approx_eq!(r.extract(i), e.extract(i), 2. * rel_err);
+        }
     }
 
     #[simd_test = "avx"]

--- a/src/x86/macros.rs
+++ b/src/x86/macros.rs
@@ -338,4 +338,22 @@ macro_rules! constify_imm2 {
     }
 }
 
+macro_rules! assert_approx_eq {
+    ($a:expr, $b:expr) => ({
+        let eps = 1.0e-6;
+        let (a, b) = (&$a, &$b);
+        assert!((*a - *b).abs() < eps,
+                "assertion failed: `(left !== right)` \
+                           (left: `{:?}`, right: `{:?}`, expect diff: `{:?}`, real diff: `{:?}`)",
+                 *a, *b, eps, (*a - *b).abs());
+    });
+    ($a:expr, $b:expr, $eps:expr) => ({
+        let (a, b) = (&$a, &$b);
+        assert!((*a - *b).abs() < $eps,
+                "assertion failed: `(left !== right)` \
+                           (left: `{:?}`, right: `{:?}`, expect diff: `{:?}`, real diff: `{:?}`)",
+                 *a, *b, $eps, (*a - *b).abs());
+    })
+}
+
 

--- a/src/x86/macros.rs
+++ b/src/x86/macros.rs
@@ -339,14 +339,6 @@ macro_rules! constify_imm2 {
 }
 
 macro_rules! assert_approx_eq {
-    ($a:expr, $b:expr) => ({
-        let eps = 1.0e-6;
-        let (a, b) = (&$a, &$b);
-        assert!((*a - *b).abs() < eps,
-                "assertion failed: `(left !== right)` \
-                           (left: `{:?}`, right: `{:?}`, expect diff: `{:?}`, real diff: `{:?}`)",
-                 *a, *b, eps, (*a - *b).abs());
-    });
     ($a:expr, $b:expr, $eps:expr) => ({
         let (a, b) = (&$a, &$b);
         assert!((*a - *b).abs() < $eps,

--- a/src/x86/macros.rs
+++ b/src/x86/macros.rs
@@ -338,6 +338,7 @@ macro_rules! constify_imm2 {
     }
 }
 
+#[cfg(test)]
 macro_rules! assert_approx_eq {
     ($a:expr, $b:expr, $eps:expr) => ({
         let (a, b) = (&$a, &$b);

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -1804,7 +1804,10 @@ mod tests {
         let a = f32x4::new(4.0, 13.0, 16.0, 100.0);
         let r = sse::_mm_rcp_ps(a);
         let e = f32x4::new(0.24993896, 0.0769043, 0.06248474, 0.0099983215);
-        assert_eq!(r, e);
+        let rel_err = 0.00048828125;
+        for i in 0..4 {
+            assert_approx_eq!(r.extract(i), e.extract(i), 2. * rel_err);
+        }
     }
 
     #[simd_test = "sse"]
@@ -1812,7 +1815,10 @@ mod tests {
         let a = f32x4::new(4.0, 13.0, 16.0, 100.0);
         let r = sse::_mm_rsqrt_ss(a);
         let e = f32x4::new(0.49987793, 13.0, 16.0, 100.0);
-        assert_eq!(r, e);
+        let rel_err = 0.00048828125;
+        for i in 0..4 {
+            assert_approx_eq!(r.extract(i), e.extract(i), 2. * rel_err);
+        }
     }
 
     #[simd_test = "sse"]
@@ -1820,7 +1826,10 @@ mod tests {
         let a = f32x4::new(4.0, 13.0, 16.0, 100.0);
         let r = sse::_mm_rsqrt_ps(a);
         let e = f32x4::new(0.49987793, 0.2772827, 0.24993896, 0.099990845);
-        assert_eq!(r, e);
+        let rel_err = 0.00048828125;
+        for i in 0..4 {
+            assert_approx_eq!(r.extract(i), e.extract(i), 2. * rel_err);
+        }
     }
 
     #[simd_test = "sse"]


### PR DESCRIPTION
Hi,

I have run the tests and five of them failed. I checked the Intel Intrinsics Guide and it said that these specific instructions returns approximated values while the tests don't take the error into account. I have Ryzen 1700X. I guess all of test runs until now could be done on Intel CPUs where it could possibly always return those hardcoded specific values.

I also haven't known how to cleanly make the compare, so I have added an extra macro. It is basically copy-paste of [this](https://github.com/ashleygwilliams/assert_approx_eq/blob/master/src/lib.rs) since I didn't want to add new dependencies.