### PR TITLE
[x86] expose cpuid, xgetbv, pushfd, popfd

### DIFF
--- a/src/x86/cpuid.rs
+++ b/src/x86/cpuid.rs
@@ -1,0 +1,120 @@
+//! `cpuid` intrinsics
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Result of the `cpuid` instruction.
+#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "cargo-clippy", allow(stutter))]
+pub struct CpuidResult {
+    /// EAX register.
+    pub eax: u32,
+    /// EBX register.
+    pub ebx: u32,
+    /// ECX register.
+    pub ecx: u32,
+    /// EDX register.
+    pub edx: u32,
+}
+
+/// `cpuid` instruction.
+///
+/// The [CPUID Wikipedia page][wiki_cpuid] contains how to query which
+/// information using the `eax` and `ecx` registers, and the format in
+/// which this information is returned in `eax...edx`.
+///
+/// The `has_cpuid()` intrinsics can be used to query whether the `cpuid`
+/// instruction is available.
+///
+/// The definitive references are:
+/// - [Intel 64 and IA-32 Architectures Software Developer's Manual Volume 2:
+///   Instruction Set Reference, A-Z][intel64_ref].
+/// - [AMD64 Architecture Programmer's Manual, Volume 3: General-Purpose and
+///   System Instructions][amd64_ref].
+///
+/// [wiki_cpuid]: https://en.wikipedia.org/wiki/CPUID
+/// [intel64_ref]: http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
+/// [amd64_ref]: http://support.amd.com/TechDocs/24594.pdf
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cpuid))]
+#[cfg_attr(feature = "cargo-clippy", allow(stutter))]
+pub unsafe fn __cpuid_count(eax: u32, ecx: u32) -> CpuidResult {
+    let mut r = ::std::mem::uninitialized::<CpuidResult>();
+    asm!("cpuid"
+         : "={eax}"(r.eax), "={ebx}"(r.ebx), "={ecx}"(r.ecx), "={edx}"(r.edx)
+         : "{eax}"(eax), "{ecx}"(ecx)
+         : :);
+    r
+}
+
+/// `cpuid` instruction.
+///
+/// See `__cpuid_count`.
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cpuid))]
+#[cfg_attr(feature = "cargo-clippy", allow(stutter))]
+pub unsafe fn __cpuid(eax: u32) -> CpuidResult {
+    __cpuid_count(eax, 0)
+}
+
+/// Does the host support the `cpuid` instruction?
+#[inline(always)]
+#[cfg_attr(feature = "cargo-clippy", allow(stutter))]
+pub fn has_cpuid() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        true
+    }
+    #[cfg(target_arch = "x86")]
+    {
+        use super::ia32::{__readeflags, __writeeflags};
+
+        // On `x86` the `cpuid` instruction is not always available.
+        // This follows the approach indicated in:
+        // http://wiki.osdev.org/CPUID#Checking_CPUID_availability
+        unsafe {
+            // Read EFLAGS:
+            let eflags: u32 = __readeflags();
+
+            // Invert the ID bit in EFLAGS:
+            let eflags_mod: u32 = eflags | 0x0020_0000;
+
+            // Store the modified EFLAGS (ID bit may or may not be inverted)
+            __writeeflags(eflags_mod);
+
+            // Read EFLAGS again:
+            let eflags_after: u32 = __readeflags();
+
+            // Check if the ID bit changed:
+            eflags_after != eflags
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_always_has_cpuid() {
+        // all currently-tested targets have the instruction
+        // FIXME: add targets without `cpuid` to CI
+        assert!(has_cpuid());
+    }
+
+    #[cfg(target_arch = "x86")]
+    #[test]
+    fn test_has_cpuid() {
+        use vendor::__readeflags;
+        unsafe {
+            let before = __readeflags();
+
+            if has_cpuid() {
+                assert!(before != __readeflags());
+            } else {
+                assert!(before == __readeflags());
+            }
+        }
+    }
+
+}

--- a/src/x86/ia32.rs
+++ b/src/x86/ia32.rs
@@ -1,0 +1,50 @@
+//! `i386/ia32` intrinsics
+
+/// Reads EFLAGS.
+#[cfg(target_arch = "x86")]
+#[inline(always)]
+pub unsafe fn __readeflags() -> u32 {
+    let eflags: u32;
+    asm!("pushfd; popl $0" : "=r"(eflags) : : : "volatile");
+    eflags
+}
+
+/// Reads EFLAGS.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+pub unsafe fn __readeflags() -> u64 {
+    let eflags: u64;
+    asm!("pushfq; popq $0" : "=r"(eflags) : : : "volatile");
+    eflags
+}
+
+/// Write EFLAGS.
+#[cfg(target_arch = "x86")]
+#[inline(always)]
+pub unsafe fn __writeeflags(eflags: u32) {
+    asm!("pushl $0; popfd" : : "r"(eflags) : "cc", "flags" : "volatile");
+}
+
+/// Write EFLAGS.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+pub unsafe fn __writeeflags(eflags: u64) {
+    asm!("pushq $0; popfq" : : "r"(eflags) : "cc", "flags" : "volatile");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eflags() {
+        unsafe {
+            // reads eflags, writes them back, reads them again,
+            // and compare for equality:
+            let v = __readeflags();
+            __writeeflags(v);
+            let u = __readeflags();
+            assert_eq!(v, u);
+        }
+    }
+}

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -1,5 +1,9 @@
 //! `x86` and `x86_64` intrinsics.
 
+pub use self::ia32::*;
+pub use self::cpuid::*;
+pub use self::xsave::*;
+
 pub use self::sse::*;
 pub use self::sse2::*;
 pub use self::sse3::*;
@@ -27,6 +31,10 @@ pub type __m256i = ::v256::i8x32;
 mod macros;
 #[macro_use]
 mod runtime;
+
+mod ia32;
+mod cpuid;
+mod xsave;
 
 mod sse;
 mod sse2;

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1792,7 +1792,9 @@ pub unsafe fn _mm_cvtsd_si64(a: f64x2) -> i64 {
 #[inline(always)]
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(cvtsd2si))]
-pub unsafe fn _mm_cvtsd_si64x(a: f64x2) -> i64 { _mm_cvtsd_si64(a) }
+pub unsafe fn _mm_cvtsd_si64x(a: f64x2) -> i64 {
+    _mm_cvtsd_si64(a)
+}
 
 /// Convert the lower double-precision (64-bit) floating-point element in `b`
 /// to a single-precision (32-bit) floating-point element, store the result in
@@ -1857,7 +1859,9 @@ pub unsafe fn _mm_cvttsd_si64(a: f64x2) -> i64 {
 #[inline(always)]
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(cvttsd2si))]
-pub unsafe fn _mm_cvttsd_si64x(a: f64x2) -> i64 { _mm_cvttsd_si64(a) }
+pub unsafe fn _mm_cvttsd_si64x(a: f64x2) -> i64 {
+    _mm_cvttsd_si64(a)
+}
 
 /// Convert packed single-precision (32-bit) floating-point elements in `a` to
 /// packed 32-bit integers with truncation.

--- a/src/x86/xsave.rs
+++ b/src/x86/xsave.rs
@@ -1,0 +1,22 @@
+//! `xsave` target feature intrinsics
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Reads the contents of the extended control register `XCR`
+/// specified in `xcr_no`.
+#[inline(always)]
+// #[target_feature = "+xsave"] // FIXME: see
+// https://github.com/rust-lang-nursery/stdsimd/issues/167
+#[cfg_attr(test, assert_instr(xgetbv))]
+pub unsafe fn _xgetbv(xcr_no: u32) -> u64 {
+    let eax: u32;
+    let edx: u32;
+
+    asm!("xgetbv"
+         : "={eax}"(eax),  "={edx}"(edx)
+         : "{ecx}"(xcr_no)
+         : :);
+
+    ((edx as u64) << 32) | (eax as u64)
+}


### PR DESCRIPTION
This refactors the `cpuid` and `xgetby` intrinsics into its own functions and exposes them as part of the `x86` and `x86_64` architectures. 

The `cpuid` intrinsic is not available on all `x86` CPUs, so this also exposes a `has_cpuid() -> bool` intrinsic that detect this on non `x86_64` hosts, and the `pushfd` and `popfd` intrinsics required to implement it (GCC exposes all of this as intrinsics as well). 

When doing run-time feature detection for `x86`/`x86_64` we now check whether the `cpuid` instruction is available, and if not, then just "disable" all features.

One TODO:

- The `xgetbv` intrinsic requires the `xsave` target feature but this is not currently exposed by rustc, see #167 .

---

- `__readeflags` is equivalent to GCC's `__readeflags` exposed in [`/i386/ia32intrin.h`](https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/ia32intrin.h#L260) and Clang's `__readeflags` exposed in [`ia32intrin.h`](https://github.com/llvm-mirror/clang/blob/master/lib/Headers/ia32intrin.h#L33)
- `__writeeflags` is equivalent to GCC's `__writeeflags` exposed in [`/i386/ia32intrin.h`](https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/ia32intrin.h#L288) and Clang's `__writeeflags` exposed in [`ia32intrin.h`](https://github.com/llvm-mirror/clang/blob/master/lib/Headers/ia32intrin.h#L52)
- `_xgetbv` is equivalent to GCC's `_xgetbv` exposed in [`i386/xsaveintrin.h`](https://github.com/gcc-mirror/gcc/blob/154452f45aad4bfe7a1f719c65cd26837f416a48/gcc/config/i386/xsaveintrin.h#L60) and Clangs' `_xgetbv` exposed in [`intrin.h`](https://github.com/llvm-mirror/clang/blob/master/lib/Headers/intrin.h#L916)
- `_cpuid_count`is equivalent to GCC's `__cpuid_count` exposed in [`i386/cpuid.h`](https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/cpuid.h) and Clang's `__cpuid_count` exposed in [`cpuid.h`](https://github.com/llvm-mirror/clang/blob/master/lib/Headers/cpuid.h#L214)