### PR TITLE
XSAVE, CPUID, Runtime AVX-512 and ARM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - env: TARGET=i586-unknown-linux-gnu
     - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-gnu NO_ADD=1
-    - env: TARGET=x86_64-unknown-linux-gnu-emulated NO_ADD=1 STDSIMD_TEST_EVERYTHING=1
+    - env: TARGET=x86_64-unknown-linux-gnu-emulated NO_ADD=1 STDSIMD_TEST_EVERYTHING=1 FEATURES="intel_sde"
     - env: TARGET=arm-unknown-linux-gnueabihf
     - env: TARGET=armv7-unknown-linux-gnueabihf
     - env: TARGET=aarch64-unknown-linux-gnu
@@ -33,7 +33,7 @@ install:
 
 script:
   - cargo generate-lockfile
-  - ci/run-docker.sh $TARGET
+  - ci/run-docker.sh $TARGET $FEATURES
 
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ opt-level = 3
 
 [dev-dependencies]
 stdsimd-test = { version = "0.*", path = "stdsimd-test" }
-cupid = "0.3"
+cupid = "0.4.0"
 
 [features]
 strict = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ cupid = "0.4.0"
 [features]
 strict = []
 std = []
+intel_sde = []

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   qemu-user \
   make \
   file
+
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-aarch64 -L /usr/aarch64-linux-gnu" \
     OBJDUMP=aarch64-linux-gnu-objdump

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -4,10 +4,11 @@
 set -ex
 
 run() {
-    echo $1
+    echo "Building docker container for TARGET=${1}"
     docker build -t stdsimd ci/docker/$1
     mkdir -p target
     target=$(echo $1 | sed 's/-emulated//')
+    echo "Running docker"
     docker run \
       --user `id -u`:`id -g` \
       --rm \

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -16,6 +16,7 @@ run() {
       --env CARGO_HOME=/cargo \
       --volume `rustc --print sysroot`:/rust:ro \
       --env TARGET=$target \
+      --env FEATURES=$2 \
       --env STDSIMD_TEST_EVERYTHING \
       --volume `pwd`:/checkout:ro \
       --volume `pwd`/target:/checkout/target \
@@ -31,5 +32,5 @@ if [ -z "$1" ]; then
     run $d
   done
 else
-  run $1
+  run $1 $2
 fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -20,9 +20,10 @@ FEATURES_STD="${FEATURES},std"
 
 echo "RUSTFLAGS=${RUSTFLAGS}"
 echo "FEATURES=${FEATURES}"
+echo "OBJDUMP=${OBJDUMP}"
 
-cargo test --target $TARGET --features $FEATURES
-cargo test --release --target $TARGET --features $FEATURES
+cargo test --target $TARGET --features $FEATURES --verbose -- --nocapture
+cargo test --release --target $TARGET --features $FEATURES --verbose -- --nocapture
 
-cargo test --target $TARGET --features $FEATURES_STD
-cargo test --release --target $TARGET --features $FEATURES_STD
+cargo test --target $TARGET --features $FEATURES_STD --verbose -- --nocapture
+cargo test --release --target $TARGET --features $FEATURES_STD --verbose -- --nocapture

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -15,10 +15,14 @@ case ${TARGET} in
         ;;
 esac
 
+FEATURES="strict,$FEATURES"
+FEATURES_STD="${FEATURES},std"
+
 echo "RUSTFLAGS=${RUSTFLAGS}"
+echo "FEATURES=${FEATURES}"
 
-cargo test --target $TARGET --features "strict"
-cargo test --release --target $TARGET --features "strict"
+cargo test --target $TARGET --features $FEATURES
+cargo test --release --target $TARGET --features $FEATURES
 
-cargo test --target $TARGET --features "strict,std"
-cargo test --release --target $TARGET --features "strict,std"
+cargo test --target $TARGET --features $FEATURES_STD
+cargo test --release --target $TARGET --features $FEATURES_STD

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,28 @@ pub mod vendor {
     pub use aarch64::*;
 
     pub use nvptx::*;
+
+    #[cfg(any(
+        // x86/x86_64:
+        any(target_arch = "x86", target_arch = "x86_64"),
+        // linux + std + (arm|aarch64):
+        all(target_os = "linux",
+            feature = "std",
+            any(target_arch = "arm", target_arch = "aarch64"))
+    ))]
+    pub use runtime::{__unstable_detect_feature, __Feature};
 }
+
+#[cfg(any(
+    // x86/x86_64:
+    any(target_arch = "x86", target_arch = "x86_64"),
+    // linux + std + (arm|aarch64):
+    all(target_os = "linux",
+        feature = "std",
+        any(target_arch = "arm", target_arch = "aarch64"))
+))]
+#[macro_use]
+mod runtime;
 
 #[macro_use]
 mod macros;
@@ -204,7 +225,6 @@ mod v16 {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[macro_use]
 mod x86;
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 #![feature(const_fn, link_llvm_intrinsics, platform_intrinsics, repr_simd,
            simd_ffi, target_feature, cfg_target_feature, i128_type, asm,
            const_atomic_usize_new, stmt_expr_attributes)]
-#![cfg_attr(test, feature(proc_macro, test))]
+#![cfg_attr(test, feature(proc_macro, test, repr_align, attr_literals))]
 #![cfg_attr(feature = "cargo-clippy",
             allow(inline_always, too_many_arguments, cast_sign_loss,
                   cast_lossless, cast_possible_wrap,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -373,56 +373,6 @@ macro_rules! define_casts {
     }
 }
 
-/// Is a feature supported by the host CPU?
-///
-/// This macro performs run-time feature detection. It returns true if the host
-/// CPU in which the binary is running on supports a particular feature.
-#[macro_export]
-macro_rules! cfg_feature_enabled {
-    ($name:tt) => (
-        {
-            #[cfg(target_feature = $name)]
-            {
-                true
-            }
-            #[cfg(not(target_feature = $name))]
-            {
-                __unstable_detect_feature!($name)
-            }
-        }
-    )
-}
-
-/// On ARM features are only detected at compile-time using
-/// cfg(target_feature), so if this macro is executed the
-/// feature is not supported.
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! __unstable_detect_feature {
-    ("neon") => { false };
-    ($t:tt) => { compile_error!(concat!("unknown target feature: ", $t)) };
-}
-
-/// In all unsupported architectures using the macro is an error
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64",
-              target_arch = "arm", target_arch = "aarch64")))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! __unstable_detect_feature {
-    ($t:tt) => { compile_error!(concat!("unknown target feature: ", $t)) };
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(target_arch = "x86_64")]
-    #[test]
-    fn test_macros() {
-        assert!(cfg_feature_enabled!("sse"));
-    }
-}
-
-
 #[cfg(test)]
 #[macro_export]
 macro_rules! test_arithmetic_ {

--- a/src/runtime/aarch64.rs
+++ b/src/runtime/aarch64.rs
@@ -1,0 +1,56 @@
+//! Run-time feature detection on ARM Aarch64.
+use super::{bit, linux};
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __unstable_detect_feature {
+    ("neon") => {
+        // FIXME: this should be removed once we rename Aarch64 neon to asimd
+        $crate::vendor::__unstable_detect_feature($crate::vendor::__Feature::asimd{})
+    };
+    ("asimd") => {
+        $crate::vendor::__unstable_detect_feature($crate::vendor::__Feature::asimd{})
+    };
+    ("pmull") => {
+        $crate::vendor::__unstable_detect_feature($crate::vendor::__Feature::pmull{})
+    };
+    ($t:tt) => { compile_error!(concat!("unknown arm target feature: ", $t)) };
+}
+
+/// ARM Aarch64 CPU Feature enum. Each variant denotes a position in a bitset
+/// for a particular feature.
+///
+/// PLEASE: do not use this, it is an implementation detail subject to change.
+#[doc(hidden)]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+pub enum __Feature {
+    /// ARM Advanced SIMD (ASIMD) - Aarch64
+    asimd,
+    /// Polynomial Multiply
+    pmull,
+}
+
+pub fn detect_features<T: linux::FeatureQuery>(mut x: T) -> usize {
+    let value: usize = 0;
+    {
+        let mut enable_feature = |f| {
+            if x.has_feature(&f) {
+                bit::set(value, f as u32);
+            }
+        };
+        enable_feature(__Feature::asimd);
+        enable_feature(__Feature::pmull);
+    }
+    value
+}
+
+impl linux::FeatureQuery for linux::CpuInfo {
+    fn has_feature(&mut self, x: &__Feature) -> bool {
+        use self::__Feature::*;
+        match *x {
+            asimd => self.field("Features").has("asimd"),
+            pmull => self.field("Features").has("pmull"),
+        }
+    }
+}

--- a/src/runtime/arm.rs
+++ b/src/runtime/arm.rs
@@ -1,0 +1,66 @@
+//! Run-time feature detection on ARM Aarch32.
+
+use super::{bit, linux};
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __unstable_detect_feature {
+    ("neon") => {
+        $crate::vendor::__unstable_detect_feature($crate::vendor::__Feature::neon{})
+    };
+    ("pmull") => {
+        $crate::vendor::__unstable_detect_feature($crate::vendor::__Feature::pmull{})
+    };
+    ($t:tt) => { compile_error!(concat!("unknown arm target feature: ", $t)) };
+}
+
+/// ARM CPU Feature enum. Each variant denotes a position in a bitset for a
+/// particular feature.
+///
+/// PLEASE: do not use this, it is an implementation detail subject to change.
+#[doc(hidden)]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+pub enum __Feature {
+    /// ARM Advanced SIMD (NEON) - Aarch32
+    neon,
+    /// Polynomial Multiply
+    pmull,
+}
+
+pub fn detect_features<T: linux::FeatureQuery>(mut x: T) -> usize {
+    let value: usize = 0;
+    {
+        let mut enable_feature = |f| {
+            if x.has_feature(&f) {
+                bit::set(value, f as u32);
+            }
+        };
+        enable_feature(__Feature::neon);
+        enable_feature(__Feature::pmull);
+    }
+    value
+}
+
+/// Is the CPU known to have a broken NEON unit?
+///
+/// See https://crbug.com/341598.
+fn has_broken_neon(cpuinfo: &linux::CpuInfo) -> bool {
+    cpuinfo.field("CPU implementer") == "0x51"
+        && cpuinfo.field("CPU architecture") == "7"
+        && cpuinfo.field("CPU variant") == "0x1"
+        && cpuinfo.field("CPU part") == "0x04d"
+        && cpuinfo.field("CPU revision") == "0"
+}
+
+impl linux::FeatureQuery for linux::CpuInfo {
+    fn has_feature(&mut self, x: &__Feature) -> bool {
+        use self::__Feature::*;
+        match *x {
+            neon => {
+                self.field("Features").has("neon") && !has_broken_neon(self)
+            }
+            pmull => self.field("Features").has("pmull"),
+        }
+    }
+}

--- a/src/runtime/bit.rs
+++ b/src/runtime/bit.rs
@@ -1,0 +1,11 @@
+//! Bit manipulation utilities
+
+/// Sets the `bit` of `x`.
+pub const fn set(x: usize, bit: u32) -> usize {
+    x | 1 << bit
+}
+
+/// Tests the `bit` of `x`.
+pub const fn test(x: usize, bit: u32) -> bool {
+    x & (1 << bit) != 0
+}

--- a/src/runtime/cache.rs
+++ b/src/runtime/cache.rs
@@ -1,0 +1,29 @@
+//! Cache of run-time feature detection
+
+use super::bit;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// This global variable is a bitset used to cache the features supported by
+/// the
+/// CPU.
+static CACHE: AtomicUsize = AtomicUsize::new(::std::usize::MAX);
+
+/// Test the `bit` of the storage. If the storage has not been initialized,
+/// initializes it with the result of `f()`.
+///
+/// On its first invocation, it detects the CPU features and caches them in the
+/// `FEATURES` global variable as an `AtomicUsize`.
+///
+/// It uses the `__Feature` variant to index into this variable as a bitset. If
+/// the bit is set, the feature is enabled, and otherwise it is disabled.
+///
+/// PLEASE: do not use this, it is an implementation detail subject to change.
+pub fn test<F>(bit: u32, f: F) -> bool
+where
+    F: FnOnce() -> usize,
+{
+    if CACHE.load(Ordering::Relaxed) == ::std::usize::MAX {
+        CACHE.store(f(), Ordering::Relaxed);
+    }
+    bit::test(CACHE.load(Ordering::Relaxed), bit)
+}

--- a/src/runtime/linux/cpuinfo.rs
+++ b/src/runtime/linux/cpuinfo.rs
@@ -1,0 +1,211 @@
+//! Reads /proc/cpuinfo on Linux systems
+
+/// cpuinfo
+pub struct CpuInfo {
+    raw: String,
+}
+
+/// Field of cpuinfo
+#[derive(Debug)]
+pub struct CpuInfoField<'a>(Option<&'a str>);
+
+impl<'a> PartialEq<&'a str> for CpuInfoField<'a> {
+    fn eq(&self, other: &&'a str) -> bool {
+        match self.0 {
+            None => other.len() == 0,
+            Some(f) => f == other.trim(),
+        }
+    }
+}
+
+impl<'a> CpuInfoField<'a> {
+    pub fn new<'b>(v: Option<&'b str>) -> CpuInfoField<'b> {
+        match v {
+            None => CpuInfoField::<'b>(None),
+            Some(f) => CpuInfoField::<'b>(Some(f.trim())),
+        }
+    }
+    /// Does the field exist?
+    pub fn exists(&self) -> bool {
+        self.0.is_some()
+    }
+    /// Does the field contain `other`?
+    pub fn has(&self, other: &str) -> bool {
+        match self.0 {
+            None => other.len() == 0,
+            Some(f) => {
+                let other = other.trim();
+                for v in f.split(" ") {
+                    if v == other {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
+}
+
+impl CpuInfo {
+    /// Reads /proc/cpuinfo into CpuInfo.
+    pub fn new() -> Result<CpuInfo, ::std::io::Error> {
+        use std::io::Read;
+        let mut file = ::std::fs::File::open("/proc/cpuinfo")?;
+        let mut cpui = CpuInfo { raw: String::new() };
+        file.read_to_string(&mut cpui.raw)?;
+        Ok(cpui)
+    }
+    /// Returns the value of the cpuinfo `field`.
+    pub fn field(&self, field: &str) -> CpuInfoField {
+        for l in self.raw.lines() {
+            if l.trim().starts_with(field) {
+                return CpuInfoField(l.split(": ").skip(1).next());
+            }
+        }
+        CpuInfoField(None)
+    }
+
+    /// Returns the `raw` contents of `/proc/cpuinfo`
+    fn raw(&self) -> &String {
+        &self.raw
+    }
+
+    fn from_str(other: &str) -> Result<CpuInfo, ::std::io::Error> {
+        Ok(CpuInfo {
+            raw: String::from(other),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_cpuinfo_linux() {
+        let cpuinfo = CpuInfo::new().unwrap();
+        if cpuinfo.field("vendor_id") == "GenuineIntel" {
+            assert!(cpuinfo.field("flags").exists());
+            assert!(!cpuinfo.field("vendor33_id").exists());
+            assert!(cpuinfo.field("flags").has("sse"));
+            assert!(!cpuinfo.field("flags").has("avx314"));
+        }
+        println!("{}", cpuinfo.raw());
+    }
+
+
+    const CORE_DUO_T6500: &str = r"processor       : 0
+vendor_id       : GenuineIntel
+cpu family      : 6
+model           : 23
+model name      : Intel(R) Core(TM)2 Duo CPU     T6500  @ 2.10GHz
+stepping        : 10
+microcode       : 0xa0b
+cpu MHz         : 1600.000
+cache size      : 2048 KB
+physical id     : 0
+siblings        : 2
+core id         : 0
+cpu cores       : 2
+apicid          : 0
+initial apicid  : 0
+fdiv_bug        : no
+hlt_bug         : no
+f00f_bug        : no
+coma_bug        : no
+fpu             : yes
+fpu_exception   : yes
+cpuid level     : 13
+wp              : yes
+flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe nx lm constant_tsc arch_perfmon pebs bts aperfmperf pni dtes64 monitor ds_cpl est tm2 ssse3 cx16 xtpr pdcm sse4_1 xsave lahf_lm dtherm
+bogomips        : 4190.43
+clflush size    : 64
+cache_alignment : 64
+address sizes   : 36 bits physical, 48 bits virtual
+power management:
+";
+
+    #[test]
+    fn test_cpuinfo_linux_core_duo_t6500() {
+        let cpuinfo = CpuInfo::from_str(CORE_DUO_T6500).unwrap();
+        assert_eq!(cpuinfo.field("vendor_id"), "GenuineIntel");
+        assert_eq!(cpuinfo.field("cpu family"), "6");
+        assert_eq!(cpuinfo.field("model"), "23");
+        assert_eq!(
+            cpuinfo.field("model name"),
+            "Intel(R) Core(TM)2 Duo CPU     T6500  @ 2.10GHz"
+        );
+        assert_eq!(
+            cpuinfo.field("flags"),
+            "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe nx lm constant_tsc arch_perfmon pebs bts aperfmperf pni dtes64 monitor ds_cpl est tm2 ssse3 cx16 xtpr pdcm sse4_1 xsave lahf_lm dtherm"
+        );
+        assert!(cpuinfo.field("flags").has("fpu"));
+        assert!(cpuinfo.field("flags").has("dtherm"));
+        assert!(cpuinfo.field("flags").has("sse2"));
+        assert!(!cpuinfo.field("flags").has("avx"));
+    }
+
+    const ARM_CORTEX_A53: &str = r"Processor   : AArch64 Processor rev 3 (aarch64)
+        processor   : 0
+        processor   : 1
+        processor   : 2
+        processor   : 3
+        processor   : 4
+        processor   : 5
+        processor   : 6
+        processor   : 7
+        Features    : fp asimd evtstrm aes pmull sha1 sha2 crc32
+        CPU implementer : 0x41
+        CPU architecture: AArch64
+        CPU variant : 0x0
+        CPU part    : 0xd03
+        CPU revision    : 3
+
+        Hardware    : HiKey Development Board
+        ";
+
+    #[test]
+    fn test_cpuinfo_linux_arm_cortex_a53() {
+        let cpuinfo = CpuInfo::from_str(ARM_CORTEX_A53).unwrap();
+        assert_eq!(
+            cpuinfo.field("Processor"),
+            "AArch64 Processor rev 3 (aarch64)"
+        );
+        assert_eq!(
+            cpuinfo.field("Features"),
+            "fp asimd evtstrm aes pmull sha1 sha2 crc32"
+        );
+        assert!(cpuinfo.field("Features").has("pmull"));
+        assert!(!cpuinfo.field("Features").has("neon"));
+        assert!(cpuinfo.field("Features").has("asimd"));
+    }
+
+    const ARM_CORTEX_A57: &str = r"Processor	: Cortex A57 Processor rev 1 (aarch64)
+processor	: 0
+processor	: 1
+processor	: 2
+processor	: 3
+Features	: fp asimd aes pmull sha1 sha2 crc32 wp half thumb fastmult vfp edsp neon vfpv3 tlsi vfpv4 idiva idivt
+CPU implementer	: 0x41
+CPU architecture: 8
+CPU variant	: 0x1
+CPU part	: 0xd07
+CPU revision	: 1";
+
+    #[test]
+    fn test_cpuinfo_linux_arm_cortex_a57() {
+        let cpuinfo = CpuInfo::from_str(ARM_CORTEX_A57).unwrap();
+        assert_eq!(
+            cpuinfo.field("Processor"),
+            "Cortex A57 Processor rev 1 (aarch64)"
+        );
+        assert_eq!(
+            cpuinfo.field("Features"),
+            "fp asimd aes pmull sha1 sha2 crc32 wp half thumb fastmult vfp edsp neon vfpv3 tlsi vfpv4 idiva idivt"
+        );
+        assert!(cpuinfo.field("Features").has("pmull"));
+        assert!(cpuinfo.field("Features").has("neon"));
+        assert!(cpuinfo.field("Features").has("asimd"));
+    }
+}

--- a/src/runtime/linux/mod.rs
+++ b/src/runtime/linux/mod.rs
@@ -1,0 +1,31 @@
+//! Run-time feature detection for ARM on linux
+mod cpuinfo;
+pub use self::cpuinfo::CpuInfo;
+
+use super::__Feature;
+
+pub trait FeatureQuery {
+    fn has_feature(&mut self, x: &__Feature) -> bool;
+}
+
+fn detect_features_impl<T: FeatureQuery>(x: T) -> usize {
+    #[cfg(target_arch = "arm")]
+    {
+        super::arm::detect_features(x)
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        super::aarch64::detect_features(x)
+    }
+}
+
+/// Detects ARM features:
+pub fn detect_features() -> usize {
+    // FIXME: use libc::getauxval, and if that fails /proc/auxv
+    // Try to read /proc/cpuinfo
+    if let Ok(v) = cpuinfo::CpuInfo::new() {
+        return detect_features_impl(v);
+    }
+    // Otherwise all features are disabled
+    0
+}

--- a/src/runtime/macros.rs
+++ b/src/runtime/macros.rs
@@ -1,0 +1,39 @@
+//! Run-time feature detection macros.
+
+/// Is a feature supported by the host CPU?
+///
+/// This macro performs run-time feature detection. It returns true if the host
+/// CPU in which the binary is running on supports a particular feature.
+#[macro_export]
+macro_rules! cfg_feature_enabled {
+    ($name:tt) => (
+        {
+            #[cfg(target_feature = $name)]
+            {
+                true
+            }
+            #[cfg(not(target_feature = $name))]
+            {
+                __unstable_detect_feature!($name)
+            }
+        }
+    )
+}
+
+/// In all unsupported architectures using the macro is an error
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64",
+              target_arch = "arm", target_arch = "aarch64")))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __unstable_detect_feature {
+    ($t:tt) => { compile_error!(concat!("unknown target feature: ", $t)) };
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_macros() {
+        assert!(cfg_feature_enabled!("sse"));
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,0 +1,40 @@
+//! Run-time feature detection
+mod cache;
+mod bit;
+
+#[macro_use]
+mod macros;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[macro_use]
+mod x86;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub use self::x86::__Feature;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use self::x86::detect_features;
+
+#[cfg(all(target_arch = "arm", target_os = "linux", feature = "std"))]
+#[macro_use]
+mod arm;
+#[cfg(all(target_arch = "arm", target_os = "linux", feature = "std"))]
+pub use self::arm::__Feature;
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux", feature = "std"))]
+#[macro_use]
+mod aarch64;
+#[cfg(all(target_arch = "aarch64", target_os = "linux", feature = "std"))]
+pub use self::aarch64::__Feature;
+
+#[cfg(all(feature = "std", target_os = "linux",
+          any(target_arch = "arm", target_arch = "aarch64")))]
+mod linux;
+
+#[cfg(all(feature = "std", target_os = "linux",
+          any(target_arch = "arm", target_arch = "aarch64")))]
+pub use self::linux::detect_features;
+
+/// Performs run-time feature detection.
+#[doc(hidden)]
+pub fn __unstable_detect_feature(x: __Feature) -> bool {
+    cache::test(x as u32, detect_features)
+}

--- a/src/x86/cpuid.rs
+++ b/src/x86/cpuid.rs
@@ -1,0 +1,119 @@
+//! `cpuid` intrinsics
+
+#![cfg_attr(feature = "cargo-clippy", allow(stutter))]
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Result of the `cpuid` instruction.
+#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "cargo-clippy", allow(stutter))]
+pub struct CpuidResult {
+    /// EAX register.
+    pub eax: u32,
+    /// EBX register.
+    pub ebx: u32,
+    /// ECX register.
+    pub ecx: u32,
+    /// EDX register.
+    pub edx: u32,
+}
+
+/// `cpuid` instruction.
+///
+/// The [CPUID Wikipedia page][wiki_cpuid] contains how to query which
+/// information using the `eax` and `ecx` registers, and the format in
+/// which this information is returned in `eax...edx`.
+///
+/// The `has_cpuid()` intrinsics can be used to query whether the `cpuid`
+/// instruction is available.
+///
+/// The definitive references are:
+/// - [Intel 64 and IA-32 Architectures Software Developer's Manual Volume 2:
+///   Instruction Set Reference, A-Z][intel64_ref].
+/// - [AMD64 Architecture Programmer's Manual, Volume 3: General-Purpose and
+///   System Instructions][amd64_ref].
+///
+/// [wiki_cpuid]: https://en.wikipedia.org/wiki/CPUID
+/// [intel64_ref]: http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
+/// [amd64_ref]: http://support.amd.com/TechDocs/24594.pdf
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cpuid))]
+pub unsafe fn __cpuid_count(eax: u32, ecx: u32) -> CpuidResult {
+    let mut r = ::std::mem::uninitialized::<CpuidResult>();
+    asm!("cpuid"
+         : "={eax}"(r.eax), "={ebx}"(r.ebx), "={ecx}"(r.ecx), "={edx}"(r.edx)
+         : "{eax}"(eax), "{ecx}"(ecx)
+         : :);
+    r
+}
+
+/// `cpuid` instruction.
+///
+/// See `__cpuid_count`.
+#[inline(always)]
+#[cfg_attr(test, assert_instr(cpuid))]
+pub unsafe fn __cpuid(eax: u32) -> CpuidResult {
+    __cpuid_count(eax, 0)
+}
+
+/// Does the host support the `cpuid` instruction?
+#[inline(always)]
+pub fn has_cpuid() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        true
+    }
+    #[cfg(target_arch = "x86")]
+    {
+        use super::ia32::{__readeflags, __writeeflags};
+
+        // On `x86` the `cpuid` instruction is not always available.
+        // This follows the approach indicated in:
+        // http://wiki.osdev.org/CPUID#Checking_CPUID_availability
+        unsafe {
+            // Read EFLAGS:
+            let eflags: u32 = __readeflags();
+
+            // Invert the ID bit in EFLAGS:
+            let eflags_mod: u32 = eflags | 0x0020_0000;
+
+            // Store the modified EFLAGS (ID bit may or may not be inverted)
+            __writeeflags(eflags_mod);
+
+            // Read EFLAGS again:
+            let eflags_after: u32 = __readeflags();
+
+            // Check if the ID bit changed:
+            eflags_after != eflags
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_always_has_cpuid() {
+        // all currently-tested targets have the instruction
+        // FIXME: add targets without `cpuid` to CI
+        assert!(has_cpuid());
+    }
+
+    #[cfg(target_arch = "x86")]
+    #[test]
+    fn test_has_cpuid() {
+        use vendor::__readeflags;
+        unsafe {
+            let before = __readeflags();
+
+            if has_cpuid() {
+                assert!(before != __readeflags());
+            } else {
+                assert!(before == __readeflags());
+            }
+        }
+    }
+
+}

--- a/src/x86/ia32.rs
+++ b/src/x86/ia32.rs
@@ -1,0 +1,50 @@
+//! `i386/ia32` intrinsics
+
+/// Reads EFLAGS.
+#[cfg(target_arch = "x86")]
+#[inline(always)]
+pub unsafe fn __readeflags() -> u32 {
+    let eflags: u32;
+    asm!("pushfd; popl $0" : "=r"(eflags) : : : "volatile");
+    eflags
+}
+
+/// Reads EFLAGS.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+pub unsafe fn __readeflags() -> u64 {
+    let eflags: u64;
+    asm!("pushfq; popq $0" : "=r"(eflags) : : : "volatile");
+    eflags
+}
+
+/// Write EFLAGS.
+#[cfg(target_arch = "x86")]
+#[inline(always)]
+pub unsafe fn __writeeflags(eflags: u32) {
+    asm!("pushl $0; popfd" : : "r"(eflags) : "cc", "flags" : "volatile");
+}
+
+/// Write EFLAGS.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+pub unsafe fn __writeeflags(eflags: u64) {
+    asm!("pushq $0; popfq" : : "r"(eflags) : "cc", "flags" : "volatile");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eflags() {
+        unsafe {
+            // reads eflags, writes them back, reads them again,
+            // and compare for equality:
+            let v = __readeflags();
+            __writeeflags(v);
+            let u = __readeflags();
+            assert_eq!(v, u);
+        }
+    }
+}

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -20,8 +20,6 @@ pub use self::bmi2::*;
 #[cfg(not(feature = "intel_sde"))]
 pub use self::tbm::*;
 
-pub use self::runtime::{__unstable_detect_feature, __Feature};
-
 /// 128-bit wide signed integer vector type
 #[allow(non_camel_case_types)]
 pub type __m128i = ::v128::i8x16;
@@ -31,8 +29,6 @@ pub type __m256i = ::v256::i8x32;
 
 #[macro_use]
 mod macros;
-#[macro_use]
-mod runtime;
 
 mod ia32;
 mod cpuid;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -50,8 +50,9 @@ mod bmi2;
 #[cfg(not(feature = "intel_sde"))]
 mod tbm;
 
-#[allow(non_camel_case_types)]
+/// `C`'s `void` type.
 #[cfg(not(feature = "std"))]
+#[allow(non_camel_case_types)]
 #[repr(u8)]
 pub enum c_void {
     #[doc(hidden)] __variant1,

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -1,5 +1,6 @@
 //! `x86` and `x86_64` intrinsics.
 
+pub use self::ia32::*;
 pub use self::xsave::*;
 
 pub use self::sse::*;
@@ -31,6 +32,7 @@ mod macros;
 mod runtime;
 
 mod xsave;
+mod ia32;
 
 mod sse;
 mod sse2;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -1,6 +1,7 @@
 //! `x86` and `x86_64` intrinsics.
 
 pub use self::ia32::*;
+pub use self::cpuid::*;
 pub use self::xsave::*;
 
 pub use self::sse::*;
@@ -31,8 +32,9 @@ mod macros;
 #[macro_use]
 mod runtime;
 
-mod xsave;
 mod ia32;
+mod cpuid;
+mod xsave;
 
 mod sse;
 mod sse2;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -16,6 +16,8 @@ pub use self::avx2::*;
 pub use self::abm::*;
 pub use self::bmi::*;
 pub use self::bmi2::*;
+
+#[cfg(not(feature = "intel_sde"))]
 pub use self::tbm::*;
 
 pub use self::runtime::{__unstable_detect_feature, __Feature};
@@ -48,6 +50,8 @@ mod avx2;
 mod abm;
 mod bmi;
 mod bmi2;
+
+#[cfg(not(feature = "intel_sde"))]
 mod tbm;
 
 #[allow(non_camel_case_types)]

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -1,5 +1,7 @@
 //! `x86` and `x86_64` intrinsics.
 
+pub use self::xsave::*;
+
 pub use self::sse::*;
 pub use self::sse2::*;
 pub use self::sse3::*;
@@ -27,6 +29,8 @@ pub type __m256i = ::v256::i8x32;
 mod macros;
 #[macro_use]
 mod runtime;
+
+mod xsave;
 
 mod sse;
 mod sse2;

--- a/src/x86/xsave.rs
+++ b/src/x86/xsave.rs
@@ -377,6 +377,7 @@ mod tests {
         assert_eq!(a, b);
     }
 
+    #[cfg(not(feature = "intel_sde"))]
     #[simd_test = "xsaves"]
     unsafe fn xsaves() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
@@ -389,7 +390,7 @@ mod tests {
         assert_eq!(a, b);
     }
 
-    #[cfg(not(target_arch = "x86"))]
+    #[cfg(not(any(target_arch = "x86", feature = "intel_sde")))]
     #[simd_test = "xsaves"]
     unsafe fn xsaves64() {
         let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers

--- a/src/x86/xsave.rs
+++ b/src/x86/xsave.rs
@@ -1,0 +1,404 @@
+//! `xsave` and `xsaveopt` target feature intrinsics
+
+#![cfg_attr(feature = "cargo-clippy", allow(stutter))]
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+use x86::c_void;
+
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.x86.xsave"]
+    fn xsave(p: *mut i8, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xrstor"]
+    fn xrstor(p: *const c_void, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xsetbv"]
+    fn xsetbv(v: i32, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xgetbv"]
+    fn xgetbv(x: i32) -> i64;
+    #[link_name = "llvm.x86.xsave64"]
+    fn xsave64(p: *mut i8, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xrstor64"]
+    fn xrstor64(p: *const c_void, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xsaveopt"]
+    fn xsaveopt(p: *mut i8, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xsaveopt64"]
+    fn xsaveopt64(p: *mut i8, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xsavec"]
+    fn xsavec(p: *mut i8, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xsavec64"]
+    fn xsavec64(p: *mut i8, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xsaves"]
+    fn xsaves(p: *mut i8, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xsaves64"]
+    fn xsaves64(p: *mut i8, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xrstors"]
+    fn xrstors(p: *const c_void, hi: i32, lo: i32) -> ();
+    #[link_name = "llvm.x86.xrstors64"]
+    fn xrstors64(p: *const c_void, hi: i32, lo: i32) -> ();
+}
+
+/// Perform a full or partial save of the enabled processor states to memory at
+/// `mem_addr`.
+///
+/// State is saved based on bits [62:0] in `save_mask` and XCR0.
+/// `mem_addr` must be aligned on a 64-byte boundary.
+///
+/// The format of the XSAVE area is detailed in Section 13.4, “XSAVE Area,” of
+/// Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 1.
+#[inline(always)]
+#[target_feature = "+xsave"]
+#[cfg_attr(test, assert_instr(xsave))]
+pub unsafe fn _xsave(mem_addr: *mut c_void, save_mask: u64) -> () {
+    xsave(mem_addr as *mut i8, (save_mask >> 32) as i32, save_mask as i32);
+}
+
+/// Perform a full or partial restore of the enabled processor states using
+/// the state information stored in memory at `mem_addr`.
+///
+/// State is restored based on bits [62:0] in `rs_mask`, `XCR0`, and
+/// `mem_addr.HEADER.XSTATE_BV`. `mem_addr` must be aligned on a 64-byte
+/// boundary.
+#[inline(always)]
+#[target_feature = "+xsave"]
+#[cfg_attr(test, assert_instr(xrstor))]
+pub unsafe fn _xrstor(mem_addr: *const c_void, rs_mask: u64) -> () {
+    xrstor(mem_addr, (rs_mask >> 32) as i32, rs_mask as i32);
+}
+
+/// `XFEATURE_ENABLED_MASK` for `XCR`
+///
+/// This intrinsic maps to `XSETBV` instruction.
+const _XCR_XFEATURE_ENABLED_MASK: u32 = 0;
+
+/// Copy 64-bits from `val` to the extended control register (`XCR`) specified
+/// by `a`.
+///
+/// Currently only `XFEATURE_ENABLED_MASK` `XCR` is supported.
+#[inline(always)]
+#[target_feature = "+xsave"]
+#[cfg_attr(test, assert_instr(xsetbv))]
+pub unsafe fn _xsetbv(a: u32, val: u64) -> () {
+    xsetbv(a as i32, (val >> 32) as i32, val as i32);
+}
+
+/// Reads the contents of the extended control register `XCR`
+/// specified in `xcr_no`.
+#[inline(always)]
+#[target_feature = "+xsave"]
+#[cfg_attr(test, assert_instr(xgetbv))]
+pub unsafe fn _xgetbv(xcr_no: u32) -> u64 {
+    xgetbv(xcr_no as i32) as u64
+}
+
+/// Perform a full or partial save of the enabled processor states to memory at
+/// `mem_addr`.
+///
+/// State is saved based on bits [62:0] in `save_mask` and XCR0.
+/// `mem_addr` must be aligned on a 64-byte boundary.
+///
+/// The format of the XSAVE area is detailed in Section 13.4, “XSAVE Area,” of
+/// Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 1.
+#[inline(always)]
+#[target_feature = "+xsave"]
+#[cfg_attr(test, assert_instr(xsave64))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _xsave64(mem_addr: *mut c_void, save_mask: u64) -> () {
+    xsave64(mem_addr as *mut i8, (save_mask >> 32) as i32, save_mask as i32);
+}
+
+/// Perform a full or partial restore of the enabled processor states using
+/// the state information stored in memory at `mem_addr`.
+///
+/// State is restored based on bits [62:0] in `rs_mask`, `XCR0`, and
+/// `mem_addr.HEADER.XSTATE_BV`. `mem_addr` must be aligned on a 64-byte
+/// boundary.
+#[inline(always)]
+#[target_feature = "+xsave"]
+#[cfg_attr(test, assert_instr(xrstor64))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _xrstor64(mem_addr: *const c_void, rs_mask: u64) -> () {
+    xrstor64(mem_addr, (rs_mask >> 32) as i32, rs_mask as i32);
+}
+
+/// Perform a full or partial save of the enabled processor states to memory at
+/// `mem_addr`.
+///
+/// State is saved based on bits [62:0] in `save_mask` and `XCR0`.
+/// `mem_addr` must be aligned on a 64-byte boundary. The hardware may optimize
+/// the manner in which data is saved. The performance of this instruction will
+/// be equal to or better than using the `XSAVE` instruction.
+#[inline(always)]
+#[target_feature = "+xsave,+xsaveopt"]
+#[cfg_attr(test, assert_instr(xsaveopt))]
+pub unsafe fn _xsaveopt(mem_addr: *mut c_void, save_mask: u64) -> () {
+    xsaveopt(mem_addr as *mut i8, (save_mask >> 32) as i32, save_mask as i32);
+}
+
+/// Perform a full or partial save of the enabled processor states to memory at
+/// `mem_addr`.
+///
+/// State is saved based on bits [62:0] in `save_mask` and `XCR0`.
+/// `mem_addr` must be aligned on a 64-byte boundary. The hardware may optimize
+/// the manner in which data is saved. The performance of this instruction will
+/// be equal to or better than using the `XSAVE64` instruction.
+#[inline(always)]
+#[target_feature = "+xsave,+xsaveopt"]
+#[cfg_attr(test, assert_instr(xsaveopt64))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _xsaveopt64(mem_addr: *mut c_void, save_mask: u64) -> () {
+    xsaveopt64(
+        mem_addr as *mut i8,
+        (save_mask >> 32) as i32,
+        save_mask as i32,
+    );
+}
+
+/// Perform a full or partial save of the enabled processor states to memory
+/// at `mem_addr`.
+///
+/// `xsavec` differs from `xsave` in that it uses compaction and that it may
+/// use init optimization. State is saved based on bits [62:0] in `save_mask`
+/// and `XCR0`. `mem_addr` must be aligned on a 64-byte boundary.
+#[inline(always)]
+#[target_feature = "+xsave,+xsavec"]
+#[cfg_attr(test, assert_instr(xsavec))]
+pub unsafe fn _xsavec(mem_addr: *mut c_void, save_mask: u64) -> () {
+    xsavec(mem_addr as *mut i8, (save_mask >> 32) as i32, save_mask as i32);
+}
+
+/// Perform a full or partial save of the enabled processor states to memory
+/// at `mem_addr`.
+///
+/// `xsavec` differs from `xsave` in that it uses compaction and that it may
+/// use init optimization. State is saved based on bits [62:0] in `save_mask`
+/// and `XCR0`. `mem_addr` must be aligned on a 64-byte boundary.
+#[inline(always)]
+#[target_feature = "+xsave,+xsavec"]
+#[cfg_attr(test, assert_instr(xsavec64))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _xsavec64(mem_addr: *mut c_void, save_mask: u64) -> () {
+    xsavec64(mem_addr as *mut i8, (save_mask >> 32) as i32, save_mask as i32);
+}
+
+/// Perform a full or partial save of the enabled processor states to memory at
+/// `mem_addr`
+///
+/// `xsaves` differs from xsave in that it can save state components
+/// corresponding to bits set in `IA32_XSS` `MSR` and that it may use the
+/// modified optimization. State is saved based on bits [62:0] in `save_mask`
+/// and `XCR0`. `mem_addr` must be aligned on a 64-byte boundary.
+#[inline(always)]
+#[target_feature = "+xsave,+xsaves"]
+#[cfg_attr(test, assert_instr(xsaves))]
+pub unsafe fn _xsaves(mem_addr: *mut c_void, save_mask: u64) -> () {
+    xsaves(mem_addr as *mut i8, (save_mask >> 32) as i32, save_mask as i32);
+}
+
+/// Perform a full or partial save of the enabled processor states to memory at
+/// `mem_addr`
+///
+/// `xsaves` differs from xsave in that it can save state components
+/// corresponding to bits set in `IA32_XSS` `MSR` and that it may use the
+/// modified optimization. State is saved based on bits [62:0] in `save_mask`
+/// and `XCR0`. `mem_addr` must be aligned on a 64-byte boundary.
+#[inline(always)]
+#[target_feature = "+xsave,+xsaves"]
+#[cfg_attr(test, assert_instr(xsaves64))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _xsaves64(mem_addr: *mut c_void, save_mask: u64) -> () {
+    xsaves64(mem_addr as *mut i8, (save_mask >> 32) as i32, save_mask as i32);
+}
+
+/// Perform a full or partial restore of the enabled processor states using the
+/// state information stored in memory at `mem_addr`.
+///
+/// `xrstors` differs from `xrstor` in that it can restore state components
+/// corresponding to bits set in the `IA32_XSS` `MSR`; `xrstors` cannot restore
+/// from an `xsave` area in which the extended region is in the standard form.
+/// State is restored based on bits [62:0] in `rs_mask`, `XCR0`, and
+/// `mem_addr.HEADER.XSTATE_BV`. `mem_addr` must be aligned on a 64-byte
+/// boundary.
+#[inline(always)]
+#[target_feature = "+xsave,+xsaves"]
+#[cfg_attr(test, assert_instr(xrstors))]
+pub unsafe fn _xrstors(mem_addr: *const c_void, rs_mask: u64) -> () {
+    xrstors(mem_addr, (rs_mask >> 32) as i32, rs_mask as i32);
+}
+/// Perform a full or partial restore of the enabled processor states using the
+/// state information stored in memory at `mem_addr`.
+///
+/// `xrstors` differs from `xrstor` in that it can restore state components
+/// corresponding to bits set in the `IA32_XSS` `MSR`; `xrstors` cannot restore
+/// from an `xsave` area in which the extended region is in the standard form.
+/// State is restored based on bits [62:0] in `rs_mask`, `XCR0`, and
+/// `mem_addr.HEADER.XSTATE_BV`. `mem_addr` must be aligned on a 64-byte
+/// boundary.
+#[inline(always)]
+#[target_feature = "+xsave,+xsaves"]
+#[cfg_attr(test, assert_instr(xrstors64))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _xrstors64(mem_addr: *const c_void, rs_mask: u64) -> () {
+    xrstors64(mem_addr, (rs_mask >> 32) as i32, rs_mask as i32);
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stdsimd_test::simd_test;
+    use std::fmt;
+
+    #[repr(align(64))]
+    struct Buffer {
+        data: [u64; 1024], // 8192 bytes
+    }
+
+    impl Buffer {
+        fn new() -> Buffer {
+            Buffer { data: [0; 1024] }
+        }
+        fn ptr(&mut self) -> *mut c_void {
+            &mut self.data[0] as *mut _ as *mut c_void
+        }
+    }
+
+    impl PartialEq<Buffer> for Buffer {
+        fn eq(&self, other: &Buffer) -> bool {
+            for i in 0..1024 {
+                if self.data[i] != other.data[i] {
+                    return false;
+                }
+            }
+            true
+        }
+    }
+
+    impl fmt::Debug for Buffer {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "[")?;
+            for i in 0..1024 {
+                write!(f, "{}", self.data[i])?;
+                if i != 1023 {
+                    write!(f, ", ")?;
+                }
+            }
+            write!(f, "]")
+        }
+    }
+
+    #[simd_test = "xsave"]
+    unsafe fn xsave() {
+        let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
+        let mut a = Buffer::new();
+        let mut b = Buffer::new();
+
+        _xsave(a.ptr(), m);
+        _xrstor(a.ptr(), m);
+        _xsave(b.ptr(), m);
+        assert_eq!(a, b);
+    }
+
+    #[cfg(not(target_arch = "x86"))]
+    #[simd_test = "xsave"]
+    unsafe fn xsave64() {
+        let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
+        let mut a = Buffer::new();
+        let mut b = Buffer::new();
+
+        _xsave64(a.ptr(), m);
+        _xrstor64(a.ptr(), m);
+        _xsave64(b.ptr(), m);
+        assert_eq!(a, b);
+    }
+
+    #[simd_test = "xsave"]
+    unsafe fn xgetbv_xsetbv() {
+        let xcr_n: u32 = _XCR_XFEATURE_ENABLED_MASK;
+
+        let xcr: u64 = _xgetbv(xcr_n);
+        // FIXME: XSETBV is a privileged instruction we should only test this
+        // when running in privileged mode:
+        //
+        // _xsetbv(xcr_n, xcr);
+        let xcr_cpy: u64 = _xgetbv(xcr_n);
+        assert_eq!(xcr, xcr_cpy);
+    }
+
+    #[simd_test = "xsave,xsaveopt"]
+    unsafe fn xsaveopt() {
+        let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
+        let mut a = Buffer::new();
+        let mut b = Buffer::new();
+
+        _xsaveopt(a.ptr(), m);
+        _xrstor(a.ptr(), m);
+        _xsaveopt(b.ptr(), m);
+        assert_eq!(a, b);
+    }
+
+    #[cfg(not(target_arch = "x86"))]
+    #[simd_test = "xsave,xsaveopt"]
+    unsafe fn xsaveopt64() {
+        let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
+        let mut a = Buffer::new();
+        let mut b = Buffer::new();
+
+        _xsaveopt64(a.ptr(), m);
+        _xrstor64(a.ptr(), m);
+        _xsaveopt64(b.ptr(), m);
+        assert_eq!(a, b);
+    }
+
+
+    #[simd_test = "xsave,xsavec"]
+    unsafe fn xsavec() {
+        let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
+        let mut a = Buffer::new();
+        let mut b = Buffer::new();
+
+        _xsavec(a.ptr(), m);
+        _xrstor(a.ptr(), m);
+        _xsavec(b.ptr(), m);
+        assert_eq!(a, b);
+    }
+
+    #[cfg(not(target_arch = "x86"))]
+    #[simd_test = "xsave,xsavec"]
+    unsafe fn xsavec64() {
+        let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
+        let mut a = Buffer::new();
+        let mut b = Buffer::new();
+
+        _xsavec64(a.ptr(), m);
+        _xrstor64(a.ptr(), m);
+        _xsavec64(b.ptr(), m);
+        assert_eq!(a, b);
+    }
+
+    #[simd_test = "xsaves"]
+    unsafe fn xsaves() {
+        let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
+        let mut a = Buffer::new();
+        let mut b = Buffer::new();
+
+        _xsaves(a.ptr(), m);
+        _xrstors(a.ptr(), m);
+        _xsaves(b.ptr(), m);
+        assert_eq!(a, b);
+    }
+
+    #[cfg(not(target_arch = "x86"))]
+    #[simd_test = "xsaves"]
+    unsafe fn xsaves64() {
+        let m = 0xFFFFFFFFFFFFFFFF_u64; //< all registers
+        let mut a = Buffer::new();
+        let mut b = Buffer::new();
+
+        _xsaves64(a.ptr(), m);
+        _xrstors64(a.ptr(), m);
+        _xsaves64(b.ptr(), m);
+        assert_eq!(a, b);
+    }
+}

--- a/tests/cpu-detection.rs
+++ b/tests/cpu-detection.rs
@@ -27,9 +27,12 @@ fn works() {
     // assert_eq!(cfg_feature_enabled!("avx512bw"), information.avx512bw());
     // assert_eq!(cfg_feature_enabled!("avx512dq"), information.avx512dq());
     // assert_eq!(cfg_feature_enabled!("avx512vl"), information.avx512vl());
-    // assert_eq!(cfg_feature_enabled!("avx512ifma"), information.avx512ifma());
-    // assert_eq!(cfg_feature_enabled!("avx512vbmi"), information.avx512vbmi());
-    // assert_eq!(cfg_feature_enabled!("avx512vpopcntdq"), information.avx512vpopcntdq());
+    // assert_eq!(cfg_feature_enabled!("avx512ifma"),
+    // information.avx512_ifma());
+    // assert_eq!(cfg_feature_enabled!("avx512vbmi"),
+    // information.avx512_vbmi());
+    // assert_eq!(cfg_feature_enabled!("avx512vpopcntdq"),
+    // information.avx512_vpopcntdq());
     assert_eq!(cfg_feature_enabled!("fma"), information.fma());
     assert_eq!(cfg_feature_enabled!("bmi"), information.bmi1());
     assert_eq!(cfg_feature_enabled!("bmi2"), information.bmi2());
@@ -40,6 +43,12 @@ fn works() {
     assert_eq!(cfg_feature_enabled!("lzcnt"), information.lzcnt());
     assert_eq!(cfg_feature_enabled!("xsave"), information.xsave());
     assert_eq!(cfg_feature_enabled!("xsaveopt"), information.xsaveopt());
-    assert_eq!(cfg_feature_enabled!("xsavec"), information.xsavec_and_xrstor());
-    assert_eq!(cfg_feature_enabled!("xsavec"), information.xsaves_xrstors_and_ia32_xss());
+    assert_eq!(
+        cfg_feature_enabled!("xsavec"),
+        information.xsavec_and_xrstor()
+    );
+    assert_eq!(
+        cfg_feature_enabled!("xsavec"),
+        information.xsaves_xrstors_and_ia32_xss()
+    );
 }

--- a/tests/cpu-detection.rs
+++ b/tests/cpu-detection.rs
@@ -20,10 +20,26 @@ fn works() {
     assert_eq!(cfg_feature_enabled!("sse4.2"), information.sse4_2());
     assert_eq!(cfg_feature_enabled!("avx"), information.avx());
     assert_eq!(cfg_feature_enabled!("avx2"), information.avx2());
+    // assert_eq!(cfg_feature_enabled!("avx512f"), information.avx512f());
+    // assert_eq!(cfg_feature_enabled!("avx512cd"), information.avx512cd());
+    // assert_eq!(cfg_feature_enabled!("avx512er"), information.avx512er());
+    // assert_eq!(cfg_feature_enabled!("avx512pf"), information.avx512pf());
+    // assert_eq!(cfg_feature_enabled!("avx512bw"), information.avx512bw());
+    // assert_eq!(cfg_feature_enabled!("avx512dq"), information.avx512dq());
+    // assert_eq!(cfg_feature_enabled!("avx512vl"), information.avx512vl());
+    // assert_eq!(cfg_feature_enabled!("avx512ifma"), information.avx512ifma());
+    // assert_eq!(cfg_feature_enabled!("avx512vbmi"), information.avx512vbmi());
+    // assert_eq!(cfg_feature_enabled!("avx512vpopcntdq"), information.avx512vpopcntdq());
     assert_eq!(cfg_feature_enabled!("fma"), information.fma());
     assert_eq!(cfg_feature_enabled!("bmi"), information.bmi1());
     assert_eq!(cfg_feature_enabled!("bmi2"), information.bmi2());
     assert_eq!(cfg_feature_enabled!("popcnt"), information.popcnt());
-
-    // TODO: tbm, abm, lzcnt
+    // assert_eq!(cfg_feature_enabled!("sse4a"), information.sse4a());
+    assert_eq!(cfg_feature_enabled!("abm"), information.lzcnt());
+    assert_eq!(cfg_feature_enabled!("tbm"), information.tbm());
+    assert_eq!(cfg_feature_enabled!("lzcnt"), information.lzcnt());
+    assert_eq!(cfg_feature_enabled!("xsave"), information.xsave());
+    assert_eq!(cfg_feature_enabled!("xsaveopt"), information.xsaveopt());
+    assert_eq!(cfg_feature_enabled!("xsavec"), information.xsavec_and_xrstor());
+    assert_eq!(cfg_feature_enabled!("xsavec"), information.xsaves_xrstors_and_ia32_xss());
 }


### PR DESCRIPTION
This PR implements:

- the `xsave` intrinsics,
- the `__readeflags`/`__writeeflags` intrinsics,
- the `cpuid` intrinsics (except for GCC's `__get_cpuid_max`, Issue #174 ), and
- run-time feature detection for `xsave` and `AVX-512`,

and fixes one bug:
- the `CPUID` instruction was used before testing whether the CPU supported it.

Note that the `has_cpuid` intrinsic does not exist in GCC nor Clang (it is a sub-set of GCC's `__get_cpuid_max`) but I've included it because we can make it a no-op on `x86_64` which is what most folks are targeting nowadays, which is useful for our own run-time feature detection support and for cpuid crates like @shepmaster's cupid.

This PR does arguably a lot of stuff. We need the `EFLAGS` intrinsics to properly refactor `cpuid` into its own intrinsic. We need `xsave` run-time support for properly refactoring the `xgetbv` intrinsic. And `xsave` run-time support is tightly coupled with AVX run-time feature detection, which is different for AVX/AVX2 and AVX-512 and since we want to support AVX-512 soon anyways I did not want to have to go through the spec twice. I also wanted to test the `xgetbv` intrinsic and ended implementing all of the `xsave` intrinsics for this. Arguably I just needed to implement `xsetbv` but, again, I did not wanted to have to go through the spec twice.

The run-time feature detection for x86 grows significantly with AVX-512 support, so I backported one of the refactorings I have in the run-time feature detection module for ARM (which is even bigger). There I refactor it further into its own top-level module to be able to share some code between both.

---

This is blocked on:

- ~https://github.com/rust-lang/rust/pull/45761 (whitelisting XSAVE in rustc)~
- https://github.com/rust-lang/rust/pull/45528 (whitelisting AVX-512 in rustc)

Closes #171 .
Helps with the run-time part of #146 .