### PR TITLE
Implement missing std::ops

### DIFF
--- a/src/simd_llvm.rs
+++ b/src/simd_llvm.rs
@@ -25,6 +25,7 @@ extern "platform-intrinsic" {
     pub fn simd_sub<T>(x: T, y: T) -> T;
     pub fn simd_mul<T>(x: T, y: T) -> T;
     pub fn simd_div<T>(x: T, y: T) -> T;
+    pub fn simd_rem<T>(x: T, y: T) -> T;
     pub fn simd_shl<T>(x: T, y: T) -> T;
     pub fn simd_shr<T>(x: T, y: T) -> T;
     pub fn simd_and<T>(x: T, y: T) -> T;

--- a/src/v128.rs
+++ b/src/v128.rs
@@ -74,6 +74,7 @@ define_integer_ops!(
     (u8x16, u8),
     (i8x16, i8)
 );
+define_signed_integer_ops!(i64x2, i32x4, i16x8, i8x16);
 define_casts!(
     (f64x2, f32x2, as_f32x2),
     (f64x2, u64x2, as_u64x2),
@@ -94,3 +95,15 @@ define_casts!(
     (u8x16, i8x16, as_i8x16),
     (i8x16, u8x16, as_u8x16)
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operators() {
+        test_ops_si!(i8x16, i16x8, i32x4, i64x2);
+        test_ops_ui!(u8x16, u16x8, u32x4, u64x2);
+        test_ops_f!(f32x4, f64x2);
+    }
+}

--- a/src/v256.rs
+++ b/src/v256.rs
@@ -98,6 +98,7 @@ define_integer_ops!(
     (u8x32, u8),
     (i8x32, i8)
 );
+define_signed_integer_ops!(i64x4, i32x8, i16x16, i8x32);
 define_casts!(
     (f64x4, f32x4, as_f32x4),
     (f64x4, u64x4, as_u64x4),
@@ -117,3 +118,15 @@ define_casts!(
     (u8x32, i8x32, as_i8x32),
     (i8x32, u8x32, as_u8x32)
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operators() {
+        test_ops_si!(i8x32, i16x16, i32x8, i64x4);
+        test_ops_ui!(u8x32, u16x16, u32x8, u64x4);
+        test_ops_f!(f32x8, f64x4);
+    }
+}

--- a/src/v512.rs
+++ b/src/v512.rs
@@ -144,6 +144,7 @@ define_integer_ops!(
     (u8x64, u8),
     (i8x64, i8)
 );
+define_signed_integer_ops!(i64x8, i32x16, i16x32, i8x64);
 define_casts!(
     (f64x8, f32x8, as_f32x8),
     (f64x8, u64x8, as_u64x8),
@@ -163,3 +164,15 @@ define_casts!(
     (u8x64, i8x64, as_i8x64),
     (i8x64, u8x64, as_u8x64)
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operators() {
+        test_ops_si!(i8x64, i16x32, i32x16, i64x8);
+        test_ops_ui!(u8x64, u16x32, u32x16, u64x8);
+        test_ops_f!(f32x16, f64x8);
+    }
+}

--- a/src/v64.rs
+++ b/src/v64.rs
@@ -46,6 +46,7 @@ define_integer_ops!(
     (u8x8, u8),
     (i8x8, i8)
 );
+define_signed_integer_ops!(i32x2, i16x4, i8x8);
 define_casts!(
     (f32x2, f64x2, as_f64x2),
     (f32x2, u32x2, as_u32x2),
@@ -65,3 +66,15 @@ define_casts!(
     (u16x4, u32x4, as_u32x4),
     (u32x2, u64x2, as_u64x2)
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operators() {
+        test_ops_si!(i8x8, i16x4, i32x2);
+        test_ops_ui!(u8x8, u16x4, u32x2);
+        test_ops_f!(f32x2);
+    }
+}


### PR DESCRIPTION
Implements missing `std::ops` and adds test for all operators of all vector types.

Blocked on https://github.com/rust-lang/rust/pull/45804