### PR TITLE
[ci] disallow failures in fmt and clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
       script: |
         cargo install clippy
         cargo clippy --all -- -D clippy-pedantic
-  allow_failures:
-    - env: RUSTFMT=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
-    - env: CLIPPY=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
 install:
   - if [ "$NO_ADD" == "" ]; then rustup target add $TARGET; fi
 


### PR DESCRIPTION
Reviewers interpret the travis "green light" as "ok to merge" instead of "check if the allowed failures are green, and then merge". The proof is that basically every pull-request since rustfmt was enabled has broken the formatting. This pollutes unrelated pull-requests with formatting changes. 

The downside of this is that when clippy and rustfmt fail to build, the PRs will appear "red". Nothing more, nothing less.

In particular, I want to emphasize that _red pull-requests can still be merged_. Just check that everything is green, and that the reason, e.g., formatting is broken is because rustfmt-nigthly doesn't build and not because the submitter forgot to run it. 