### PR TITLE
syn API breaking change

### DIFF
--- a/stdsimd-test/assert-instr-macro/src/lib.rs
+++ b/stdsimd-test/assert-instr-macro/src/lib.rs
@@ -28,8 +28,8 @@ pub fn assert_instr(
         .expect("expected #[assert_instr(instr, a = b, ...)]");
     let item =
         syn::parse::<syn::Item>(item).expect("must be attached to an item");
-    let func = match item.node {
-        syn::ItemKind::Fn(ref f) => f,
+    let func = match item {
+        syn::Item::Fn(ref f) => f,
         _ => panic!("must be attached to a function"),
     };
 
@@ -70,7 +70,8 @@ pub fn assert_instr(
                 }
             };
         }
-        let attrs = item.attrs
+
+        let attrs = func.attrs
             .iter()
             .filter(|attr| {
                 attr.path


### PR DESCRIPTION
The syn API changed in the following commit breaking our builds: https://github.com/dtolnay/syn/commit/c6b55bcbe4627a9293b9354b3d76a7db8bf7d6dd 

This commit fixes it by using the new API.