### PR TITLE
add nvptx vendor intrinsics and initial no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ cupid = "0.3"
 
 [features]
 strict = []
+std = []

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -19,3 +19,6 @@ echo "RUSTFLAGS=${RUSTFLAGS}"
 
 cargo test --target $TARGET --features "strict"
 cargo test --release --target $TARGET --features "strict"
+
+cargo test --target $TARGET --features "strict,std"
+cargo test --release --target $TARGET --features "strict,std"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,10 @@
                   cast_possible_truncation, cast_precision_loss,
                   shadow_reuse, cyclomatic_complexity, similar_names,
                   doc_markdown, many_single_char_names))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate core as std;
 
 #[cfg(test)]
 extern crate stdsimd_test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,8 @@ pub mod vendor {
 
     #[cfg(target_arch = "aarch64")]
     pub use aarch64::*;
+
+    pub use nvptx::*;
 }
 
 #[macro_use]
@@ -194,3 +196,5 @@ mod x86;
 mod arm;
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
+
+mod nvptx;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -485,7 +485,7 @@ macro_rules! test_arithmetic_ {
 
 #[cfg(test)]
 #[macro_export]
-    macro_rules! test_neg_ {
+macro_rules! test_neg_ {
         ($tn:ident, $zero:expr, $one:expr, $two:expr, $four:expr) => {
             {
                 let z = $tn::splat($zero);
@@ -573,7 +573,7 @@ macro_rules! test_bit_arithmetic_ {
 
 #[cfg(test)]
 #[macro_export]
-    macro_rules! test_ops_si {
+macro_rules! test_ops_si {
         ($($tn:ident),+) => {
             $(
                 test_arithmetic_!($tn, 0, 1, 2, 4);
@@ -585,7 +585,7 @@ macro_rules! test_bit_arithmetic_ {
 
 #[cfg(test)]
 #[macro_export]
-    macro_rules! test_ops_ui {
+macro_rules! test_ops_ui {
         ($($tn:ident),+) => {
             $(
                 test_arithmetic_!($tn, 0, 1, 2, 4);
@@ -596,7 +596,7 @@ macro_rules! test_bit_arithmetic_ {
 
 #[cfg(test)]
 #[macro_export]
-    macro_rules! test_ops_f {
+macro_rules! test_ops_f {
         ($($tn:ident),+)  => {
             $(
                 test_arithmetic_!($tn, 0., 1., 2., 4.);

--- a/src/nvptx/mod.rs
+++ b/src/nvptx/mod.rs
@@ -1,0 +1,109 @@
+//! nvptx intrinsics
+
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.cuda.syncthreads"]
+    fn syncthreads() -> ();
+    #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.x"]
+    fn block_dim_x() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.y"]
+    fn block_dim_y() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.z"]
+    fn block_dim_z() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.ctaid.x"]
+    fn block_idx_x() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.ctaid.y"]
+    fn block_idx_y() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.ctaid.z"]
+    fn block_idx_z() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.nctaid.x"]
+    fn grid_dim_x() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.nctaid.y"]
+    fn grid_dim_y() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.nctaid.z"]
+    fn grid_dim_z() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.tid.x"]
+    fn thread_idx_x() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.tid.y"]
+    fn thread_idx_y() -> i32;
+    #[link_name = "llvm.nvvm.read.ptx.sreg.tid.z"]
+    fn thread_idx_z() -> i32;
+}
+
+/// Synchronizes all threads in the block.
+#[inline(always)]
+pub unsafe fn _syncthreads() -> () {
+    syncthreads()
+}
+
+/// x-th thread-block dimension.
+#[inline(always)]
+pub unsafe fn _block_dim_x() -> i32 {
+    block_dim_x()
+}
+
+/// y-th thread-block dimension.
+#[inline(always)]
+pub unsafe fn _block_dim_y() -> i32 {
+    block_dim_y()
+}
+
+/// z-th thread-block dimension.
+#[inline(always)]
+pub unsafe fn _block_dim_z() -> i32 {
+    block_dim_z()
+}
+
+/// x-th thread-block index.
+#[inline(always)]
+pub unsafe fn _block_idx_x() -> i32 {
+    block_idx_x()
+}
+
+/// y-th thread-block index.
+#[inline(always)]
+pub unsafe fn _block_idx_y() -> i32 {
+    block_idx_y()
+}
+
+/// z-th thread-block index.
+#[inline(always)]
+pub unsafe fn _block_idx_z() -> i32 {
+    block_idx_z()
+}
+
+/// x-th block-grid dimension.
+#[inline(always)]
+pub unsafe fn _grid_dim_x() -> i32 {
+    grid_dim_x()
+}
+
+/// y-th block-grid dimension.
+#[inline(always)]
+pub unsafe fn _grid_dim_y() -> i32 {
+    grid_dim_y()
+}
+
+/// z-th block-grid dimension.
+#[inline(always)]
+pub unsafe fn _grid_dim_z() -> i32 {
+    grid_dim_z()
+}
+
+/// x-th thread index.
+#[inline(always)]
+pub unsafe fn _thread_idx_x() -> i32 {
+    thread_idx_x()
+}
+
+/// y-th thread index.
+#[inline(always)]
+pub unsafe fn _thread_idx_y() -> i32 {
+    thread_idx_y()
+}
+
+/// z-th thread index.
+#[inline(always)]
+pub unsafe fn _thread_idx_z() -> i32 {
+    thread_idx_z()
+}

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -41,3 +41,14 @@ mod abm;
 mod bmi;
 mod bmi2;
 mod tbm;
+
+#[allow(non_camel_case_types)]
+#[cfg(not(feature = "std"))]
+#[repr(u8)]
+pub enum c_void {
+    #[doc(hidden)] __variant1,
+    #[doc(hidden)] __variant2,
+}
+
+#[cfg(feature = "std")]
+use std::os::raw::c_void;

--- a/src/x86/runtime.rs
+++ b/src/x86/runtime.rs
@@ -283,6 +283,7 @@ pub fn __unstable_detect_feature(x: __Feature) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
     #[test]
     fn runtime_detection_x86_nocapture() {
         println!("sse: {:?}", cfg_feature_enabled!("sse"));

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -3,7 +3,7 @@
 use simd_llvm::simd_shuffle4;
 use v128::*;
 use v64::f32x2;
-use std::os::raw::c_void;
+use super::c_void;
 use std::mem;
 use std::ptr;
 

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -4,7 +4,7 @@
 use stdsimd_test::assert_instr;
 
 use std::mem;
-use std::os::raw::c_void;
+use super::c_void;
 use std::ptr;
 
 use simd_llvm::{simd_cast, simd_shuffle16, simd_shuffle2, simd_shuffle4,
@@ -2242,7 +2242,7 @@ extern "C" {
 
 #[cfg(test)]
 mod tests {
-    use std::os::raw::c_void;
+    use super::c_void;
     use stdsimd_test::simd_test;
     use test::black_box; // Used to inhibit constant-folding.
 


### PR DESCRIPTION
`stdsimd` does currently not compile as is with `#![no_std]`. 

This PR adds the "nostd" crate feature that enforces `#![no_std]` and ci test to cover this.

The only dependency `stdsimd` has on `std` is `std::os::raw::c_void`, which I've worked around by c&p `c_void` into the `x86` module. 

Once we merge ARM run-time feature detection it will also get a dependency on `std::fs`.  The plan is then to split stdsimd into a core component, and a std component.

---

The `nvptx` intrinsics are always available independently of the architecture, but one can only call them from an `nvptx` kernel.

