### PR TITLE
refactor the x86 module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ stdsimd-test = { version = "0.*", path = "stdsimd-test" }
 cupid = "0.4.0"
 
 [features]
-strict = []
 std = []
+
+# Internal-only: denies all warnings.
+strict = []
+# Internal-only: enables only those intrinsics supported by Intel's
+# Software Development Environment (SDE).
 intel_sde = []

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -16,7 +16,7 @@ case ${TARGET} in
 esac
 
 FEATURES="strict,$FEATURES"
-FEATURES_STD="${FEATURES},std"
+FEATURES_STD="$std,${FEATURES}"
 
 echo "RUSTFLAGS=${RUSTFLAGS}"
 echo "FEATURES=${FEATURES}"

--- a/src/nvptx/mod.rs
+++ b/src/nvptx/mod.rs
@@ -1,4 +1,14 @@
-//! nvptx intrinsics
+//! NVPTX intrinsics (experimental)
+//!
+//! These intrinsics form the foundation of the CUDA
+//! programming model.
+//!
+//! The reference is the [CUDA C Programming Guide][cuda_c]. Relevant is also the [LLVM NVPTX Backend documentation][llvm_docs].
+//!
+//! [cuda_c]:
+//! http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html
+//! [llvm_docs]:
+//! https://llvm.org/docs/NVPTXUsage.html
 
 #[allow(improper_ctypes)]
 extern "C" {

--- a/src/x86/i386/eflags.rs
+++ b/src/x86/i386/eflags.rs
@@ -1,4 +1,4 @@
-//! `i386/ia32` intrinsics
+//! `i386` intrinsics
 
 /// Reads EFLAGS.
 #[cfg(target_arch = "x86")]
@@ -34,7 +34,7 @@ pub unsafe fn __writeeflags(eflags: u64) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use x86::i386::*;
 
     #[test]
     fn test_eflags() {

--- a/src/x86/i386/mod.rs
+++ b/src/x86/i386/mod.rs
@@ -1,0 +1,4 @@
+//! `i386` intrinsics
+
+mod eflags;
+pub use self::eflags::*;

--- a/src/x86/i586/abm.rs
+++ b/src/x86/i586/abm.rs
@@ -61,7 +61,7 @@ pub unsafe fn _popcnt64(x: u64) -> u64 {
 mod tests {
     use stdsimd_test::simd_test;
 
-    use x86::abm;
+    use x86::i586::abm;
 
     #[simd_test = "lzcnt"]
     unsafe fn _lzcnt_u32() {

--- a/src/x86/i586/avx.rs
+++ b/src/x86/i586/avx.rs
@@ -986,7 +986,7 @@ pub unsafe fn _mm256_permute_ps(a: f32x8, imm8: i32) -> f32x8 {
 #[target_feature = "+avx,+sse"]
 #[cfg_attr(test, assert_instr(vpermilps, imm8 = 9))]
 pub unsafe fn _mm_permute_ps(a: f32x4, imm8: i32) -> f32x4 {
-    use x86::sse::_mm_undefined_ps;
+    use x86::i586::sse::_mm_undefined_ps;
 
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
@@ -1100,7 +1100,7 @@ pub unsafe fn _mm256_permute_pd(a: f64x4, imm8: i32) -> f64x4 {
 #[target_feature = "+avx,+sse2"]
 #[cfg_attr(test, assert_instr(vpermilpd, imm8 = 0x1))]
 pub unsafe fn _mm_permute_pd(a: f64x2, imm8: i32) -> f64x2 {
-    use x86::sse2::_mm_undefined_pd;
+    use x86::i586::sse2::_mm_undefined_pd;
 
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle2 {
@@ -2159,7 +2159,7 @@ pub unsafe fn _mm256_castsi128_si256(a: __m128i) -> __m256i {
 #[inline(always)]
 #[target_feature = "+avx,+sse"]
 pub unsafe fn _mm256_zextps128_ps256(a: f32x4) -> f32x8 {
-    use x86::sse::_mm_setzero_ps;
+    use x86::i586::sse::_mm_setzero_ps;
     simd_shuffle8(a, _mm_setzero_ps(), [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
@@ -2169,7 +2169,7 @@ pub unsafe fn _mm256_zextps128_ps256(a: f32x4) -> f32x8 {
 #[inline(always)]
 #[target_feature = "+avx,+sse2"]
 pub unsafe fn _mm256_zextsi128_si256(a: __m128i) -> __m256i {
-    use x86::sse2::_mm_setzero_si128;
+    use x86::i586::sse2::_mm_setzero_si128;
     let b = mem::transmute(_mm_setzero_si128());
     let dst: i64x4 = simd_shuffle4(i64x2::from(a), b, [0, 1, 2, 3]);
     __m256i::from(dst)
@@ -2182,7 +2182,7 @@ pub unsafe fn _mm256_zextsi128_si256(a: __m128i) -> __m256i {
 #[inline(always)]
 #[target_feature = "+avx,+sse2"]
 pub unsafe fn _mm256_zextpd128_pd256(a: f64x2) -> f64x4 {
-    use x86::sse2::_mm_setzero_pd;
+    use x86::i586::sse2::_mm_setzero_pd;
     simd_shuffle4(a, _mm_setzero_pd(), [0, 1, 2, 3])
 }
 
@@ -2268,7 +2268,7 @@ pub unsafe fn _mm256_setr_m128i(lo: __m128i, hi: __m128i) -> __m256i {
 pub unsafe fn _mm256_loadu2_m128(
     hiaddr: *const f32, loaddr: *const f32
 ) -> f32x8 {
-    use x86::sse::_mm_loadu_ps;
+    use x86::i586::sse::_mm_loadu_ps;
     let a = _mm256_castps128_ps256(_mm_loadu_ps(loaddr));
     _mm256_insertf128_ps(a, _mm_loadu_ps(hiaddr), 1)
 }
@@ -2282,7 +2282,7 @@ pub unsafe fn _mm256_loadu2_m128(
 pub unsafe fn _mm256_loadu2_m128d(
     hiaddr: *const f64, loaddr: *const f64
 ) -> f64x4 {
-    use x86::sse2::_mm_loadu_pd;
+    use x86::i586::sse2::_mm_loadu_pd;
     let a = _mm256_castpd128_pd256(_mm_loadu_pd(loaddr));
     _mm256_insertf128_pd(a, _mm_loadu_pd(hiaddr), 1)
 }
@@ -2295,7 +2295,7 @@ pub unsafe fn _mm256_loadu2_m128d(
 pub unsafe fn _mm256_loadu2_m128i(
     hiaddr: *const __m128i, loaddr: *const __m128i
 ) -> __m256i {
-    use x86::sse2::_mm_loadu_si128;
+    use x86::i586::sse2::_mm_loadu_si128;
     let a = _mm256_castsi128_si256(_mm_loadu_si128(loaddr));
     _mm256_insertf128_si256(a, _mm_loadu_si128(hiaddr), 1)
 }
@@ -2309,7 +2309,7 @@ pub unsafe fn _mm256_loadu2_m128i(
 pub unsafe fn _mm256_storeu2_m128(
     hiaddr: *mut f32, loaddr: *mut f32, a: f32x8
 ) {
-    use x86::sse::_mm_storeu_ps;
+    use x86::i586::sse::_mm_storeu_ps;
     let lo = _mm256_castps256_ps128(a);
     _mm_storeu_ps(loaddr, lo);
     let hi = _mm256_extractf128_ps(a, 1);
@@ -2325,7 +2325,7 @@ pub unsafe fn _mm256_storeu2_m128(
 pub unsafe fn _mm256_storeu2_m128d(
     hiaddr: *mut f64, loaddr: *mut f64, a: f64x4
 ) {
-    use x86::sse2::_mm_storeu_pd;
+    use x86::i586::sse2::_mm_storeu_pd;
     let lo = _mm256_castpd256_pd128(a);
     _mm_storeu_pd(loaddr, lo);
     let hi = _mm256_extractf128_pd(a, 1);
@@ -2340,7 +2340,7 @@ pub unsafe fn _mm256_storeu2_m128d(
 pub unsafe fn _mm256_storeu2_m128i(
     hiaddr: *mut __m128i, loaddr: *mut __m128i, a: __m256i
 ) {
-    use x86::sse2::_mm_storeu_si128;
+    use x86::i586::sse2::_mm_storeu_si128;
     let lo = _mm256_castsi256_si128(a);
     _mm_storeu_si128(loaddr, lo);
     let hi = _mm256_extractf128_si256(a, 1);
@@ -2501,7 +2501,7 @@ mod tests {
 
     use v128::{f32x4, f64x2, i32x4, i64x2, i8x16};
     use v256::*;
-    use x86::avx;
+    use x86::i586::avx;
     use x86::{__m128i, __m256i};
 
     #[simd_test = "avx"]
@@ -4173,7 +4173,7 @@ mod tests {
 
     #[simd_test = "avx"]
     unsafe fn _mm256_storeu2_m128() {
-        use x86::sse::_mm_undefined_ps;
+        use x86::i586::sse::_mm_undefined_ps;
         let a = f32x8::new(1., 2., 3., 4., 5., 6., 7., 8.);
         let mut hi = _mm_undefined_ps();
         let mut lo = _mm_undefined_ps();
@@ -4188,7 +4188,7 @@ mod tests {
 
     #[simd_test = "avx"]
     unsafe fn _mm256_storeu2_m128d() {
-        use x86::sse2::_mm_undefined_pd;
+        use x86::i586::sse2::_mm_undefined_pd;
         let a = f64x4::new(1., 2., 3., 4.);
         let mut hi = _mm_undefined_pd();
         let mut lo = _mm_undefined_pd();
@@ -4203,7 +4203,7 @@ mod tests {
 
     #[simd_test = "avx"]
     unsafe fn _mm256_storeu2_m128i() {
-        use x86::sse2::_mm_undefined_si128;
+        use x86::i586::sse2::_mm_undefined_si128;
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = i8x32::new(
             1, 2, 3, 4, 5, 6, 7, 8,

--- a/src/x86/i586/avx2.rs
+++ b/src/x86/i586/avx2.rs
@@ -2217,7 +2217,7 @@ mod tests {
 
     use v256::*;
     use v128::*;
-    use x86::avx2;
+    use x86::i586::avx2;
     use x86::__m256i;
     use std;
 

--- a/src/x86/i586/bmi.rs
+++ b/src/x86/i586/bmi.rs
@@ -192,7 +192,7 @@ extern "C" {
 mod tests {
     use stdsimd_test::simd_test;
 
-    use x86::bmi;
+    use x86::i586::bmi;
 
     #[simd_test = "bmi"]
     unsafe fn _bextr_u32() {

--- a/src/x86/i586/bmi2.rs
+++ b/src/x86/i586/bmi2.rs
@@ -118,7 +118,7 @@ extern "C" {
 mod tests {
     use stdsimd_test::simd_test;
 
-    use x86::bmi2;
+    use x86::i586::bmi2;
 
     #[simd_test = "bmi2"]
     unsafe fn _pext_u32() {

--- a/src/x86/i586/cpuid.rs
+++ b/src/x86/i586/cpuid.rs
@@ -77,7 +77,7 @@ pub fn has_cpuid() -> bool {
     }
     #[cfg(target_arch = "x86")]
     {
-        use super::ia32::{__readeflags, __writeeflags};
+        use x86::i386::{__readeflags, __writeeflags};
 
         // On `x86` the `cpuid` instruction is not always available.
         // This follows the approach indicated in:
@@ -119,23 +119,23 @@ pub unsafe fn __get_cpuid_max(leaf: u32) -> (u32, u32) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use x86::i586::cpuid;
 
     #[test]
     fn test_always_has_cpuid() {
         // all currently-tested targets have the instruction
         // FIXME: add targets without `cpuid` to CI
-        assert!(has_cpuid());
+        assert!(cpuid::has_cpuid());
     }
 
     #[cfg(target_arch = "x86")]
     #[test]
     fn test_has_cpuid() {
-        use vendor::__readeflags;
+        use x86::i386::__readeflags;
         unsafe {
             let before = __readeflags();
 
-            if has_cpuid() {
+            if cpuid::has_cpuid() {
                 assert!(before != __readeflags());
             } else {
                 assert!(before == __readeflags());

--- a/src/x86/i586/mod.rs
+++ b/src/x86/i586/mod.rs
@@ -1,0 +1,39 @@
+//! `i586` intrinsics
+
+pub use self::cpuid::*;
+pub use self::xsave::*;
+
+pub use self::sse::*;
+pub use self::sse2::*;
+pub use self::sse3::*;
+pub use self::ssse3::*;
+pub use self::sse41::*;
+pub use self::sse42::*;
+pub use self::avx::*;
+pub use self::avx2::*;
+
+pub use self::abm::*;
+pub use self::bmi::*;
+pub use self::bmi2::*;
+
+#[cfg(not(feature = "intel_sde"))]
+pub use self::tbm::*;
+
+mod cpuid;
+mod xsave;
+
+mod sse;
+mod sse2;
+mod sse3;
+mod ssse3;
+mod sse41;
+mod sse42;
+mod avx;
+mod avx2;
+
+mod abm;
+mod bmi;
+mod bmi2;
+
+#[cfg(not(feature = "intel_sde"))]
+mod tbm;

--- a/src/x86/i586/sse.rs
+++ b/src/x86/i586/sse.rs
@@ -3,7 +3,7 @@
 use simd_llvm::simd_shuffle4;
 use v128::*;
 use v64::f32x2;
-use super::c_void;
+use x86::c_void;
 use std::mem;
 use std::ptr;
 
@@ -626,23 +626,6 @@ pub unsafe fn _mm_cvt_ss2si(a: f32x4) -> i32 {
     _mm_cvtss_si32(a)
 }
 
-/// Convert the lowest 32 bit float in the input vector to a 64 bit integer.
-///
-/// The result is rounded according to the current rounding mode. If the result
-/// cannot be represented as a 64 bit integer the result will be
-/// `0x8000_0000_0000_0000` (`std::i64::MIN`) or trigger an invalid operation
-/// floating point exception if unmasked (see
-/// [`_mm_setcsr`](fn._mm_setcsr.html)).
-///
-/// This corresponds to the `CVTSS2SI` instruction (with 64 bit output).
-#[inline(always)]
-#[target_feature = "+sse"]
-#[cfg_attr(test, assert_instr(cvtss2si))]
-#[cfg(target_arch = "x86_64")]
-pub unsafe fn _mm_cvtss_si64(a: f32x4) -> i64 {
-    cvtss2si64(a)
-}
-
 // Blocked by https://github.com/rust-lang-nursery/stdsimd/issues/74
 // pub unsafe fn _mm_cvtps_pi32(a: f32x4) -> i32x2
 // pub unsafe fn _mm_cvt_ps2pi(a: f32x4) -> i32x2 { _mm_cvtps_pi32(a) }
@@ -670,23 +653,6 @@ pub unsafe fn _mm_cvttss_si32(a: f32x4) -> i32 {
 #[cfg_attr(test, assert_instr(cvttss2si))]
 pub unsafe fn _mm_cvtt_ss2si(a: f32x4) -> i32 {
     _mm_cvttss_si32(a)
-}
-
-/// Convert the lowest 32 bit float in the input vector to a 64 bit integer
-/// with truncation.
-///
-/// The result is rounded always using truncation (round towards zero). If the
-/// result cannot be represented as a 64 bit integer the result will be
-/// `0x8000_0000_0000_0000` (`std::i64::MIN`) or an invalid operation floating
-/// point exception if unmasked (see [`_mm_setcsr`](fn._mm_setcsr.html)).
-///
-/// This corresponds to the `CVTTSS2SI` instruction (with 64 bit output).
-#[inline(always)]
-#[target_feature = "+sse"]
-#[cfg_attr(test, assert_instr(cvttss2si))]
-#[cfg(target_arch = "x86_64")]
-pub unsafe fn _mm_cvttss_si64(a: f32x4) -> i64 {
-    cvttss2si64(a)
 }
 
 // Blocked by https://github.com/rust-lang-nursery/stdsimd/issues/74
@@ -722,20 +688,6 @@ pub unsafe fn _mm_cvtsi32_ss(a: f32x4, b: i32) -> f32x4 {
 #[cfg_attr(all(test, not(target_os = "macos")), assert_instr(cvtsi2ss))]
 pub unsafe fn _mm_cvt_si2ss(a: f32x4, b: i32) -> f32x4 {
     _mm_cvtsi32_ss(a, b)
-}
-
-/// Convert a 64 bit integer to a 32 bit float. The result vector is the input
-/// vector `a` with the lowest 32 bit float replaced by the converted integer.
-///
-/// This intrinsic corresponds to the `CVTSI2SS` instruction (with 64 bit
-/// input).
-#[inline(always)]
-#[target_feature = "+sse"]
-#[cfg_attr(all(test, target_os = "macos"), assert_instr(cvtsi2ssq))]
-#[cfg_attr(all(test, not(target_os = "macos")), assert_instr(cvtsi2ss))]
-#[cfg(target_arch = "x86_64")]
-pub unsafe fn _mm_cvtsi64_ss(a: f32x4, b: i64) -> f32x4 {
-    a.replace(0, b as f32)
 }
 
 // Blocked by https://github.com/rust-lang-nursery/stdsimd/issues/74
@@ -1133,14 +1085,16 @@ pub unsafe fn _mm_loadr_ps(p: *const f32) -> f32x4 {
 #[cfg_attr(all(test, any(target_arch = "x86_64", target_feature = "sse2")),
            assert_instr(movhpd))]
 pub unsafe fn _mm_storeh_pi(p: *mut u64, a: f32x4) {
-    if cfg!(target_arch = "x86") {
+    #[cfg(target_arch = "x86")]
+    {
         // If this is a `f64x2` then on i586, LLVM generates fldl & fstpl which
         // is just silly
         let a64: u64x2 = mem::transmute(a);
         let a_hi = a64.extract(1);
         *p = a_hi;
-    } else {
-        // target_arch = "x86_64"
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
         // If this is a `u64x2` LLVM generates a pshufd + movq, but we really
         // want a a MOVHPD or MOVHPS here.
         let a64: f64x2 = mem::transmute(a);
@@ -1164,14 +1118,16 @@ pub unsafe fn _mm_storeh_pi(p: *mut u64, a: f32x4) {
                target_family = "windows"),
            assert_instr(movsd))]
 pub unsafe fn _mm_storel_pi(p: *mut u64, a: f32x4) {
-    if cfg!(target_arch = "x86") {
+    #[cfg(target_arch = "x86")]
+    {
         // Same as for _mm_storeh_pi: i586 code gen would use floating point
         // stack.
         let a64: u64x2 = mem::transmute(a);
         let a_hi = a64.extract(0);
         *p = a_hi;
-    } else {
-        // target_arch = "x86_64"
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
         let a64: f64x2 = mem::transmute(a);
         let a_hi = a64.extract(0);
         *p = mem::transmute(a_hi);
@@ -1718,14 +1674,8 @@ extern "C" {
     fn ucomineq_ss(a: f32x4, b: f32x4) -> i32;
     #[link_name = "llvm.x86.sse.cvtss2si"]
     fn cvtss2si(a: f32x4) -> i32;
-    #[link_name = "llvm.x86.sse.cvtss2si64"]
-    #[cfg(target_arch = "x86_64")]
-    fn cvtss2si64(a: f32x4) -> i64;
     #[link_name = "llvm.x86.sse.cvttss2si"]
     fn cvttss2si(a: f32x4) -> i32;
-    #[link_name = "llvm.x86.sse.cvttss2si64"]
-    #[cfg(target_arch = "x86_64")]
-    fn cvttss2si64(a: f32x4) -> i64;
     #[link_name = "llvm.x86.sse.sfence"]
     fn sfence();
     #[link_name = "llvm.x86.sse.stmxcsr"]
@@ -1741,7 +1691,7 @@ extern "C" {
 #[cfg(test)]
 mod tests {
     use v128::*;
-    use x86::sse;
+    use x86::i586::sse;
     use stdsimd_test::simd_test;
     use test::black_box; // Used to inhibit constant-folding.
 
@@ -2860,38 +2810,6 @@ mod tests {
     }
 
     #[simd_test = "sse"]
-    #[cfg(target_arch = "x86_64")]
-    unsafe fn _mm_cvtss_si64() {
-        use std::f32::NAN;
-        use std::i64::MIN;
-        let inputs = &[
-            (42.0f32, 42i64),
-            (-31.4, -31),
-            (-33.5, -34),
-            (-34.5, -34),
-            (4.0e10, 40_000_000_000),
-            (4.0e-10, 0),
-            (NAN, MIN),
-            (2147483500.1, 2147483520),
-            (9.223371e18, 9223370937343148032),
-        ];
-        for i in 0..inputs.len() {
-            let (xi, e) = inputs[i];
-            let x = f32x4::new(xi, 1.0, 3.0, 4.0);
-            let r = sse::_mm_cvtss_si64(x);
-            assert_eq!(
-                e,
-                r,
-                "TestCase #{} _mm_cvtss_si64({:?}) = {}, expected: {}",
-                i,
-                x,
-                r,
-                e
-            );
-        }
-    }
-
-    #[simd_test = "sse"]
     unsafe fn _mm_cvttss_si32() {
         use std::f32::NAN;
         use std::i32::MIN;
@@ -2924,41 +2842,6 @@ mod tests {
     }
 
     #[simd_test = "sse"]
-    #[cfg(target_arch = "x86_64")]
-    unsafe fn _mm_cvttss_si64() {
-        use std::f32::NAN;
-        use std::i64::MIN;
-        let inputs = &[
-            (42.0f32, 42i64),
-            (-31.4, -31),
-            (-33.5, -33),
-            (-34.5, -34),
-            (10.999, 10),
-            (-5.99, -5),
-            (4.0e10, 40_000_000_000),
-            (4.0e-10, 0),
-            (NAN, MIN),
-            (2147483500.1, 2147483520),
-            (9.223371e18, 9223370937343148032),
-            (9.223372e18, MIN),
-        ];
-        for i in 0..inputs.len() {
-            let (xi, e) = inputs[i];
-            let x = f32x4::new(xi, 1.0, 3.0, 4.0);
-            let r = sse::_mm_cvttss_si64(x);
-            assert_eq!(
-                e,
-                r,
-                "TestCase #{} _mm_cvttss_si64({:?}) = {}, expected: {}",
-                i,
-                x,
-                r,
-                e
-            );
-        }
-    }
-
-    #[simd_test = "sse"]
     pub unsafe fn _mm_cvtsi32_ss() {
         let inputs = &[
             (4555i32, 4555.0f32),
@@ -2976,36 +2859,6 @@ mod tests {
                 e,
                 r,
                 "TestCase #{} _mm_cvtsi32_ss({:?}, {}) = {:?}, expected: {:?}",
-                i,
-                a,
-                x,
-                r,
-                e
-            );
-        }
-    }
-
-    #[simd_test = "sse"]
-    #[cfg(target_arch = "x86_64")]
-    pub unsafe fn _mm_cvtsi64_ss() {
-        let inputs = &[
-            (4555i64, 4555.0f32),
-            (322223333, 322223330.0),
-            (-432, -432.0),
-            (-322223333, -322223330.0),
-            (9223372036854775807, 9.223372e18),
-            (-9223372036854775808, -9.223372e18),
-        ];
-
-        for i in 0..inputs.len() {
-            let (x, f) = inputs[i];
-            let a = f32x4::new(5.0, 6.0, 7.0, 8.0);
-            let r = sse::_mm_cvtsi64_ss(a, x);
-            let e = a.replace(0, f);
-            assert_eq!(
-                e,
-                r,
-                "TestCase #{} _mm_cvtsi64_ss({:?}, {}) = {:?}, expected: {:?}",
                 i,
                 a,
                 x,

--- a/src/x86/i586/sse2.rs
+++ b/src/x86/i586/sse2.rs
@@ -4,7 +4,7 @@
 use stdsimd_test::assert_instr;
 
 use std::mem;
-use super::c_void;
+use x86::c_void;
 use std::ptr;
 
 use simd_llvm::{simd_cast, simd_shuffle16, simd_shuffle2, simd_shuffle4,
@@ -677,26 +677,6 @@ pub unsafe fn _mm_cvtsi32_sd(a: f64x2, b: i32) -> f64x2 {
     a.replace(0, b as f64)
 }
 
-/// Return `a` with its lower element replaced by `b` after converting it to
-/// an `f64`.
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-#[cfg_attr(test, assert_instr(cvtsi2sd))]
-pub unsafe fn _mm_cvtsi64_sd(a: f64x2, b: i64) -> f64x2 {
-    a.replace(0, b as f64)
-}
-
-/// Return `a` with its lower element replaced by `b` after converting it to
-/// an `f64`.
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-#[cfg_attr(test, assert_instr(cvtsi2sd))]
-pub unsafe fn _mm_cvtsi64x_sd(a: f64x2, b: i64) -> f64x2 {
-    _mm_cvtsi64_sd(a, b)
-}
-
 /// Convert packed 32-bit integers in `a` to packed single-precision (32-bit)
 /// floating-point elements.
 #[inline(always)]
@@ -724,50 +704,12 @@ pub unsafe fn _mm_cvtsi32_si128(a: i32) -> i32x4 {
     i32x4::new(a, 0, 0, 0)
 }
 
-/// Return a vector whose lowest element is `a` and all higher elements are
-/// `0`.
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-// no particular instruction to test
-pub unsafe fn _mm_cvtsi64_si128(a: i64) -> i64x2 {
-    i64x2::new(a, 0)
-}
-
-/// Return a vector whose lowest element is `a` and all higher elements are
-/// `0`.
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-// no particular instruction to test
-pub unsafe fn _mm_cvtsi64x_si128(a: i64) -> i64x2 {
-    _mm_cvtsi64_si128(a)
-}
-
 /// Return the lowest element of `a`.
 #[inline(always)]
 #[target_feature = "+sse2"]
 // no particular instruction to test
 pub unsafe fn _mm_cvtsi128_si32(a: i32x4) -> i32 {
     a.extract(0)
-}
-
-/// Return the lowest element of `a`.
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-// no particular instruction to test
-pub unsafe fn _mm_cvtsi128_si64(a: i64x2) -> i64 {
-    a.extract(0)
-}
-
-/// Return the lowest element of `a`.
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-// no particular instruction to test
-pub unsafe fn _mm_cvtsi128_si64x(a: i64x2) -> i64 {
-    _mm_cvtsi128_si64(a)
 }
 
 /// Set packed 64-bit integers with the supplied values, from highest to
@@ -1777,25 +1719,6 @@ pub unsafe fn _mm_cvtsd_si32(a: f64x2) -> i32 {
     cvtsd2si(a)
 }
 
-/// Convert the lower double-precision (64-bit) floating-point element in a to
-/// a 64-bit integer.
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-#[cfg_attr(test, assert_instr(cvtsd2si))]
-pub unsafe fn _mm_cvtsd_si64(a: f64x2) -> i64 {
-    cvtsd2si64(a)
-}
-
-/// Alias for [`_mm_cvtsd_si64`](fn._mm_cvtsd_si64_ss.html).
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-#[cfg_attr(test, assert_instr(cvtsd2si))]
-pub unsafe fn _mm_cvtsd_si64x(a: f64x2) -> i64 {
-    _mm_cvtsd_si64(a)
-}
-
 /// Convert the lower double-precision (64-bit) floating-point element in `b`
 /// to a single-precision (32-bit) floating-point element, store the result in
 /// the lower element of the return value, and copy the upper element from `a`
@@ -1842,25 +1765,6 @@ pub unsafe fn _mm_cvttpd_epi32(a: f64x2) -> i32x4 {
 #[cfg_attr(test, assert_instr(cvttsd2si))]
 pub unsafe fn _mm_cvttsd_si32(a: f64x2) -> i32 {
     cvttsd2si(a)
-}
-
-/// Convert the lower double-precision (64-bit) floating-point element in `a`
-/// to a 64-bit integer with truncation.
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-#[cfg_attr(test, assert_instr(cvttsd2si))]
-pub unsafe fn _mm_cvttsd_si64(a: f64x2) -> i64 {
-    cvttsd2si64(a)
-}
-
-/// Alias for [`_mm_cvttsd_si64`](fn._mm_cvttsd_si64_ss.html).
-#[cfg(target_arch = "x86_64")]
-#[inline(always)]
-#[target_feature = "+sse2"]
-#[cfg_attr(test, assert_instr(cvttsd2si))]
-pub unsafe fn _mm_cvttsd_si64x(a: f64x2) -> i64 {
-    _mm_cvttsd_si64(a)
 }
 
 /// Convert packed single-precision (32-bit) floating-point elements in `a` to
@@ -2224,8 +2128,6 @@ extern "C" {
     fn cvtpd2dq(a: f64x2) -> i32x4;
     #[link_name = "llvm.x86.sse2.cvtsd2si"]
     fn cvtsd2si(a: f64x2) -> i32;
-    #[link_name = "llvm.x86.sse2.cvtsd2si64"]
-    fn cvtsd2si64(a: f64x2) -> i64;
     #[link_name = "llvm.x86.sse2.cvtsd2ss"]
     fn cvtsd2ss(a: f32x4, b: f64x2) -> f32x4;
     #[link_name = "llvm.x86.sse2.cvtss2sd"]
@@ -2234,8 +2136,6 @@ extern "C" {
     fn cvttpd2dq(a: f64x2) -> i32x4;
     #[link_name = "llvm.x86.sse2.cvttsd2si"]
     fn cvttsd2si(a: f64x2) -> i32;
-    #[link_name = "llvm.x86.sse2.cvttsd2si64"]
-    fn cvttsd2si64(a: f64x2) -> i64;
     #[link_name = "llvm.x86.sse2.cvttps2dq"]
     fn cvttps2dq(a: f32x4) -> i32x4;
 }
@@ -2247,7 +2147,8 @@ mod tests {
     use test::black_box; // Used to inhibit constant-folding.
 
     use v128::*;
-    use x86::{__m128i, sse2};
+    use x86::__m128i;
+    use x86::i586::sse2;
 
     #[simd_test = "sse2"]
     unsafe fn _mm_pause() {
@@ -2962,14 +2863,6 @@ mod tests {
         assert_eq!(r, f64x2::new(5.0, 3.5));
     }
 
-    #[cfg(target_arch = "x86_64")]
-    #[simd_test = "sse2"]
-    unsafe fn _mm_cvtsi64_sd() {
-        let a = f64x2::splat(3.5);
-        let r = sse2::_mm_cvtsi64_sd(a, 5);
-        assert_eq!(r, f64x2::new(5.0, 3.5));
-    }
-
     #[simd_test = "sse2"]
     unsafe fn _mm_cvtepi32_ps() {
         let a = i32x4::new(1, 2, 3, 4);
@@ -2990,23 +2883,9 @@ mod tests {
         assert_eq!(r, i32x4::new(5, 0, 0, 0));
     }
 
-    #[cfg(target_arch = "x86_64")]
-    #[simd_test = "sse2"]
-    unsafe fn _mm_cvtsi64_si128() {
-        let r = sse2::_mm_cvtsi64_si128(5);
-        assert_eq!(r, i64x2::new(5, 0));
-    }
-
     #[simd_test = "sse2"]
     unsafe fn _mm_cvtsi128_si32() {
         let r = sse2::_mm_cvtsi128_si32(i32x4::new(5, 0, 0, 0));
-        assert_eq!(r, 5);
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[simd_test = "sse2"]
-    unsafe fn _mm_cvtsi128_si64() {
-        let r = sse2::_mm_cvtsi128_si64(i64x2::new(5, 0));
         assert_eq!(r, 5);
     }
 
@@ -4019,27 +3898,6 @@ mod tests {
         assert_eq!(r, i32::MIN);
     }
 
-    #[cfg(target_arch = "x86_64")]
-    #[simd_test = "sse2"]
-    unsafe fn _mm_cvtsd_si64() {
-        use std::{f64, i64};
-
-        let r = sse2::_mm_cvtsd_si64(f64x2::new(-2.0, 5.0));
-        assert_eq!(r, -2_i64);
-
-        let r = sse2::_mm_cvtsd_si64(f64x2::new(f64::MAX, f64::MIN));
-        assert_eq!(r, i64::MIN);
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[simd_test = "sse2"]
-    unsafe fn _mm_cvtsd_si64x() {
-        use std::{f64, i64};
-
-        let r = sse2::_mm_cvtsd_si64x(f64x2::new(f64::NAN, f64::NAN));
-        assert_eq!(r, i64::MIN);
-    }
-
     #[simd_test = "sse2"]
     unsafe fn _mm_cvtsd_ss() {
         use std::{f32, f64};
@@ -4115,24 +3973,6 @@ mod tests {
         let a = f64x2::new(f64::NEG_INFINITY, f64::NAN);
         let r = sse2::_mm_cvttsd_si32(a);
         assert_eq!(r, i32::MIN);
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[simd_test = "sse2"]
-    unsafe fn _mm_cvttsd_si64() {
-        let a = f64x2::new(-1.1, 2.2);
-        let r = sse2::_mm_cvttsd_si64(a);
-        assert_eq!(r, -1_i64);
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[simd_test = "sse2"]
-    unsafe fn _mm_cvttsd_si64x() {
-        use std::{f64, i64};
-
-        let a = f64x2::new(f64::NEG_INFINITY, f64::NAN);
-        let r = sse2::_mm_cvttsd_si64x(a);
-        assert_eq!(r, i64::MIN);
     }
 
     #[simd_test = "sse2"]

--- a/src/x86/i586/sse3.rs
+++ b/src/x86/i586/sse3.rs
@@ -85,7 +85,7 @@ pub unsafe fn _mm_movedup_pd(a: f64x2) -> f64x2 {
 #[inline(always)]
 #[target_feature = "+sse3"]
 pub unsafe fn _mm_loaddup_pd(mem_addr: *const f64) -> f64x2 {
-    use x86::sse2::_mm_load1_pd;
+    use x86::i586::sse2::_mm_load1_pd;
     _mm_load1_pd(mem_addr)
 }
 
@@ -131,7 +131,7 @@ mod tests {
     use stdsimd_test::simd_test;
 
     use v128::*;
-    use x86::sse3;
+    use x86::i586::sse3;
 
     #[simd_test = "sse3"]
     unsafe fn _mm_addsub_ps() {

--- a/src/x86/i586/ssse3.rs
+++ b/src/x86/i586/ssse3.rs
@@ -286,7 +286,7 @@ mod tests {
     use stdsimd_test::simd_test;
 
     use v128::*;
-    use x86::ssse3;
+    use x86::i586::ssse3;
 
     #[simd_test = "ssse3"]
     unsafe fn _mm_abs_epi8() {

--- a/src/x86/i586/tbm.rs
+++ b/src/x86/i586/tbm.rs
@@ -263,7 +263,7 @@ pub unsafe fn _tzmsk_u64(x: u64) -> u64 {
 mod tests {
     use stdsimd_test::simd_test;
 
-    use x86::tbm;
+    use x86::i586::tbm;
 
     /*
     #[simd_test = "tbm"]

--- a/src/x86/i586/xsave.rs
+++ b/src/x86/i586/xsave.rs
@@ -226,6 +226,7 @@ pub unsafe fn _xsaves64(mem_addr: *mut c_void, save_mask: u64) -> () {
 pub unsafe fn _xrstors(mem_addr: *const c_void, rs_mask: u64) -> () {
     xrstors(mem_addr, (rs_mask >> 32) as i32, rs_mask as i32);
 }
+
 /// Perform a full or partial restore of the enabled processor states using the
 /// state information stored in memory at `mem_addr`.
 ///
@@ -243,10 +244,10 @@ pub unsafe fn _xrstors64(mem_addr: *const c_void, rs_mask: u64) -> () {
     xrstors64(mem_addr, (rs_mask >> 32) as i32, rs_mask as i32);
 }
 
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use x86::c_void;
+    use x86::i586::xsave;
     use stdsimd_test::simd_test;
     use std::fmt;
 
@@ -294,9 +295,9 @@ mod tests {
         let mut a = Buffer::new();
         let mut b = Buffer::new();
 
-        _xsave(a.ptr(), m);
-        _xrstor(a.ptr(), m);
-        _xsave(b.ptr(), m);
+        xsave::_xsave(a.ptr(), m);
+        xsave::_xrstor(a.ptr(), m);
+        xsave::_xsave(b.ptr(), m);
         assert_eq!(a, b);
     }
 
@@ -307,22 +308,22 @@ mod tests {
         let mut a = Buffer::new();
         let mut b = Buffer::new();
 
-        _xsave64(a.ptr(), m);
-        _xrstor64(a.ptr(), m);
-        _xsave64(b.ptr(), m);
+        xsave::_xsave64(a.ptr(), m);
+        xsave::_xrstor64(a.ptr(), m);
+        xsave::_xsave64(b.ptr(), m);
         assert_eq!(a, b);
     }
 
     #[simd_test = "xsave"]
     unsafe fn xgetbv_xsetbv() {
-        let xcr_n: u32 = _XCR_XFEATURE_ENABLED_MASK;
+        let xcr_n: u32 = xsave::_XCR_XFEATURE_ENABLED_MASK;
 
-        let xcr: u64 = _xgetbv(xcr_n);
+        let xcr: u64 = xsave::_xgetbv(xcr_n);
         // FIXME: XSETBV is a privileged instruction we should only test this
         // when running in privileged mode:
         //
         // _xsetbv(xcr_n, xcr);
-        let xcr_cpy: u64 = _xgetbv(xcr_n);
+        let xcr_cpy: u64 = xsave::_xgetbv(xcr_n);
         assert_eq!(xcr, xcr_cpy);
     }
 
@@ -332,9 +333,9 @@ mod tests {
         let mut a = Buffer::new();
         let mut b = Buffer::new();
 
-        _xsaveopt(a.ptr(), m);
-        _xrstor(a.ptr(), m);
-        _xsaveopt(b.ptr(), m);
+        xsave::_xsaveopt(a.ptr(), m);
+        xsave::_xrstor(a.ptr(), m);
+        xsave::_xsaveopt(b.ptr(), m);
         assert_eq!(a, b);
     }
 
@@ -345,9 +346,9 @@ mod tests {
         let mut a = Buffer::new();
         let mut b = Buffer::new();
 
-        _xsaveopt64(a.ptr(), m);
-        _xrstor64(a.ptr(), m);
-        _xsaveopt64(b.ptr(), m);
+        xsave::_xsaveopt64(a.ptr(), m);
+        xsave::_xrstor64(a.ptr(), m);
+        xsave::_xsaveopt64(b.ptr(), m);
         assert_eq!(a, b);
     }
 
@@ -358,9 +359,9 @@ mod tests {
         let mut a = Buffer::new();
         let mut b = Buffer::new();
 
-        _xsavec(a.ptr(), m);
-        _xrstor(a.ptr(), m);
-        _xsavec(b.ptr(), m);
+        xsave::_xsavec(a.ptr(), m);
+        xsave::_xrstor(a.ptr(), m);
+        xsave::_xsavec(b.ptr(), m);
         assert_eq!(a, b);
     }
 
@@ -371,9 +372,9 @@ mod tests {
         let mut a = Buffer::new();
         let mut b = Buffer::new();
 
-        _xsavec64(a.ptr(), m);
-        _xrstor64(a.ptr(), m);
-        _xsavec64(b.ptr(), m);
+        xsave::_xsavec64(a.ptr(), m);
+        xsave::_xrstor64(a.ptr(), m);
+        xsave::_xsavec64(b.ptr(), m);
         assert_eq!(a, b);
     }
 
@@ -384,9 +385,9 @@ mod tests {
         let mut a = Buffer::new();
         let mut b = Buffer::new();
 
-        _xsaves(a.ptr(), m);
-        _xrstors(a.ptr(), m);
-        _xsaves(b.ptr(), m);
+        xsave::_xsaves(a.ptr(), m);
+        xsave::_xrstors(a.ptr(), m);
+        xsave::_xsaves(b.ptr(), m);
         assert_eq!(a, b);
     }
 
@@ -397,9 +398,9 @@ mod tests {
         let mut a = Buffer::new();
         let mut b = Buffer::new();
 
-        _xsaves64(a.ptr(), m);
-        _xrstors64(a.ptr(), m);
-        _xsaves64(b.ptr(), m);
+        xsave::_xsaves64(a.ptr(), m);
+        xsave::_xrstors64(a.ptr(), m);
+        xsave::_xsaves64(b.ptr(), m);
         assert_eq!(a, b);
     }
 }

--- a/src/x86/i686/mod.rs
+++ b/src/x86/i686/mod.rs
@@ -1,0 +1,10 @@
+//! `i686` intrinsics
+
+mod sse2;
+pub use self::sse2::*;
+
+mod sse41;
+pub use self::sse41::*;
+
+mod sse42;
+pub use self::sse42::*;

--- a/src/x86/i686/sse2.rs
+++ b/src/x86/i686/sse2.rs
@@ -1,0 +1,85 @@
+//! `i686`'s Streaming SIMD Extensions 2 (SSE2)
+
+use v128::*;
+
+#[cfg(all(test, not(target_arch = "x86")))]
+use stdsimd_test::assert_instr;
+
+/// Return `a` with its lower element replaced by `b` after converting it to
+/// an `f64`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(all(test, not(target_arch = "x86")), assert_instr(cvtsi2sd))]
+pub unsafe fn _mm_cvtsi64_sd(a: f64x2, b: i64) -> f64x2 {
+    a.replace(0, b as f64)
+}
+
+/// Return `a` with its lower element replaced by `b` after converting it to
+/// an `f64`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(all(test, not(target_arch = "x86")), assert_instr(cvtsi2sd))]
+pub unsafe fn _mm_cvtsi64x_sd(a: f64x2, b: i64) -> f64x2 {
+    _mm_cvtsi64_sd(a, b)
+}
+
+/// Return a vector whose lowest element is `a` and all higher elements are
+/// `0`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+// no particular instruction to test
+pub unsafe fn _mm_cvtsi64_si128(a: i64) -> i64x2 {
+    i64x2::new(a, 0)
+}
+
+/// Return a vector whose lowest element is `a` and all higher elements are
+/// `0`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+// no particular instruction to test
+pub unsafe fn _mm_cvtsi64x_si128(a: i64) -> i64x2 {
+    _mm_cvtsi64_si128(a)
+}
+
+/// Return the lowest element of `a`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+// no particular instruction to test
+pub unsafe fn _mm_cvtsi128_si64(a: i64x2) -> i64 {
+    a.extract(0)
+}
+
+/// Return the lowest element of `a`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+// no particular instruction to test
+pub unsafe fn _mm_cvtsi128_si64x(a: i64x2) -> i64 {
+    _mm_cvtsi128_si64(a)
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+
+    use v128::*;
+    use x86::i686::sse2;
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsi64_sd() {
+        let a = f64x2::splat(3.5);
+        let r = sse2::_mm_cvtsi64_sd(a, 5);
+        assert_eq!(r, f64x2::new(5.0, 3.5));
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsi64_si128() {
+        let r = sse2::_mm_cvtsi64_si128(5);
+        assert_eq!(r, i64x2::new(5, 0));
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsi128_si64() {
+        let r = sse2::_mm_cvtsi128_si64(i64x2::new(5, 0));
+        assert_eq!(r, 5);
+    }
+}

--- a/src/x86/i686/sse41.rs
+++ b/src/x86/i686/sse41.rs
@@ -1,0 +1,285 @@
+//! `i686`'s Streaming SIMD Extensions 4.1 (SSE4.1)
+
+use v128::*;
+use x86::__m128i;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.x86.sse41.ptestz"]
+    fn ptestz(a: i64x2, mask: i64x2) -> i32;
+    #[link_name = "llvm.x86.sse41.ptestc"]
+    fn ptestc(a: i64x2, mask: i64x2) -> i32;
+    #[link_name = "llvm.x86.sse41.ptestnzc"]
+    fn ptestnzc(a: i64x2, mask: i64x2) -> i32;
+}
+
+/// Extract an 64-bit integer from `a` selected with `imm8`
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+// TODO: Add test for Windows
+#[cfg_attr(all(test, not(windows), target_arch = "x86_64"),
+           assert_instr(pextrq, imm8 = 1))]
+// On x86 this emits 2 pextrd instructions
+#[cfg_attr(all(test, not(windows), target_arch = "x86"),
+           assert_instr(pextrd, imm8 = 1))]
+pub unsafe fn _mm_extract_epi64(a: i64x2, imm8: u8) -> i64 {
+    a.extract((imm8 & 0b1) as u32)
+}
+
+/// Return a copy of `a` with the 64-bit integer from `i` inserted at a
+/// location specified by `imm8`.
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+#[cfg_attr(all(test, target_arch = "x86_64"), assert_instr(pinsrq, imm8 = 0))]
+// On x86 this emits 2 pinsrd instructions
+#[cfg_attr(all(test, target_arch = "x86"), assert_instr(pinsrd, imm8 = 0))]
+pub unsafe fn _mm_insert_epi64(a: i64x2, i: i64, imm8: u8) -> i64x2 {
+    a.replace((imm8 & 0b1) as u32, i)
+}
+
+/// Tests whether the specified bits in a 128-bit integer vector are all
+/// zeros.
+///
+/// Arguments:
+///
+/// * `a` - A 128-bit integer vector containing the bits to be tested.
+/// * `mask` - A 128-bit integer vector selecting which bits to test in
+///            operand `a`.
+///
+/// Returns:
+///
+/// * `1` - if the specified bits are all zeros,
+/// * `0` - otherwise.
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+#[cfg_attr(test, assert_instr(ptest))]
+pub unsafe fn _mm_testz_si128(a: __m128i, mask: __m128i) -> i32 {
+    ptestz(a.into(), mask.into())
+}
+
+/// Tests whether the specified bits in a 128-bit integer vector are all
+/// ones.
+///
+/// Arguments:
+///
+/// * `a` - A 128-bit integer vector containing the bits to be tested.
+/// * `mask` - A 128-bit integer vector selecting which bits to test in
+///            operand `a`.
+///
+/// Returns:
+///
+/// * `1` - if the specified bits are all ones,
+/// * `0` - otherwise.
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+#[cfg_attr(test, assert_instr(ptest))]
+pub unsafe fn _mm_testc_si128(a: __m128i, mask: __m128i) -> i32 {
+    ptestc(a.into(), mask.into())
+}
+
+/// Tests whether the specified bits in a 128-bit integer vector are
+/// neither all zeros nor all ones.
+///
+/// Arguments:
+///
+/// * `a` - A 128-bit integer vector containing the bits to be tested.
+/// * `mask` - A 128-bit integer vector selecting which bits to test in
+///            operand `a`.
+///
+/// Returns:
+///
+/// * `1` - if the specified bits are neither all zeros nor all ones,
+/// * `0` - otherwise.
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+#[cfg_attr(test, assert_instr(ptest))]
+pub unsafe fn _mm_testnzc_si128(a: __m128i, mask: __m128i) -> i32 {
+    ptestnzc(a.into(), mask.into())
+}
+
+/// Tests whether the specified bits in a 128-bit integer vector are all
+/// zeros.
+///
+/// Arguments:
+///
+/// * `a` - A 128-bit integer vector containing the bits to be tested.
+/// * `mask` - A 128-bit integer vector selecting which bits to test in
+///            operand `a`.
+///
+/// Returns:
+///
+/// * `1` - if the specified bits are all zeros,
+/// * `0` - otherwise.
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+#[cfg_attr(test, assert_instr(ptest))]
+pub unsafe fn _mm_test_all_zeros(a: __m128i, mask: __m128i) -> i32 {
+    _mm_testz_si128(a, mask)
+}
+
+/// Tests whether the specified bits in `a` 128-bit integer vector are all
+/// ones.
+///
+/// Argument:
+///
+/// * `a` - A 128-bit integer vector containing the bits to be tested.
+///
+/// Returns:
+///
+/// * `1` - if the bits specified in the operand are all set to 1,
+/// * `0` - otherwise.
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+#[cfg_attr(test, assert_instr(pcmpeqd))]
+#[cfg_attr(test, assert_instr(ptest))]
+pub unsafe fn _mm_test_all_ones(a: __m128i) -> i32 {
+    _mm_testc_si128(a, ::x86::_mm_cmpeq_epi32(a.into(), a.into()).into())
+}
+
+/// Tests whether the specified bits in a 128-bit integer vector are
+/// neither all zeros nor all ones.
+///
+/// Arguments:
+///
+/// * `a` - A 128-bit integer vector containing the bits to be tested.
+/// * `mask` - A 128-bit integer vector selecting which bits to test in
+///            operand `a`.
+///
+/// Returns:
+///
+/// * `1` - if the specified bits are neither all zeros nor all ones,
+/// * `0` - otherwise.
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+#[cfg_attr(test, assert_instr(ptest))]
+pub unsafe fn _mm_test_mix_ones_zeros(a: __m128i, mask: __m128i) -> i32 {
+    _mm_testnzc_si128(a, mask)
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+    use x86::i686::sse41;
+    use v128::*;
+    use x86::__m128i;
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_extract_epi64() {
+        let a = i64x2::new(0, 1);
+        let r = sse41::_mm_extract_epi64(a, 1);
+        assert_eq!(r, 1);
+        let r = sse41::_mm_extract_epi64(a, 3);
+        assert_eq!(r, 1);
+    }
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_insert_epi64() {
+        let a = i64x2::splat(0);
+        let e = i64x2::splat(0).replace(1, 32);
+        let r = sse41::_mm_insert_epi64(a, 32, 1);
+        assert_eq!(r, e);
+        let r = sse41::_mm_insert_epi64(a, 32, 3);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_testz_si128() {
+        let a = __m128i::splat(1);
+        let mask = __m128i::splat(0);
+        let r = sse41::_mm_testz_si128(a, mask);
+        assert_eq!(r, 1);
+        let a = __m128i::splat(0b101);
+        let mask = __m128i::splat(0b110);
+        let r = sse41::_mm_testz_si128(a, mask);
+        assert_eq!(r, 0);
+        let a = __m128i::splat(0b011);
+        let mask = __m128i::splat(0b100);
+        let r = sse41::_mm_testz_si128(a, mask);
+        assert_eq!(r, 1);
+    }
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_testc_si128() {
+        let a = __m128i::splat(-1);
+        let mask = __m128i::splat(0);
+        let r = sse41::_mm_testc_si128(a, mask);
+        assert_eq!(r, 1);
+        let a = __m128i::splat(0b101);
+        let mask = __m128i::splat(0b110);
+        let r = sse41::_mm_testc_si128(a, mask);
+        assert_eq!(r, 0);
+        let a = __m128i::splat(0b101);
+        let mask = __m128i::splat(0b100);
+        let r = sse41::_mm_testc_si128(a, mask);
+        assert_eq!(r, 1);
+    }
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_testnzc_si128() {
+        let a = __m128i::splat(0);
+        let mask = __m128i::splat(1);
+        let r = sse41::_mm_testnzc_si128(a, mask);
+        assert_eq!(r, 0);
+        let a = __m128i::splat(-1);
+        let mask = __m128i::splat(0);
+        let r = sse41::_mm_testnzc_si128(a, mask);
+        assert_eq!(r, 0);
+        let a = __m128i::splat(0b101);
+        let mask = __m128i::splat(0b110);
+        let r = sse41::_mm_testnzc_si128(a, mask);
+        assert_eq!(r, 1);
+        let a = __m128i::splat(0b101);
+        let mask = __m128i::splat(0b101);
+        let r = sse41::_mm_testnzc_si128(a, mask);
+        assert_eq!(r, 0);
+    }
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_test_all_zeros() {
+        let a = __m128i::splat(1);
+        let mask = __m128i::splat(0);
+        let r = sse41::_mm_test_all_zeros(a, mask);
+        assert_eq!(r, 1);
+        let a = __m128i::splat(0b101);
+        let mask = __m128i::splat(0b110);
+        let r = sse41::_mm_test_all_zeros(a, mask);
+        assert_eq!(r, 0);
+        let a = __m128i::splat(0b011);
+        let mask = __m128i::splat(0b100);
+        let r = sse41::_mm_test_all_zeros(a, mask);
+        assert_eq!(r, 1);
+    }
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_test_all_ones() {
+        let a = __m128i::splat(-1);
+        let r = sse41::_mm_test_all_ones(a);
+        assert_eq!(r, 1);
+        let a = __m128i::splat(0b101);
+        let r = sse41::_mm_test_all_ones(a);
+        assert_eq!(r, 0);
+    }
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_test_mix_ones_zeros() {
+        let a = __m128i::splat(0);
+        let mask = __m128i::splat(1);
+        let r = sse41::_mm_test_mix_ones_zeros(a, mask);
+        assert_eq!(r, 0);
+        let a = __m128i::splat(-1);
+        let mask = __m128i::splat(0);
+        let r = sse41::_mm_test_mix_ones_zeros(a, mask);
+        assert_eq!(r, 0);
+        let a = __m128i::splat(0b101);
+        let mask = __m128i::splat(0b110);
+        let r = sse41::_mm_test_mix_ones_zeros(a, mask);
+        assert_eq!(r, 1);
+        let a = __m128i::splat(0b101);
+        let mask = __m128i::splat(0b101);
+        let r = sse41::_mm_test_mix_ones_zeros(a, mask);
+        assert_eq!(r, 0);
+    }
+}

--- a/src/x86/i686/sse42.rs
+++ b/src/x86/i686/sse42.rs
@@ -1,0 +1,31 @@
+//! `i686`'s Streaming SIMD Extensions 4.2 (SSE4.2)
+
+use v128::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Compare packed 64-bit integers in `a` and `b` for greater-than,
+/// return the results.
+#[inline(always)]
+#[target_feature = "+sse4.2"]
+#[cfg_attr(test, assert_instr(pcmpgtq))]
+pub unsafe fn _mm_cmpgt_epi64(a: i64x2, b: i64x2) -> i64x2 {
+    a.gt(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use v128::*;
+    use x86::i686::sse42;
+
+    use stdsimd_test::simd_test;
+
+    #[simd_test = "sse4.2"]
+    unsafe fn _mm_cmpgt_epi64() {
+        let a = i64x2::splat(0x00).replace(1, 0x2a);
+        let b = i64x2::splat(0x00);
+        let i = sse42::_mm_cmpgt_epi64(a, b);
+        assert_eq!(i, i64x2::new(0x00, 0xffffffffffffffffu64 as i64));
+    }
+}

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -10,6 +10,10 @@ pub use self::i386::*;
 mod i586;
 pub use self::i586::*;
 
+// `i686` is `i586 + sse2`.
+//
+// This module is not available for `i586` targets,
+// but available for all `i686` targets by default
 #[cfg(any(all(target_arch = "x86", target_feature = "sse2"),
           target_arch = "x86_64"))]
 mod i686;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -1,24 +1,26 @@
 //! `x86` and `x86_64` intrinsics.
 
-pub use self::ia32::*;
-pub use self::cpuid::*;
-pub use self::xsave::*;
+#[macro_use]
+mod macros;
 
-pub use self::sse::*;
-pub use self::sse2::*;
-pub use self::sse3::*;
-pub use self::ssse3::*;
-pub use self::sse41::*;
-pub use self::sse42::*;
-pub use self::avx::*;
-pub use self::avx2::*;
+mod i386;
+pub use self::i386::*;
 
-pub use self::abm::*;
-pub use self::bmi::*;
-pub use self::bmi2::*;
+// x86 w/o sse2
+mod i586;
+pub use self::i586::*;
 
-#[cfg(not(feature = "intel_sde"))]
-pub use self::tbm::*;
+#[cfg(any(all(target_arch = "x86", target_feature = "sse2"),
+          target_arch = "x86_64"))]
+mod i686;
+#[cfg(any(all(target_arch = "x86", target_feature = "sse2"),
+          target_arch = "x86_64"))]
+pub use self::i686::*;
+
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
+#[cfg(target_arch = "x86_64")]
+pub use self::x86_64::*;
 
 /// 128-bit wide signed integer vector type
 #[allow(non_camel_case_types)]
@@ -27,28 +29,6 @@ pub type __m128i = ::v128::i8x16;
 #[allow(non_camel_case_types)]
 pub type __m256i = ::v256::i8x32;
 
-#[macro_use]
-mod macros;
-
-mod ia32;
-mod cpuid;
-mod xsave;
-
-mod sse;
-mod sse2;
-mod sse3;
-mod ssse3;
-mod sse41;
-mod sse42;
-mod avx;
-mod avx2;
-
-mod abm;
-mod bmi;
-mod bmi2;
-
-#[cfg(not(feature = "intel_sde"))]
-mod tbm;
 
 /// `C`'s `void` type.
 #[cfg(not(feature = "std"))]
@@ -59,5 +39,6 @@ pub enum c_void {
     #[doc(hidden)] __variant2,
 }
 
+// FIXME: we should not depend on std for this
 #[cfg(feature = "std")]
 use std::os::raw::c_void;

--- a/src/x86/x86_64/mod.rs
+++ b/src/x86/x86_64/mod.rs
@@ -1,0 +1,10 @@
+//! `x86_64` intrinsics
+
+mod sse;
+pub use self::sse::*;
+
+mod sse2;
+pub use self::sse2::*;
+
+mod sse42;
+pub use self::sse42::*;

--- a/src/x86/x86_64/sse.rs
+++ b/src/x86/x86_64/sse.rs
@@ -1,0 +1,161 @@
+//! `x86_64` Streaming SIMD Extensions (SSE)
+
+use v128::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.x86.sse.cvtss2si64"]
+    fn cvtss2si64(a: f32x4) -> i64;
+    #[link_name = "llvm.x86.sse.cvttss2si64"]
+    fn cvttss2si64(a: f32x4) -> i64;
+}
+
+/// Convert the lowest 32 bit float in the input vector to a 64 bit integer.
+///
+/// The result is rounded according to the current rounding mode. If the result
+/// cannot be represented as a 64 bit integer the result will be
+/// `0x8000_0000_0000_0000` (`std::i64::MIN`) or trigger an invalid operation
+/// floating point exception if unmasked (see
+/// [`_mm_setcsr`](fn._mm_setcsr.html)).
+///
+/// This corresponds to the `CVTSS2SI` instruction (with 64 bit output).
+#[inline(always)]
+#[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(cvtss2si))]
+pub unsafe fn _mm_cvtss_si64(a: f32x4) -> i64 {
+    cvtss2si64(a)
+}
+
+/// Convert the lowest 32 bit float in the input vector to a 64 bit integer
+/// with truncation.
+///
+/// The result is rounded always using truncation (round towards zero). If the
+/// result cannot be represented as a 64 bit integer the result will be
+/// `0x8000_0000_0000_0000` (`std::i64::MIN`) or an invalid operation floating
+/// point exception if unmasked (see [`_mm_setcsr`](fn._mm_setcsr.html)).
+///
+/// This corresponds to the `CVTTSS2SI` instruction (with 64 bit output).
+#[inline(always)]
+#[target_feature = "+sse"]
+#[cfg_attr(test, assert_instr(cvttss2si))]
+pub unsafe fn _mm_cvttss_si64(a: f32x4) -> i64 {
+    cvttss2si64(a)
+}
+
+/// Convert a 64 bit integer to a 32 bit float. The result vector is the input
+/// vector `a` with the lowest 32 bit float replaced by the converted integer.
+///
+/// This intrinsic corresponds to the `CVTSI2SS` instruction (with 64 bit
+/// input).
+#[inline(always)]
+#[target_feature = "+sse"]
+#[cfg_attr(all(test, target_os = "macos"), assert_instr(cvtsi2ssq))]
+#[cfg_attr(all(test, not(target_os = "macos")), assert_instr(cvtsi2ss))]
+pub unsafe fn _mm_cvtsi64_ss(a: f32x4, b: i64) -> f32x4 {
+    a.replace(0, b as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use v128::*;
+    use x86::x86_64::sse;
+
+    use stdsimd_test::simd_test;
+
+    #[simd_test = "sse"]
+    unsafe fn _mm_cvtss_si64() {
+        use std::f32::NAN;
+        use std::i64::MIN;
+        let inputs = &[
+            (42.0f32, 42i64),
+            (-31.4, -31),
+            (-33.5, -34),
+            (-34.5, -34),
+            (4.0e10, 40_000_000_000),
+            (4.0e-10, 0),
+            (NAN, MIN),
+            (2147483500.1, 2147483520),
+            (9.223371e18, 9223370937343148032),
+        ];
+        for i in 0..inputs.len() {
+            let (xi, e) = inputs[i];
+            let x = f32x4::new(xi, 1.0, 3.0, 4.0);
+            let r = sse::_mm_cvtss_si64(x);
+            assert_eq!(
+                e,
+                r,
+                "TestCase #{} _mm_cvtss_si64({:?}) = {}, expected: {}",
+                i,
+                x,
+                r,
+                e
+            );
+        }
+    }
+
+    #[simd_test = "sse"]
+    unsafe fn _mm_cvttss_si64() {
+        use std::f32::NAN;
+        use std::i64::MIN;
+        let inputs = &[
+            (42.0f32, 42i64),
+            (-31.4, -31),
+            (-33.5, -33),
+            (-34.5, -34),
+            (10.999, 10),
+            (-5.99, -5),
+            (4.0e10, 40_000_000_000),
+            (4.0e-10, 0),
+            (NAN, MIN),
+            (2147483500.1, 2147483520),
+            (9.223371e18, 9223370937343148032),
+            (9.223372e18, MIN),
+        ];
+        for i in 0..inputs.len() {
+            let (xi, e) = inputs[i];
+            let x = f32x4::new(xi, 1.0, 3.0, 4.0);
+            let r = sse::_mm_cvttss_si64(x);
+            assert_eq!(
+                e,
+                r,
+                "TestCase #{} _mm_cvttss_si64({:?}) = {}, expected: {}",
+                i,
+                x,
+                r,
+                e
+            );
+        }
+    }
+
+    #[simd_test = "sse"]
+    pub unsafe fn _mm_cvtsi64_ss() {
+        let inputs = &[
+            (4555i64, 4555.0f32),
+            (322223333, 322223330.0),
+            (-432, -432.0),
+            (-322223333, -322223330.0),
+            (9223372036854775807, 9.223372e18),
+            (-9223372036854775808, -9.223372e18),
+        ];
+
+        for i in 0..inputs.len() {
+            let (x, f) = inputs[i];
+            let a = f32x4::new(5.0, 6.0, 7.0, 8.0);
+            let r = sse::_mm_cvtsi64_ss(a, x);
+            let e = a.replace(0, f);
+            assert_eq!(
+                e,
+                r,
+                "TestCase #{} _mm_cvtsi64_ss({:?}, {}) = {:?}, expected: {:?}",
+                i,
+                a,
+                x,
+                r,
+                e
+            );
+        }
+    }
+}

--- a/src/x86/x86_64/sse2.rs
+++ b/src/x86/x86_64/sse2.rs
@@ -1,0 +1,91 @@
+//! `x86_64`'s Streaming SIMD Extensions 2 (SSE2)
+
+use v128::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.x86.sse2.cvtsd2si64"]
+    fn cvtsd2si64(a: f64x2) -> i64;
+    #[link_name = "llvm.x86.sse2.cvttsd2si64"]
+    fn cvttsd2si64(a: f64x2) -> i64;
+}
+
+/// Convert the lower double-precision (64-bit) floating-point element in a to
+/// a 64-bit integer.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(cvtsd2si))]
+pub unsafe fn _mm_cvtsd_si64(a: f64x2) -> i64 {
+    cvtsd2si64(a)
+}
+
+/// Alias for [`_mm_cvtsd_si64`](fn._mm_cvtsd_si64_ss.html).
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(cvtsd2si))]
+pub unsafe fn _mm_cvtsd_si64x(a: f64x2) -> i64 {
+    _mm_cvtsd_si64(a)
+}
+
+/// Convert the lower double-precision (64-bit) floating-point element in `a`
+/// to a 64-bit integer with truncation.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(cvttsd2si))]
+pub unsafe fn _mm_cvttsd_si64(a: f64x2) -> i64 {
+    cvttsd2si64(a)
+}
+
+/// Alias for [`_mm_cvttsd_si64`](fn._mm_cvttsd_si64_ss.html).
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(cvttsd2si))]
+pub unsafe fn _mm_cvttsd_si64x(a: f64x2) -> i64 {
+    _mm_cvttsd_si64(a)
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+
+    use v128::*;
+    use x86::x86_64::sse2;
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsd_si64() {
+        use std::{f64, i64};
+
+        let r = sse2::_mm_cvtsd_si64(f64x2::new(-2.0, 5.0));
+        assert_eq!(r, -2_i64);
+
+        let r = sse2::_mm_cvtsd_si64(f64x2::new(f64::MAX, f64::MIN));
+        assert_eq!(r, i64::MIN);
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsd_si64x() {
+        use std::{f64, i64};
+
+        let r = sse2::_mm_cvtsd_si64x(f64x2::new(f64::NAN, f64::NAN));
+        assert_eq!(r, i64::MIN);
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvttsd_si64() {
+        let a = f64x2::new(-1.1, 2.2);
+        let r = sse2::_mm_cvttsd_si64(a);
+        assert_eq!(r, -1_i64);
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvttsd_si64x() {
+        use std::{f64, i64};
+
+        let a = f64x2::new(f64::NEG_INFINITY, f64::NAN);
+        let r = sse2::_mm_cvttsd_si64x(a);
+        assert_eq!(r, i64::MIN);
+    }
+}

--- a/src/x86/x86_64/sse42.rs
+++ b/src/x86/x86_64/sse42.rs
@@ -1,0 +1,34 @@
+//! `x86_64`'s Streaming SIMD Extensions 4.2 (SSE4.2)
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.x86.sse42.crc32.64.64"]
+    fn crc32_64_64(crc: u64, v: u64) -> u64;
+}
+
+/// Starting with the initial value in `crc`, return the accumulated
+/// CRC32 value for unsigned 64-bit integer `v`.
+#[inline(always)]
+#[target_feature = "+sse4.2"]
+#[cfg_attr(test, assert_instr(crc32))]
+pub unsafe fn _mm_crc32_u64(crc: u64, v: u64) -> u64 {
+    crc32_64_64(crc, v)
+}
+
+#[cfg(test)]
+mod tests {
+    use x86::x86_64::sse42;
+
+    use stdsimd_test::simd_test;
+
+    #[simd_test = "sse4.2"]
+    unsafe fn _mm_crc32_u64() {
+        let crc = 0x7819dccd3e824;
+        let v = 0x2a22b845fed;
+        let i = sse42::_mm_crc32_u64(crc, v);
+        assert_eq!(i, 0xbb6cdc6c);
+    }
+}


### PR DESCRIPTION
This PR refactors the x86 module into `i386`, `i586`, `i686` and `x86_64`. Most of the intrinsics that were previously `x86_64` only can now be used on `i686` as well.