### PR TITLE
Unconditionally flag as `#![no_std]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,10 +128,11 @@
                   cast_possible_truncation, cast_precision_loss,
                   shadow_reuse, cyclomatic_complexity, similar_names,
                   doc_markdown, many_single_char_names))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
-extern crate core as std;
+#[cfg(any(feature = "std", test))]
+#[macro_use]
+extern crate std;
 
 #[cfg(test)]
 extern crate stdsimd_test;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -63,8 +63,8 @@ macro_rules! define_impl {
                 slice: &mut [$elemty],
                 offset: usize,
             ) {
-                use std::mem::size_of;
-                use std::ptr;
+                use core::mem::size_of;
+                use core::ptr;
 
                 ptr::copy_nonoverlapping(
                     &self as *const $name as *const u8,
@@ -83,8 +83,8 @@ macro_rules! define_impl {
                 slice: &[$elemty],
                 offset: usize,
             ) -> $name {
-                use std::mem::size_of;
-                use std::ptr;
+                use core::mem::size_of;
+                use core::ptr;
 
                 let mut x = $name::splat(0 as $elemty);
                 ptr::copy_nonoverlapping(
@@ -133,7 +133,7 @@ macro_rules! define_from {
             impl From<$from> for $to {
                 #[inline(always)]
                 fn from(f: $from) -> $to {
-                    unsafe { ::std::mem::transmute(f) }
+                    unsafe { ::core::mem::transmute(f) }
                 }
             }
         )+
@@ -143,7 +143,7 @@ macro_rules! define_from {
 macro_rules! define_common_ops {
     ($($ty:ident),+) => {
         $(
-            impl ::std::ops::Add for $ty {
+            impl ::core::ops::Add for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn add(self, other: Self) -> Self {
@@ -151,7 +151,7 @@ macro_rules! define_common_ops {
                 }
             }
 
-            impl ::std::ops::Sub for $ty {
+            impl ::core::ops::Sub for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn sub(self, other: Self) -> Self {
@@ -159,7 +159,7 @@ macro_rules! define_common_ops {
                 }
             }
 
-            impl ::std::ops::Mul for $ty {
+            impl ::core::ops::Mul for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn mul(self, other: Self) -> Self {
@@ -167,7 +167,7 @@ macro_rules! define_common_ops {
                 }
             }
 
-            impl ::std::ops::Div for $ty {
+            impl ::core::ops::Div for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn div(self, other: Self) -> Self {
@@ -175,7 +175,7 @@ macro_rules! define_common_ops {
                 }
             }
 
-            impl ::std::ops::Rem for $ty {
+            impl ::core::ops::Rem for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn rem(self, other: Self) -> Self {
@@ -183,35 +183,35 @@ macro_rules! define_common_ops {
                 }
             }
 
-            impl ::std::ops::AddAssign for $ty {
+            impl ::core::ops::AddAssign for $ty {
                 #[inline(always)]
                 fn add_assign(&mut self, other: Self) {
                     *self = *self + other;
                 }
             }
 
-            impl ::std::ops::SubAssign for $ty {
+            impl ::core::ops::SubAssign for $ty {
                 #[inline(always)]
                 fn sub_assign(&mut self, other: Self) {
                     *self = *self - other;
                 }
             }
 
-            impl ::std::ops::MulAssign for $ty {
+            impl ::core::ops::MulAssign for $ty {
                 #[inline(always)]
                 fn mul_assign(&mut self, other: Self) {
                     *self = *self * other;
                 }
             }
 
-            impl ::std::ops::DivAssign for $ty {
+            impl ::core::ops::DivAssign for $ty {
                 #[inline(always)]
                 fn div_assign(&mut self, other: Self) {
                     *self = *self / other;
                 }
             }
 
-            impl ::std::ops::RemAssign for $ty {
+            impl ::core::ops::RemAssign for $ty {
                 #[inline(always)]
                 fn rem_assign(&mut self, other: Self) {
                     *self = *self % other;
@@ -225,14 +225,14 @@ macro_rules! define_common_ops {
 macro_rules! define_shifts {
     ($ty:ident, $elem:ident, $($by:ident),+) => {
         $(
-            impl ::std::ops::Shl<$by> for $ty {
+            impl ::core::ops::Shl<$by> for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn shl(self, other: $by) -> Self {
                     unsafe { simd_shl(self, $ty::splat(other as $elem)) }
                 }
             }
-            impl ::std::ops::Shr<$by> for $ty {
+            impl ::core::ops::Shr<$by> for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn shr(self, other: $by) -> Self {
@@ -240,13 +240,13 @@ macro_rules! define_shifts {
                 }
             }
 
-            impl ::std::ops::ShlAssign<$by> for $ty {
+            impl ::core::ops::ShlAssign<$by> for $ty {
                 #[inline(always)]
                 fn shl_assign(&mut self, other: $by) {
                     *self = *self << other;
                 }
             }
-            impl ::std::ops::ShrAssign<$by> for $ty {
+            impl ::core::ops::ShrAssign<$by> for $ty {
                 #[inline(always)]
                 fn shr_assign(&mut self, other: $by) {
                     *self = *self >> other;
@@ -260,7 +260,7 @@ macro_rules! define_shifts {
 macro_rules! define_float_ops {
     ($($ty:ident),+) => {
         $(
-            impl ::std::ops::Neg for $ty {
+            impl ::core::ops::Neg for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn neg(self) -> Self {
@@ -274,7 +274,7 @@ macro_rules! define_float_ops {
 macro_rules! define_signed_integer_ops {
     ($($ty:ident),+) => {
         $(
-            impl ::std::ops::Neg for $ty {
+            impl ::core::ops::Neg for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn neg(self) -> Self {
@@ -288,7 +288,7 @@ macro_rules! define_signed_integer_ops {
 macro_rules! define_integer_ops {
     ($(($ty:ident, $elem:ident)),+) => {
         $(
-            impl ::std::ops::Not for $ty {
+            impl ::core::ops::Not for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn not(self) -> Self {
@@ -296,40 +296,40 @@ macro_rules! define_integer_ops {
                 }
             }
 
-            impl ::std::ops::BitAnd for $ty {
+            impl ::core::ops::BitAnd for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn bitand(self, other: Self) -> Self {
                     unsafe { simd_and(self, other) }
                 }
             }
-            impl ::std::ops::BitOr for $ty {
+            impl ::core::ops::BitOr for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn bitor(self, other: Self) -> Self {
                     unsafe { simd_or(self, other) }
                 }
             }
-            impl ::std::ops::BitXor for $ty {
+            impl ::core::ops::BitXor for $ty {
                 type Output = Self;
                 #[inline(always)]
                 fn bitxor(self, other: Self) -> Self {
                     unsafe { simd_xor(self, other) }
                 }
             }
-            impl ::std::ops::BitAndAssign for $ty {
+            impl ::core::ops::BitAndAssign for $ty {
                 #[inline(always)]
                 fn bitand_assign(&mut self, other: Self) {
                     *self = *self & other;
                 }
             }
-            impl ::std::ops::BitOrAssign for $ty {
+            impl ::core::ops::BitOrAssign for $ty {
                 #[inline(always)]
                 fn bitor_assign(&mut self, other: Self) {
                     *self = *self | other;
                 }
             }
-            impl ::std::ops::BitXorAssign for $ty {
+            impl ::core::ops::BitXorAssign for $ty {
                 #[inline(always)]
                 fn bitxor_assign(&mut self, other: Self) {
                     *self = *self ^ other;
@@ -341,12 +341,12 @@ macro_rules! define_integer_ops {
                 u8, u16, u32, u64, usize,
                 i8, i16, i32, i64, isize);
 
-            impl ::std::fmt::LowerHex for $ty {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter)
-                       -> ::std::fmt::Result {
+            impl ::core::fmt::LowerHex for $ty {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter)
+                       -> ::core::fmt::Result {
                     write!(f, "{}(", stringify!($ty))?;
-                    let n = ::std::mem::size_of_val(self)
-                        / ::std::mem::size_of::<$elem>();
+                    let n = ::core::mem::size_of_val(self)
+                        / ::core::mem::size_of::<$elem>();
                     for i in 0..n {
                         if i > 0 {
                             write!(f, ", ")?;

--- a/src/runtime/cache.rs
+++ b/src/runtime/cache.rs
@@ -1,12 +1,14 @@
 //! Cache of run-time feature detection
 
+use core::sync::atomic::{AtomicUsize, Ordering};
+use core::usize;
+
 use super::bit;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// This global variable is a bitset used to cache the features supported by
 /// the
 /// CPU.
-static CACHE: AtomicUsize = AtomicUsize::new(::std::usize::MAX);
+static CACHE: AtomicUsize = AtomicUsize::new(usize::MAX);
 
 /// Test the `bit` of the storage. If the storage has not been initialized,
 /// initializes it with the result of `f()`.
@@ -22,7 +24,7 @@ pub fn test<F>(bit: u32, f: F) -> bool
 where
     F: FnOnce() -> usize,
 {
-    if CACHE.load(Ordering::Relaxed) == ::std::usize::MAX {
+    if CACHE.load(Ordering::Relaxed) == usize::MAX {
         CACHE.store(f(), Ordering::Relaxed);
     }
     bit::test(CACHE.load(Ordering::Relaxed), bit)

--- a/src/runtime/linux/cpuinfo.rs
+++ b/src/runtime/linux/cpuinfo.rs
@@ -1,5 +1,7 @@
 //! Reads /proc/cpuinfo on Linux systems
 
+use std::prelude::v1::*;
+
 /// cpuinfo
 pub struct CpuInfo {
     raw: String,

--- a/src/runtime/x86.rs
+++ b/src/runtime/x86.rs
@@ -16,6 +16,8 @@
 //! in a global `AtomicUsize` variable. The query is performed by just checking
 //! whether the feature bit in this global variable is set or cleared.
 
+use core::mem;
+
 use super::bit;
 
 /// This macro maps the string-literal feature names to values of the
@@ -271,11 +273,11 @@ pub fn detect_features() -> usize {
             edx,
         } = __cpuid(0);
         let vendor_id: [[u8; 4]; 3] = [
-            ::std::mem::transmute(ebx),
-            ::std::mem::transmute(edx),
-            ::std::mem::transmute(ecx),
+            mem::transmute(ebx),
+            mem::transmute(edx),
+            mem::transmute(ecx),
         ];
-        let vendor_id: [u8; 12] = ::std::mem::transmute(vendor_id);
+        let vendor_id: [u8; 12] = mem::transmute(vendor_id);
         (max_leaf, vendor_id)
     };
 

--- a/src/x86/i586/avx.rs
+++ b/src/x86/i586/avx.rs
@@ -13,8 +13,8 @@
 //! [amd64_ref]: http://support.amd.com/TechDocs/24594.pdf
 //! [wiki]: https://en.wikipedia.org/wiki/Advanced_Vector_Extensions
 
-use std::mem;
-use std::ptr;
+use core::mem;
+use core::ptr;
 
 #[cfg(test)]
 use stdsimd_test::assert_instr;

--- a/src/x86/i586/cpuid.rs
+++ b/src/x86/i586/cpuid.rs
@@ -45,7 +45,7 @@ pub struct CpuidResult {
 #[inline(always)]
 #[cfg_attr(test, assert_instr(cpuid))]
 pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
-    let mut r = ::std::mem::uninitialized::<CpuidResult>();
+    let mut r = ::core::mem::uninitialized::<CpuidResult>();
     if cfg!(target_arch = "x86") {
         asm!("cpuid"
              : "={eax}"(r.eax), "={ebx}"(r.ebx), "={ecx}"(r.ecx), "={edx}"(r.edx)

--- a/src/x86/i586/sse.rs
+++ b/src/x86/i586/sse.rs
@@ -1,11 +1,12 @@
 //! Streaming SIMD Extensions (SSE)
 
+use core::mem;
+use core::ptr;
+
 use simd_llvm::simd_shuffle4;
 use v128::*;
 use v64::f32x2;
 use x86::c_void;
-use std::mem;
-use std::ptr;
 
 #[cfg(test)]
 use stdsimd_test::assert_instr;

--- a/src/x86/i586/sse2.rs
+++ b/src/x86/i586/sse2.rs
@@ -3,12 +3,12 @@
 #[cfg(test)]
 use stdsimd_test::assert_instr;
 
-use std::mem;
-use x86::c_void;
-use std::ptr;
+use core::mem;
+use core::ptr;
 
 use simd_llvm::{simd_cast, simd_shuffle16, simd_shuffle2, simd_shuffle4,
                 simd_shuffle8};
+use x86::c_void;
 use x86::__m128i;
 use v128::*;
 use v64::*;

--- a/src/x86/i586/sse41.rs
+++ b/src/x86/i586/sse41.rs
@@ -1,6 +1,6 @@
 //! Streaming SIMD Extensions 4.1 (SSE4.1)
 
-use std::mem;
+use core::mem;
 
 #[cfg(test)]
 use stdsimd_test::assert_instr;


### PR DESCRIPTION
This is more idiomatic for no-std-compatible crates where imports are
unconditionally rewritten to `core` and then only when necessary `std` is pulled
in explicitly.