### PR TITLE
Upgrade to cupid 0.0.5 and cleanup duplicated code in x86 run-time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ opt-level = 3
 
 [dev-dependencies]
 stdsimd-test = { version = "0.*", path = "stdsimd-test" }
-cupid = "0.4.0"
+cupid = "0.5.0"
 
 [features]
 std = []

--- a/src/nvptx/mod.rs
+++ b/src/nvptx/mod.rs
@@ -3,7 +3,8 @@
 //! These intrinsics form the foundation of the CUDA
 //! programming model.
 //!
-//! The reference is the [CUDA C Programming Guide][cuda_c]. Relevant is also the [LLVM NVPTX Backend documentation][llvm_docs].
+//! The reference is the [CUDA C Programming Guide][cuda_c]. Relevant is also
+//! the [LLVM NVPTX Backend documentation][llvm_docs].
 //!
 //! [cuda_c]:
 //! http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html

--- a/tests/cpu-detection.rs
+++ b/tests/cpu-detection.rs
@@ -20,24 +20,24 @@ fn works() {
     assert_eq!(cfg_feature_enabled!("sse4.2"), information.sse4_2());
     assert_eq!(cfg_feature_enabled!("avx"), information.avx());
     assert_eq!(cfg_feature_enabled!("avx2"), information.avx2());
-    // assert_eq!(cfg_feature_enabled!("avx512f"), information.avx512f());
-    // assert_eq!(cfg_feature_enabled!("avx512cd"), information.avx512cd());
-    // assert_eq!(cfg_feature_enabled!("avx512er"), information.avx512er());
-    // assert_eq!(cfg_feature_enabled!("avx512pf"), information.avx512pf());
-    // assert_eq!(cfg_feature_enabled!("avx512bw"), information.avx512bw());
-    // assert_eq!(cfg_feature_enabled!("avx512dq"), information.avx512dq());
-    // assert_eq!(cfg_feature_enabled!("avx512vl"), information.avx512vl());
-    // assert_eq!(cfg_feature_enabled!("avx512ifma"),
-    // information.avx512_ifma());
-    // assert_eq!(cfg_feature_enabled!("avx512vbmi"),
-    // information.avx512_vbmi());
-    // assert_eq!(cfg_feature_enabled!("avx512vpopcntdq"),
-    // information.avx512_vpopcntdq());
+    assert_eq!(cfg_feature_enabled!("avx512f"), information.avx512f());
+    assert_eq!(cfg_feature_enabled!("avx512cd"), information.avx512cd());
+    assert_eq!(cfg_feature_enabled!("avx512er"), information.avx512er());
+    assert_eq!(cfg_feature_enabled!("avx512pf"), information.avx512pf());
+    assert_eq!(cfg_feature_enabled!("avx512bw"), information.avx512bw());
+    assert_eq!(cfg_feature_enabled!("avx512dq"), information.avx512dq());
+    assert_eq!(cfg_feature_enabled!("avx512vl"), information.avx512vl());
+    assert_eq!(cfg_feature_enabled!("avx512ifma"),
+    information.avx512_ifma());
+    assert_eq!(cfg_feature_enabled!("avx512vbmi"),
+    information.avx512_vbmi());
+    assert_eq!(cfg_feature_enabled!("avx512vpopcntdq"),
+    information.avx512_vpopcntdq());
     assert_eq!(cfg_feature_enabled!("fma"), information.fma());
     assert_eq!(cfg_feature_enabled!("bmi"), information.bmi1());
     assert_eq!(cfg_feature_enabled!("bmi2"), information.bmi2());
     assert_eq!(cfg_feature_enabled!("popcnt"), information.popcnt());
-    // assert_eq!(cfg_feature_enabled!("sse4a"), information.sse4a());
+    assert_eq!(cfg_feature_enabled!("sse4a"), information.sse4a());
     assert_eq!(cfg_feature_enabled!("abm"), information.lzcnt());
     assert_eq!(cfg_feature_enabled!("tbm"), information.tbm());
     assert_eq!(cfg_feature_enabled!("lzcnt"), information.lzcnt());

--- a/tests/cpu-detection.rs
+++ b/tests/cpu-detection.rs
@@ -27,12 +27,12 @@ fn works() {
     assert_eq!(cfg_feature_enabled!("avx512bw"), information.avx512bw());
     assert_eq!(cfg_feature_enabled!("avx512dq"), information.avx512dq());
     assert_eq!(cfg_feature_enabled!("avx512vl"), information.avx512vl());
-    assert_eq!(cfg_feature_enabled!("avx512ifma"),
-    information.avx512_ifma());
-    assert_eq!(cfg_feature_enabled!("avx512vbmi"),
-    information.avx512_vbmi());
-    assert_eq!(cfg_feature_enabled!("avx512vpopcntdq"),
-    information.avx512_vpopcntdq());
+    assert_eq!(cfg_feature_enabled!("avx512ifma"), information.avx512_ifma());
+    assert_eq!(cfg_feature_enabled!("avx512vbmi"), information.avx512_vbmi());
+    assert_eq!(
+        cfg_feature_enabled!("avx512vpopcntdq"),
+        information.avx512_vpopcntdq()
+    );
     assert_eq!(cfg_feature_enabled!("fma"), information.fma());
     assert_eq!(cfg_feature_enabled!("bmi"), information.bmi1());
     assert_eq!(cfg_feature_enabled!("bmi2"), information.bmi2());


### PR DESCRIPTION
Closes #63 .