### PR TITLE
update docs

### DIFF
--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -22,7 +22,6 @@ dox() {
   rm -rf target/doc/$arch
   mkdir target/doc/$arch
 
-  cargo clean
   cargo build --target $target
 
   rustdoc --target $target -o target/doc/$arch src/lib.rs --crate-name stdsimd --library-path target/$target/debug/deps

--- a/coresimd/Cargo.toml
+++ b/coresimd/Cargo.toml
@@ -21,6 +21,7 @@ maintenance = { status = "experimental" }
 [dev-dependencies]
 cupid = "0.5.0"
 stdsimd-test = { version = "0.*", path = "../stdsimd-test" }
+stdsimd = { version = "0.0.3", path = ".." }
 
 [features]
 # Internal-usage only: denies all warnings.

--- a/coresimd/src/lib.rs
+++ b/coresimd/src/lib.rs
@@ -1,26 +1,4 @@
-//! SIMD support
-//!
-//! This crate provides the fundamentals of supporting SIMD in Rust. This crate
-//! should compile on all platforms and provide `simd` and `vendor` modules at
-//! the top-level. The `simd` module contains *portable vector types* which
-//! should work across all platforms and be implemented in the most efficient
-//! manner possible for the platform at hand. The `vendor` module contains
-//! vendor intrinsics that operate over these SIMD types, typically
-//! corresponding to a particular CPU instruction
-//!
-//! ```rust
-//! extern crate coresimd as stdsimd;
-//! use stdsimd::simd::u32x4;
-//!
-//! fn main() {
-//!     let a = u32x4::new(1, 2, 3, 4);
-//!     let b = u32x4::splat(10);
-//!     assert_eq!(a + b, u32x4::new(11, 12, 13, 14));
-//! }
-//! ```
-//!
-//! > **Note**: This crate is *nightly only* at the moment, and requires a
-//! > nightly rust toolchain to compile.
+//! SIMD and vendor intrinsics support library.
 //!
 //! This documentation is only for one particular architecture, you can find
 //! others at:
@@ -29,91 +7,6 @@
 //! * [`x86_64`](https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/)
 //! * [arm](https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/)
 //! * [aarch64](https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/)
-//!
-//! ## Portability
-//!
-//! The `simd` module and its types should be portable to all platforms. The
-//! runtime characteristics of these types may vary per platform and per CPU
-//! feature enabled, but they should always have the most optimized
-//! implementation for the target at hand.
-//!
-//! The `vendor` module provides no portability guarantees. The `vendor` module
-//! is per CPU architecture currently and provides intrinsics corresponding to
-//! functions for that particular CPU architecture. Note that the functions
-//! provided in this module are intended to correspond to CPU instructions and
-//! have no runtime support for whether you CPU actually supports the
-//! instruction.
-//!
-//! CPU target feature detection is done via the `cfg_feature_enabled!` macro
-//! at runtime. This macro will detect at runtime whether the specified feature
-//! is available or not, returning true or false depending on the current CPU.
-//!
-//! ```
-//! #![feature(cfg_target_feature)]
-//!
-//! #[macro_use]
-//! extern crate coresimd as stdsimd;
-//!
-//! fn main() {
-//!     if cfg_feature_enabled!("avx2") {
-//!         println!("avx2 intrinsics will work");
-//!     } else {
-//!         println!("avx2 intrinsics will not work");
-//!         // undefined behavior: may generate a `SIGILL`.
-//!     }
-//! }
-//! ```
-//!
-//! After verifying that a specified feature is available, use `target_feature`
-//! to enable a given feature and use the desired intrinsic.
-//!
-//! ```ignore
-//! # #![feature(cfg_target_feature)]
-//! # #![feature(target_feature)]
-//! # #[macro_use]
-//! # extern crate coresimd as stdsimd;
-//! # fn main() {
-//! #     if cfg_feature_enabled!("avx2") {
-//! // avx2 specific code may be used in this function
-//! #[target_feature = "+avx2"]
-//! fn and_256() {
-//!     // avx2 feature specific intrinsics will work here!
-//!     use stdsimd::vendor::{__m256i, _mm256_and_si256};
-//!
-//!     let a = __m256i::splat(5);
-//!     let b = __m256i::splat(3);
-//!
-//!     let got = unsafe { _mm256_and_si256(a, b) };
-//!
-//!     assert_eq!(got, __m256i::splat(1));
-//! }
-//! #         and_256();
-//! #     }
-//! # }
-//! ```
-//!
-//! # Status
-//!
-//! This crate is intended for eventual inclusion into the standard library,
-//! but some work and experimentation is needed to get there! First and
-//! foremost you can help out by kicking the tires on this crate and seeing if
-//! it works for your use case! Next up you can help us fill out the [vendor
-//! intrinsics][vendor] to ensure that we've got all the SIMD support
-//! necessary.
-//!
-//! The language support and status of SIMD is also still a little up in the
-//! air right now, you may be interested in a few issues along these lines:
-//!
-//! * [Overal tracking issue for SIMD support][simd_tracking_issue]
-//! * [`cfg_target_feature` tracking issue][cfg_target_feature_issue]
-//! * [SIMD types currently not sound][simd_soundness_bug]
-//! * [`#[target_feature]` improvements][target_feature_impr]
-//!
-//! [vendor]: https://github.com/rust-lang-nursery/stdsimd/issues/40
-//! [simd_tracking_issue]: https://github.com/rust-lang/rust/issues/27731
-//! [cfg_target_feature_issue]: https://github.com/rust-lang/rust/issues/29717
-//! [simd_soundness_bug]: https://github.com/rust-lang/rust/issues/44367
-//! [target_feature_impr]: https://github.com/rust-lang/rust/issues/44839
 
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![allow(dead_code)]

--- a/coresimd/src/x86/i586/avx2.rs
+++ b/coresimd/src/x86/i586/avx2.rs
@@ -1774,14 +1774,14 @@ pub unsafe fn _mm256_shuffle_epi8(a: u8x32, b: u8x32) -> u8x32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i32x8;
-/// use coresimd::vendor::_mm256_shuffle_epi32;
+/// use stdsimd::simd::i32x8;
+/// use stdsimd::vendor::_mm256_shuffle_epi32;
 ///
 /// let a = i32x8::new(0, 1, 2, 3, 4, 5, 6, 7);
 ///
@@ -2318,14 +2318,14 @@ pub unsafe fn _mm256_subs_epu8(a: u8x32, b: u8x32) -> u8x32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i8x32;
-/// use coresimd::vendor::_mm256_unpackhi_epi8;
+/// use stdsimd::simd::i8x32;
+/// use stdsimd::vendor::_mm256_unpackhi_epi8;
 ///
 /// let a = i8x32::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 /// 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -2367,14 +2367,14 @@ pub unsafe fn _mm256_unpackhi_epi8(a: i8x32, b: i8x32) -> i8x32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i8x32;
-/// use coresimd::vendor::_mm256_unpacklo_epi8;
+/// use stdsimd::simd::i8x32;
+/// use stdsimd::vendor::_mm256_unpacklo_epi8;
 ///
 /// let a = i8x32::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 /// 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -2415,14 +2415,14 @@ pub unsafe fn _mm256_unpacklo_epi8(a: i8x32, b: i8x32) -> i8x32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i16x16;
-/// use coresimd::vendor::_mm256_unpackhi_epi16;
+/// use stdsimd::simd::i16x16;
+/// use stdsimd::vendor::_mm256_unpackhi_epi16;
 ///
 /// let a = i16x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
 /// let b = i16x16::new(0,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15);
@@ -2459,14 +2459,14 @@ pub unsafe fn _mm256_unpackhi_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i16x16;
-/// use coresimd::vendor::_mm256_unpacklo_epi16;
+/// use stdsimd::simd::i16x16;
+/// use stdsimd::vendor::_mm256_unpacklo_epi16;
 ///
 /// let a = i16x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
 /// let b = i16x16::new(0,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15);
@@ -2503,14 +2503,14 @@ pub unsafe fn _mm256_unpacklo_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i32x8;
-/// use coresimd::vendor::_mm256_unpackhi_epi32;
+/// use stdsimd::simd::i32x8;
+/// use stdsimd::vendor::_mm256_unpackhi_epi32;
 ///
 /// let a = i32x8::new(0, 1, 2, 3, 4, 5, 6, 7);
 /// let b = i32x8::new(0,-1,-2,-3,-4,-5,-6,-7);
@@ -2542,14 +2542,14 @@ pub unsafe fn _mm256_unpackhi_epi32(a: i32x8, b: i32x8) -> i32x8 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i32x8;
-/// use coresimd::vendor::_mm256_unpacklo_epi32;
+/// use stdsimd::simd::i32x8;
+/// use stdsimd::vendor::_mm256_unpacklo_epi32;
 ///
 /// let a = i32x8::new(0, 1, 2, 3, 4, 5, 6, 7);
 /// let b = i32x8::new(0,-1,-2,-3,-4,-5,-6,-7);
@@ -2581,14 +2581,14 @@ pub unsafe fn _mm256_unpacklo_epi32(a: i32x8, b: i32x8) -> i32x8 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i64x4;
-/// use coresimd::vendor::_mm256_unpackhi_epi64;
+/// use stdsimd::simd::i64x4;
+/// use stdsimd::vendor::_mm256_unpackhi_epi64;
 ///
 /// let a = i64x4::new(0, 1, 2, 3);
 /// let b = i64x4::new(0,-1,-2,-3);
@@ -2620,14 +2620,14 @@ pub unsafe fn _mm256_unpackhi_epi64(a: i64x4, b: i64x4) -> i64x4 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use coresimd::simd::i64x4;
-/// use coresimd::vendor::_mm256_unpacklo_epi64;
+/// use stdsimd::simd::i64x4;
+/// use stdsimd::vendor::_mm256_unpacklo_epi64;
 ///
 /// let a = i64x4::new(0, 1, 2, 3);
 /// let b = i64x4::new(0,-1,-2,-3);

--- a/coresimd/src/x86/i586/avx2.rs
+++ b/coresimd/src/x86/i586/avx2.rs
@@ -1774,14 +1774,14 @@ pub unsafe fn _mm256_shuffle_epi8(a: u8x32, b: u8x32) -> u8x32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i32x8;
-/// use stdsimd::vendor::_mm256_shuffle_epi32;
+/// use coresimd::simd::i32x8;
+/// use coresimd::vendor::_mm256_shuffle_epi32;
 ///
 /// let a = i32x8::new(0, 1, 2, 3, 4, 5, 6, 7);
 ///
@@ -2318,14 +2318,14 @@ pub unsafe fn _mm256_subs_epu8(a: u8x32, b: u8x32) -> u8x32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i8x32;
-/// use stdsimd::vendor::_mm256_unpackhi_epi8;
+/// use coresimd::simd::i8x32;
+/// use coresimd::vendor::_mm256_unpackhi_epi8;
 ///
 /// let a = i8x32::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 /// 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -2367,14 +2367,14 @@ pub unsafe fn _mm256_unpackhi_epi8(a: i8x32, b: i8x32) -> i8x32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i8x32;
-/// use stdsimd::vendor::_mm256_unpacklo_epi8;
+/// use coresimd::simd::i8x32;
+/// use coresimd::vendor::_mm256_unpacklo_epi8;
 ///
 /// let a = i8x32::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 /// 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -2415,14 +2415,14 @@ pub unsafe fn _mm256_unpacklo_epi8(a: i8x32, b: i8x32) -> i8x32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i16x16;
-/// use stdsimd::vendor::_mm256_unpackhi_epi16;
+/// use coresimd::simd::i16x16;
+/// use coresimd::vendor::_mm256_unpackhi_epi16;
 ///
 /// let a = i16x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
 /// let b = i16x16::new(0,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15);
@@ -2459,14 +2459,14 @@ pub unsafe fn _mm256_unpackhi_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i16x16;
-/// use stdsimd::vendor::_mm256_unpacklo_epi16;
+/// use coresimd::simd::i16x16;
+/// use coresimd::vendor::_mm256_unpacklo_epi16;
 ///
 /// let a = i16x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
 /// let b = i16x16::new(0,-1,-2,-3,-4,-5,-6,-7,-8,-9,-10,-11,-12,-13,-14,-15);
@@ -2503,14 +2503,14 @@ pub unsafe fn _mm256_unpacklo_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i32x8;
-/// use stdsimd::vendor::_mm256_unpackhi_epi32;
+/// use coresimd::simd::i32x8;
+/// use coresimd::vendor::_mm256_unpackhi_epi32;
 ///
 /// let a = i32x8::new(0, 1, 2, 3, 4, 5, 6, 7);
 /// let b = i32x8::new(0,-1,-2,-3,-4,-5,-6,-7);
@@ -2542,14 +2542,14 @@ pub unsafe fn _mm256_unpackhi_epi32(a: i32x8, b: i32x8) -> i32x8 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i32x8;
-/// use stdsimd::vendor::_mm256_unpacklo_epi32;
+/// use coresimd::simd::i32x8;
+/// use coresimd::vendor::_mm256_unpacklo_epi32;
 ///
 /// let a = i32x8::new(0, 1, 2, 3, 4, 5, 6, 7);
 /// let b = i32x8::new(0,-1,-2,-3,-4,-5,-6,-7);
@@ -2581,14 +2581,14 @@ pub unsafe fn _mm256_unpacklo_epi32(a: i32x8, b: i32x8) -> i32x8 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i64x4;
-/// use stdsimd::vendor::_mm256_unpackhi_epi64;
+/// use coresimd::simd::i64x4;
+/// use coresimd::vendor::_mm256_unpackhi_epi64;
 ///
 /// let a = i64x4::new(0, 1, 2, 3);
 /// let b = i64x4::new(0,-1,-2,-3);
@@ -2620,14 +2620,14 @@ pub unsafe fn _mm256_unpackhi_epi64(a: i64x4, b: i64x4) -> i64x4 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("avx2") {
 /// #         #[target_feature = "+avx2"]
 /// #         fn worker() {
-/// use stdsimd::simd::i64x4;
-/// use stdsimd::vendor::_mm256_unpacklo_epi64;
+/// use coresimd::simd::i64x4;
+/// use coresimd::vendor::_mm256_unpacklo_epi64;
 ///
 /// let a = i64x4::new(0, 1, 2, 3);
 /// let b = i64x4::new(0,-1,-2,-3);

--- a/coresimd/src/x86/i586/sse.rs
+++ b/coresimd/src/x86/i586/sse.rs
@@ -884,7 +884,7 @@ pub unsafe fn _mm_movemask_ps(a: f32x4) -> i32 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # // The real main function
 /// # fn main() {
@@ -936,7 +936,7 @@ pub unsafe fn _mm_loadh_pi(a: f32x4, p: *const f32) -> f32x4 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # // The real main function
 /// # fn main() {

--- a/coresimd/src/x86/i586/sse42.rs
+++ b/coresimd/src/x86/i586/sse42.rs
@@ -96,15 +96,15 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> u8x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
 ///
-/// use stdsimd::simd::u8x16;
-/// use stdsimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_EQUAL_ORDERED};
+/// use coresimd::simd::u8x16;
+/// use coresimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_EQUAL_ORDERED};
 ///
 /// let haystack = b"This is a long string of text data\r\n\tthat extends
 /// multiple lines";
@@ -139,14 +139,14 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> u8x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
-/// use stdsimd::simd::u8x16;
-/// use stdsimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_EQUAL_ANY};
+/// use coresimd::simd::u8x16;
+/// use coresimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_EQUAL_ANY};
 ///
 /// // Ensure your input is 16 byte aligned
 /// let password = b"hunter2\0\0\0\0\0\0\0\0\0";
@@ -180,14 +180,14 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> u8x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
-/// use stdsimd::simd::u8x16;
-/// use stdsimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_RANGES};
+/// use coresimd::simd::u8x16;
+/// use coresimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_RANGES};
 /// # let b = __m128i::from(u8x16::load(b":;<=>?@[\\]^_`abc", 0));
 ///
 /// // Specify the ranges of values to be searched for [A-Za-z0-9].
@@ -219,15 +219,15 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> u8x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
-/// use stdsimd::simd::u16x8;
-/// use stdsimd::vendor::{__m128i, _mm_cmpistri};
-/// use stdsimd::vendor::{_SIDD_UWORD_OPS, _SIDD_CMP_EQUAL_EACH};
+/// use coresimd::simd::u16x8;
+/// use coresimd::vendor::{__m128i, _mm_cmpistri};
+/// use coresimd::vendor::{_SIDD_UWORD_OPS, _SIDD_CMP_EQUAL_EACH};
 ///
 /// # let mut some_utf16_words = [0u16; 8];
 /// # let mut more_utf16_words = [0u16; 8];
@@ -392,15 +392,15 @@ pub unsafe fn _mm_cmpestrm(
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd as stdsimd;
+/// # #[macro_use] extern crate coresimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
 ///
-/// use stdsimd::simd::u8x16;
-/// use stdsimd::vendor::{__m128i, _mm_cmpestri, _SIDD_CMP_EQUAL_ORDERED};
+/// use coresimd::simd::u8x16;
+/// use coresimd::vendor::{__m128i, _mm_cmpestri, _SIDD_CMP_EQUAL_ORDERED};
 ///
 /// // The string we want to find a substring in
 /// let haystack = b"Split \r\n\t line  ";

--- a/coresimd/src/x86/i586/sse42.rs
+++ b/coresimd/src/x86/i586/sse42.rs
@@ -96,15 +96,15 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> u8x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
 ///
-/// use coresimd::simd::u8x16;
-/// use coresimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_EQUAL_ORDERED};
+/// use stdsimd::simd::u8x16;
+/// use stdsimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_EQUAL_ORDERED};
 ///
 /// let haystack = b"This is a long string of text data\r\n\tthat extends
 /// multiple lines";
@@ -139,14 +139,14 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> u8x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
-/// use coresimd::simd::u8x16;
-/// use coresimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_EQUAL_ANY};
+/// use stdsimd::simd::u8x16;
+/// use stdsimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_EQUAL_ANY};
 ///
 /// // Ensure your input is 16 byte aligned
 /// let password = b"hunter2\0\0\0\0\0\0\0\0\0";
@@ -180,14 +180,14 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> u8x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
-/// use coresimd::simd::u8x16;
-/// use coresimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_RANGES};
+/// use stdsimd::simd::u8x16;
+/// use stdsimd::vendor::{__m128i, _mm_cmpistri, _SIDD_CMP_RANGES};
 /// # let b = __m128i::from(u8x16::load(b":;<=>?@[\\]^_`abc", 0));
 ///
 /// // Specify the ranges of values to be searched for [A-Za-z0-9].
@@ -219,15 +219,15 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> u8x16 {
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
-/// use coresimd::simd::u16x8;
-/// use coresimd::vendor::{__m128i, _mm_cmpistri};
-/// use coresimd::vendor::{_SIDD_UWORD_OPS, _SIDD_CMP_EQUAL_EACH};
+/// use stdsimd::simd::u16x8;
+/// use stdsimd::vendor::{__m128i, _mm_cmpistri};
+/// use stdsimd::vendor::{_SIDD_UWORD_OPS, _SIDD_CMP_EQUAL_EACH};
 ///
 /// # let mut some_utf16_words = [0u16; 8];
 /// # let mut more_utf16_words = [0u16; 8];
@@ -392,15 +392,15 @@ pub unsafe fn _mm_cmpestrm(
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
 /// #
-/// # #[macro_use] extern crate coresimd;
+/// # #[macro_use] extern crate stdsimd;
 /// #
 /// # fn main() {
 /// #     if cfg_feature_enabled!("sse4.2") {
 /// #         #[target_feature = "+sse4.2"]
 /// #         fn worker() {
 ///
-/// use coresimd::simd::u8x16;
-/// use coresimd::vendor::{__m128i, _mm_cmpestri, _SIDD_CMP_EQUAL_ORDERED};
+/// use stdsimd::simd::u8x16;
+/// use stdsimd::vendor::{__m128i, _mm_cmpestri, _SIDD_CMP_EQUAL_ORDERED};
 ///
 /// // The string we want to find a substring in
 /// let haystack = b"Split \r\n\t line  ";


### PR DESCRIPTION
The `cargo clean` command was removing the previously generated docs in `ci/dox.sh` so hopefully after this the links to the architecture specific docs should work again. 

I've also removed duplicated docs between `stdsimd` and `coresimd`, remove all uses of `stdsimd` in `coresimd` examples, and unified the examples to better show how to use the library.