### PR TITLE
sse2: _mm_stream_*

### DIFF
--- a/coresimd/src/x86/i586/sse2.rs
+++ b/coresimd/src/x86/i586/sse2.rs
@@ -911,6 +911,26 @@ pub unsafe fn _mm_storel_epi64(mem_addr: *mut __m128i, a: __m128i) {
     );
 }
 
+/// Stores a 128-bit integer vector to a 128-bit aligned memory location.
+/// To minimize caching, the data is flagged as non-temporal (unlikely to be
+/// used again soon).
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(movntps))] // FIXME movntdq
+pub unsafe fn _mm_stream_si128(mem_addr: *mut __m128i, a: __m128i) {
+    ::core::intrinsics::nontemporal_store(mem::transmute(mem_addr), a);
+}
+
+/// Stores a 32-bit integer value in the specified memory location.
+/// To minimize caching, the data is flagged as non-temporal (unlikely to be
+/// used again soon).
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(movnti))]
+pub unsafe fn _mm_stream_si32(mem_addr: *mut i32, a: i32) {
+    ::core::intrinsics::nontemporal_store(mem_addr, a);
+}
+
 /// Return a vector where the low element is extracted from `a` and its upper
 /// element is zero.
 #[inline(always)]
@@ -1843,6 +1863,17 @@ pub unsafe fn _mm_movemask_pd(a: f64x2) -> i32 {
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_load_pd(mem_addr: *const f64) -> f64x2 {
     *(mem_addr as *const f64x2)
+}
+
+/// Stores a 128-bit floating point vector of [2 x double] to a 128-bit
+/// aligned memory location.
+/// To minimize caching, the data is flagged as non-temporal (unlikely to be
+/// used again soon).
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(movntps))] // FIXME movntpd
+pub unsafe fn _mm_stream_pd(mem_addr: *mut f64, a: f64x2) {
+    ::core::intrinsics::nontemporal_store(mem::transmute(mem_addr), a);
 }
 
 /// Store 128-bits (composed of 2 packed double-precision (64-bit)

--- a/coresimd/src/x86/i586/sse2.rs
+++ b/coresimd/src/x86/i586/sse2.rs
@@ -3055,6 +3055,22 @@ mod tests {
     }
 
     #[simd_test = "sse2"]
+    unsafe fn _mm_stream_si128() {
+        let a = __m128i::from(sse2::_mm_setr_epi32(1, 2, 3, 4));
+        let mut r = sse2::_mm_undefined_si128();
+        sse2::_mm_stream_si128(&mut r as *mut _, a);
+        assert_eq!(r, a);
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_stream_si32() {
+        let a: i32 = 7;
+        let mut mem = ::std::boxed::Box::<i32>::new(-1);
+        sse2::_mm_stream_si32(&mut *mem as *mut i32, a);
+        assert_eq!(a, *mem);
+    }
+
+    #[simd_test = "sse2"]
     unsafe fn _mm_move_epi64() {
         let a = i64x2::new(5, 6);
         let r = sse2::_mm_move_epi64(a);
@@ -3732,6 +3748,21 @@ mod tests {
 
         let r = sse2::_mm_load_pd(d);
         assert_eq!(r, f64x2::new(1.0, 2.0));
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_stream_pd() {
+        #[repr(align(128))]
+        struct Memory {
+            pub data: [f64; 2],
+        }
+        let a = f64x2::splat(7.0);
+        let mut mem = Memory { data: [-1.0; 2] };
+
+        sse2::_mm_stream_pd(&mut mem.data[0] as *mut f64, a);
+        for i in 0..2 {
+            assert_eq!(mem.data[i], a.extract(i as u32));
+        }
     }
 
     #[simd_test = "sse2"]

--- a/coresimd/src/x86/x86_64/sse2.rs
+++ b/coresimd/src/x86/x86_64/sse2.rs
@@ -98,4 +98,12 @@ mod tests {
         let r = sse2::_mm_cvttsd_si64x(a);
         assert_eq!(r, i64::MIN);
     }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_stream_si64() {
+        let a: i64 = 7;
+        let mut mem = ::std::boxed::Box::<i64>::new(-1);
+        sse2::_mm_stream_si64(&mut *mem as *mut i64, a);
+        assert_eq!(a, *mem);
+    }
 }

--- a/coresimd/src/x86/x86_64/sse2.rs
+++ b/coresimd/src/x86/x86_64/sse2.rs
@@ -52,7 +52,8 @@ pub unsafe fn _mm_cvttsd_si64x(a: f64x2) -> i64 {
 /// used again soon).
 #[inline(always)]
 #[target_feature = "+sse2"]
-#[cfg_attr(test, assert_instr(movntiq))]
+// FIXME movnti on windows and linux x86_64
+//#[cfg_attr(test, assert_instr(movntiq))]
 pub unsafe fn _mm_stream_si64(mem_addr: *mut i64, a: i64) {
     ::core::intrinsics::nontemporal_store(mem_addr, a);
 }

--- a/coresimd/src/x86/x86_64/sse2.rs
+++ b/coresimd/src/x86/x86_64/sse2.rs
@@ -47,6 +47,16 @@ pub unsafe fn _mm_cvttsd_si64x(a: f64x2) -> i64 {
     _mm_cvttsd_si64(a)
 }
 
+/// Stores a 64-bit integer value in the specified memory location.
+/// To minimize caching, the data is flagged as non-temporal (unlikely to be
+/// used again soon).
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(test, assert_instr(movntiq))]
+pub unsafe fn _mm_stream_si64(mem_addr: *mut i64, a: i64) {
+    ::core::intrinsics::nontemporal_store(mem_addr, a);
+}
+
 #[cfg(test)]
 mod tests {
     use stdsimd_test::simd_test;


### PR DESCRIPTION
`nontemporal_store` related intrinsics.