### PR TITLE
add test for into

### DIFF
--- a/coresimd/src/lib.rs
+++ b/coresimd/src/lib.rs
@@ -14,7 +14,7 @@
 #![feature(const_fn, link_llvm_intrinsics, platform_intrinsics, repr_simd,
            simd_ffi, target_feature, cfg_target_feature, i128_type, asm,
            const_atomic_usize_new, stmt_expr_attributes, core_intrinsics)]
-#![cfg_attr(test, feature(proc_macro, test, repr_align, attr_literals))]
+#![cfg_attr(test, feature(proc_macro, test, repr_align, attr_literals, allow_fail))]
 #![cfg_attr(feature = "cargo-clippy",
             allow(inline_always, too_many_arguments, cast_sign_loss,
                   cast_lossless, cast_possible_wrap,


### PR DESCRIPTION
This test using `.into()` fails on ~~32 bits~~ `i586-unknown-linux-gnu` (it segfaults), but it should pass. 

Using `from` instead of `.into()` does not segfault. 

It might be related to #215, @alexcrichton ? Is `into` getting inlined a pure performance issue or is it required for correctness?