### PR TITLE
Fix rustfmt

### DIFF
--- a/coresimd/src/arm/neon.rs
+++ b/coresimd/src/arm/neon.rs
@@ -56,7 +56,6 @@ pub unsafe fn vaddq_s32(a: i32x4, b: i32x4) -> i32x4 {
     simd_add(a, b)
 }
 
-
 /// Vector add.
 #[inline(always)]
 #[target_feature = "+neon"]

--- a/coresimd/src/arm/v7.rs
+++ b/coresimd/src/arm/v7.rs
@@ -47,7 +47,6 @@ extern "C" {
     fn rbit_u32(i: i32) -> i32;
 }
 
-
 #[cfg(test)]
 mod tests {
     use arm::v7;

--- a/coresimd/src/macros.rs
+++ b/coresimd/src/macros.rs
@@ -539,7 +539,6 @@ macro_rules! test_bit_arithmetic_ {
     };
 }
 
-
 #[cfg(test)]
 #[macro_export]
 macro_rules! test_ops_si {

--- a/coresimd/src/runtime/x86.rs
+++ b/coresimd/src/runtime/x86.rs
@@ -206,7 +206,8 @@ pub enum __Feature {
     avx512_ifma,
     /// AVX-512 VBMI (Vector Byte Manipulation Instructions)
     avx512_vbmi,
-    /// AVX-512 VPOPCNTDQ (Vector Population Count Doubleword and Quadword)
+    /// AVX-512 VPOPCNTDQ (Vector Population Count Doubleword and
+    /// Quadword)
     avx512_vpopcntdq,
     /// FMA (Fused Multiply Add)
     fma,
@@ -301,7 +302,8 @@ pub fn detect_features() -> usize {
     // Contains information about bmi,bmi2, and avx2 support.
     let (extended_features_ebx, extended_features_ecx) = if max_basic_leaf >= 7
     {
-        let CpuidResult { ebx, ecx, .. } = unsafe { __cpuid(0x0000_0007_u32) };
+        let CpuidResult { ebx, ecx, .. } =
+            unsafe { __cpuid(0x0000_0007_u32) };
         (ebx, ecx)
     } else {
         (0, 0) // CPUID does not support "Extended Features"
@@ -318,7 +320,8 @@ pub fn detect_features() -> usize {
     // EAX = 0x8000_0001, ECX=0: Queries "Extended Processor Info and Feature
     // Bits"
     let extended_proc_info_ecx = if extended_max_basic_leaf >= 1 {
-        let CpuidResult { ecx, .. } = unsafe { __cpuid(0x8000_0001_u32) };
+        let CpuidResult { ecx, .. } =
+            unsafe { __cpuid(0x8000_0001_u32) };
         ecx
     } else {
         0
@@ -326,8 +329,10 @@ pub fn detect_features() -> usize {
 
     {
         // borrows value till the end of this scope:
-        let mut enable = |r, rb, f| if bit::test(r as usize, rb) {
-            value = bit::set(value, f as u32);
+        let mut enable = |r, rb, f| {
+            if bit::test(r as usize, rb) {
+                value = bit::set(value, f as u32);
+            }
         };
 
         enable(proc_info_ecx, 0, __Feature::sse3);

--- a/coresimd/src/v128.rs
+++ b/coresimd/src/v128.rs
@@ -47,15 +47,105 @@ define_ty_doc! {
     /// 128-bit wide signed integer vector type
 }
 
-define_from!(u64x2, i64x2, u32x4, i32x4, u16x8, i16x8, u8x16, i8x16, __m128i);
-define_from!(i64x2, u64x2, u32x4, i32x4, u16x8, i16x8, u8x16, i8x16, __m128i);
-define_from!(u32x4, u64x2, i64x2, i32x4, u16x8, i16x8, u8x16, i8x16, __m128i);
-define_from!(i32x4, u64x2, i64x2, u32x4, u16x8, i16x8, u8x16, i8x16, __m128i);
-define_from!(u16x8, u64x2, i64x2, u32x4, i32x4, i16x8, u8x16, i8x16, __m128i);
-define_from!(i16x8, u64x2, i64x2, u32x4, i32x4, u16x8, u8x16, i8x16, __m128i);
-define_from!(u8x16, u64x2, i64x2, u32x4, i32x4, u16x8, i16x8, i8x16, __m128i);
-define_from!(i8x16, u64x2, i64x2, u32x4, i32x4, u16x8, i16x8, u8x16, __m128i);
-define_from!(__m128i, i8x16, u64x2, i64x2, u32x4, i32x4, u16x8, i16x8, u8x16);
+define_from!(
+    u64x2,
+    i64x2,
+    u32x4,
+    i32x4,
+    u16x8,
+    i16x8,
+    u8x16,
+    i8x16,
+    __m128i
+);
+define_from!(
+    i64x2,
+    u64x2,
+    u32x4,
+    i32x4,
+    u16x8,
+    i16x8,
+    u8x16,
+    i8x16,
+    __m128i
+);
+define_from!(
+    u32x4,
+    u64x2,
+    i64x2,
+    i32x4,
+    u16x8,
+    i16x8,
+    u8x16,
+    i8x16,
+    __m128i
+);
+define_from!(
+    i32x4,
+    u64x2,
+    i64x2,
+    u32x4,
+    u16x8,
+    i16x8,
+    u8x16,
+    i8x16,
+    __m128i
+);
+define_from!(
+    u16x8,
+    u64x2,
+    i64x2,
+    u32x4,
+    i32x4,
+    i16x8,
+    u8x16,
+    i8x16,
+    __m128i
+);
+define_from!(
+    i16x8,
+    u64x2,
+    i64x2,
+    u32x4,
+    i32x4,
+    u16x8,
+    u8x16,
+    i8x16,
+    __m128i
+);
+define_from!(
+    u8x16,
+    u64x2,
+    i64x2,
+    u32x4,
+    i32x4,
+    u16x8,
+    i16x8,
+    i8x16,
+    __m128i
+);
+define_from!(
+    i8x16,
+    u64x2,
+    i64x2,
+    u32x4,
+    i32x4,
+    u16x8,
+    i16x8,
+    u8x16,
+    __m128i
+);
+define_from!(
+    __m128i,
+    i8x16,
+    u64x2,
+    i64x2,
+    u32x4,
+    i32x4,
+    u16x8,
+    i16x8,
+    u8x16
+);
 
 define_common_ops!(
     f64x2,

--- a/coresimd/src/x86/i586/avx.rs
+++ b/coresimd/src/x86/i586/avx.rs
@@ -315,7 +315,6 @@ pub unsafe fn _mm256_div_pd(a: f64x4, b: f64x4) -> f64x4 {
     a / b
 }
 
-
 /// Round packed double-precision (64-bit) floating point elements in `a`
 /// according to the flag `b`. The value of `b` may be as follows:
 ///
@@ -2983,7 +2982,6 @@ mod tests {
         assert_eq!(r, e);
     }
 
-
     #[simd_test = "avx"]
     unsafe fn _mm256_xor_pd() {
         let a = f64x4::new(4., 9., 16., 25.);
@@ -4210,9 +4208,24 @@ mod tests {
             25, 26, 27, 28,
             29, 30, 31, 32,
         ));
-        let lo = __m128i::from(
-            i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
-        );
+        let lo = __m128i::from(i8x16::new(
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+        ));
         let r = avx::_mm256_set_m128i(hi, lo);
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let e = __m256i::from(i8x32::new(
@@ -4244,9 +4257,24 @@ mod tests {
 
     #[simd_test = "avx"]
     unsafe fn _mm256_setr_m128i() {
-        let lo = __m128i::from(
-            i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
-        );
+        let lo = __m128i::from(i8x16::new(
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+        ));
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let hi = __m128i::from(i8x16::new(
             17, 18, 19, 20, 21, 22, 23, 24,

--- a/coresimd/src/x86/i586/avx.rs
+++ b/coresimd/src/x86/i586/avx.rs
@@ -4208,23 +4208,12 @@ mod tests {
             25, 26, 27, 28,
             29, 30, 31, 32,
         ));
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let lo = __m128i::from(i8x16::new(
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
+            1, 2, 3, 4,
+            5, 6, 7, 8,
+            9, 10, 11, 12,
+            13, 14, 15, 16,
         ));
         let r = avx::_mm256_set_m128i(hi, lo);
         #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -4257,23 +4246,12 @@ mod tests {
 
     #[simd_test = "avx"]
     unsafe fn _mm256_setr_m128i() {
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let lo = __m128i::from(i8x16::new(
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
+            1, 2, 3, 4,
+            5, 6, 7, 8,
+            9, 10, 11, 12,
+            13, 14, 15, 16,
         ));
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let hi = __m128i::from(i8x16::new(

--- a/coresimd/src/x86/i586/avx.rs
+++ b/coresimd/src/x86/i586/avx.rs
@@ -864,7 +864,8 @@ pub unsafe fn _mm256_extractf128_si256(a: __m256i, imm8: i32) -> __m128i {
 
 /// Extract an 8-bit integer from `a`, selected with `imm8`. Returns a 32-bit
 /// integer containing the zero-extended integer data.
-/// See: https://reviews.llvm.org/D20468
+///
+/// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
 #[inline(always)]
 #[target_feature = "+avx"]
 // This intrinsic has no corresponding instruction.
@@ -875,7 +876,8 @@ pub unsafe fn _mm256_extract_epi8(a: i8x32, imm8: i32) -> i32 {
 
 /// Extract a 16-bit integer from `a`, selected with `imm8`. Returns a 32-bit
 /// integer containing the zero-extended integer data.
-/// See: https://reviews.llvm.org/D20468
+///
+/// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
 #[inline(always)]
 #[target_feature = "+avx"]
 // This intrinsic has no corresponding instruction.

--- a/coresimd/src/x86/i586/avx2.rs
+++ b/coresimd/src/x86/i586/avx2.rs
@@ -242,7 +242,6 @@ pub unsafe fn _mm_blend_epi32(a: i32x4, b: i32x4, imm8: i32) -> i32x4 {
     }
 }
 
-
 /// Blend packed 32-bit integers from `a` and `b` using control mask `imm8`.
 #[inline(always)]
 #[target_feature = "+avx2"]
@@ -1438,7 +1437,6 @@ pub unsafe fn _mm256_min_epu8(a: u8x32, b: u8x32) -> u8x32 {
     pminub(a, b)
 }
 
-
 /// Create mask from the most significant bit of each 8-bit element in `a`,
 /// return the result.
 #[inline(always)]
@@ -1516,7 +1514,6 @@ pub unsafe fn _mm256_mulhi_epu16(a: u16x16, b: u16x16) -> u16x16 {
 pub unsafe fn _mm256_mullo_epi16(a: i16x16, b: i16x16) -> i16x16 {
     a * b
 }
-
 
 /// Multiply the packed 32-bit integers in `a` and `b`, producing
 /// intermediate 64-bit integers, and return the low 16 bits of the
@@ -2148,7 +2145,6 @@ pub unsafe fn _mm_srav_epi32(a: i32x4, count: i32x4) -> i32x4 {
 pub unsafe fn _mm256_srav_epi32(a: i32x8, count: i32x8) -> i32x8 {
     psravd256(a, count)
 }
-
 
 /// Shift packed 16-bit integers in `a` right by `count` while shifting in
 /// zeros.
@@ -3136,7 +3132,6 @@ mod tests {
         let r = avx2::_mm256_adds_epu8(a, b);
         assert_eq!(r, a);
     }
-
 
     #[simd_test = "avx2"]
     unsafe fn _mm256_adds_epu16() {
@@ -4199,7 +4194,6 @@ mod tests {
         assert_eq!(r, e);
     }
 
-
     #[simd_test = "avx2"]
     unsafe fn _mm256_srlv_epi64() {
         let a = i64x4::splat(2);
@@ -4540,7 +4534,6 @@ mod tests {
         );
     }
 
-
     #[simd_test = "avx2"]
     unsafe fn _mm_i32gather_epi64() {
         let mut arr = [0i64; 128];
@@ -4801,7 +4794,6 @@ mod tests {
         );
         assert_eq!(r, f32x4::new(0.0, 16.0, 64.0, 256.0));
     }
-
 
     #[simd_test = "avx2"]
     unsafe fn _mm_i64gather_epi64() {

--- a/coresimd/src/x86/i586/sse.rs
+++ b/coresimd/src/x86/i586/sse.rs
@@ -1514,7 +1514,6 @@ pub const _MM_HINT_T2: i8 = 1;
 /// See [`_mm_prefetch`](fn._mm_prefetch.html).
 pub const _MM_HINT_NTA: i8 = 0;
 
-
 /// Fetch the cache line that contains address `p` using the given `strategy`.
 ///
 /// The `strategy` must be one of:

--- a/coresimd/src/x86/i586/sse2.rs
+++ b/coresimd/src/x86/i586/sse2.rs
@@ -3921,9 +3921,12 @@ mod tests {
         let r = sse2::_mm_cvtps_pd(f32x4::new(-1.0, 2.0, -3.0, 5.0));
         assert_eq!(r, f64x2::new(-1.0, 2.0));
 
-        let r = sse2::_mm_cvtps_pd(
-            f32x4::new(f32::MAX, f32::INFINITY, f32::NEG_INFINITY, f32::MIN),
-        );
+        let r = sse2::_mm_cvtps_pd(f32x4::new(
+            f32::MAX,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::MIN,
+        ));
         assert_eq!(r, f64x2::new(f32::MAX as f64, f64::INFINITY));
     }
 
@@ -3940,9 +3943,10 @@ mod tests {
         let r = sse2::_mm_cvtpd_epi32(f64x2::new(f64::MAX, f64::MIN));
         assert_eq!(r, i32x4::new(i32::MIN, i32::MIN, 0, 0));
 
-        let r = sse2::_mm_cvtpd_epi32(
-            f64x2::new(f64::INFINITY, f64::NEG_INFINITY),
-        );
+        let r = sse2::_mm_cvtpd_epi32(f64x2::new(
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ));
         assert_eq!(r, i32x4::new(i32::MIN, i32::MIN, 0, 0));
 
         let r = sse2::_mm_cvtpd_epi32(f64x2::new(f64::NAN, f64::NAN));

--- a/coresimd/src/x86/i586/sse3.rs
+++ b/coresimd/src/x86/i586/sse3.rs
@@ -181,9 +181,24 @@ mod tests {
 
     #[simd_test = "sse3"]
     unsafe fn _mm_lddqu_si128() {
-        let a = __m128i::from(
-            i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
-        );
+        let a = __m128i::from(i8x16::new(
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+        ));
         let r = sse3::_mm_lddqu_si128(&a);
         assert_eq!(a, r);
     }

--- a/coresimd/src/x86/i586/sse3.rs
+++ b/coresimd/src/x86/i586/sse3.rs
@@ -181,23 +181,12 @@ mod tests {
 
     #[simd_test = "sse3"]
     unsafe fn _mm_lddqu_si128() {
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = __m128i::from(i8x16::new(
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
+            1, 2, 3, 4,
+            5, 6, 7, 8,
+            9, 10, 11, 12,
+            13, 14, 15, 16,
         ));
         let r = sse3::_mm_lddqu_si128(&a);
         assert_eq!(a, r);

--- a/coresimd/src/x86/i586/sse41.rs
+++ b/coresimd/src/x86/i586/sse41.rs
@@ -122,7 +122,8 @@ pub unsafe fn _mm_extract_ps(a: f32x4, imm8: u8) -> i32 {
 
 /// Extract an 8-bit integer from `a`, selected with `imm8`. Returns a 32-bit
 /// integer containing the zero-extended integer data.
-/// See: https://reviews.llvm.org/D20468
+///
+/// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(pextrb, imm8 = 0))]

--- a/coresimd/src/x86/i586/sse41.rs
+++ b/coresimd/src/x86/i586/sse41.rs
@@ -1157,7 +1157,6 @@ mod tests {
         assert_eq!(r, e);
     }
 
-
     #[simd_test = "sse4.1"]
     unsafe fn _mm_dp_pd() {
         let a = f64x2::new(2.0, 3.0);

--- a/examples/nbody.rs
+++ b/examples/nbody.rs
@@ -33,9 +33,12 @@ impl Frsqrt for f64x2 {
             let t = self.as_f32x2();
 
             let u = unsafe {
-                vendor::_mm_rsqrt_ps(
-                    f32x4::new(t.extract(0), t.extract(1), 0., 0.),
-                ).as_f64x4()
+                vendor::_mm_rsqrt_ps(f32x4::new(
+                    t.extract(0),
+                    t.extract(1),
+                    0.,
+                    0.,
+                )).as_f64x4()
             };
             Self::new(u.extract(0), u.extract(1))
         }

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -56,7 +56,6 @@ mod example {
         // let r = s::_mm_cmplt_sd(a, b);
         // let r = foobar(a, b);
 
-
         let needle = env::args().nth(1).unwrap();
         let haystack = env::args().nth(2).unwrap();
         println!("{:?}", index(&needle, &haystack));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,10 @@
 //! #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 //! #[target_feature = "+sse2"]
 //! unsafe fn sum_sse2(x: i32x4) -> i32 {
-//! let x = vendor::_mm_add_epi32(x, vendor::_mm_srli_si128(x.into(),
-//! 8).into()); let x = vendor::_mm_add_epi32(x,
-//! vendor::_mm_srli_si128(x.into(), 4).into()); vendor::
-//! _mm_cvtsi128_si32(x) }
+//!     let x = vendor::_mm_add_epi32(x, vendor::_mm_srli_si128(x.into(), 8).into());
+//!     let x = vendor::_mm_add_epi32(x, vendor::_mm_srli_si128(x.into(), 4).into());
+//!     vendor::_mm_cvtsi128_si32(x)
+//! }
 //!
 //! // Uses the SSE2 version if SSE2 is enabled for all target
 //! // CPUs at compile-time (does not perform any run-time

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,8 +139,7 @@ pub mod vendor {
     pub use coresimd::vendor::*;
 
     #[cfg(all(target_os = "linux",
-              any(target_arch = "arm",
-                  target_arch = "aarch64",
+              any(target_arch = "arm", target_arch = "aarch64",
                   target_arch = "powerpc64")))]
     pub use super::runtime::{__unstable_detect_feature, __Feature};
 }
@@ -151,8 +150,7 @@ pub mod simd {
 }
 
 #[cfg(all(target_os = "linux",
-          any(target_arch = "arm",
-              target_arch = "aarch64",
+          any(target_arch = "arm", target_arch = "aarch64",
               target_arch = "powerpc64")))]
 #[macro_use]
 mod runtime;

--- a/src/runtime/linux/auxvec.rs
+++ b/src/runtime/linux/auxvec.rs
@@ -52,7 +52,10 @@ impl AuxVec {
 
         mem::forget(raw);
 
-        let mut auxv = AuxVec { hwcap: None, hwcap2: None };
+        let mut auxv = AuxVec {
+            hwcap: None,
+            hwcap2: None,
+        };
 
         for el in buf.chunks(2) {
             if el[0] == AT::HWCAP as usize {

--- a/src/runtime/linux/cpuinfo.rs
+++ b/src/runtime/linux/cpuinfo.rs
@@ -99,7 +99,6 @@ mod tests {
         println!("{}", cpuinfo.raw());
     }
 
-
     const CORE_DUO_T6500: &str = r"processor       : 0
 vendor_id       : GenuineIntel
 cpu family      : 6

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -24,11 +24,13 @@ mod powerpc64;
 pub use self::powerpc64::__Feature;
 
 #[cfg(all(target_os = "linux",
-          any(target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64")))]
+          any(target_arch = "arm", target_arch = "aarch64",
+              target_arch = "powerpc64")))]
 mod linux;
 
 #[cfg(all(target_os = "linux",
-          any(target_arch = "arm", target_arch = "aarch64", target_arch = "powerpc64")))]
+          any(target_arch = "arm", target_arch = "aarch64",
+              target_arch = "powerpc64")))]
 pub use self::linux::detect_features;
 
 /// Performs run-time feature detection.

--- a/src/runtime/powerpc64.rs
+++ b/src/runtime/powerpc64.rs
@@ -59,7 +59,7 @@ impl linux::FeatureQuery for linux::AuxVec {
             altivec => self.lookup(linux::AT::HWCAP)
                 .map(|caps| caps & 0x10000000 != 0)
                 .unwrap_or(false),
-            vsx  => self.lookup(linux::AT::HWCAP)
+            vsx => self.lookup(linux::AT::HWCAP)
                 .map(|caps| caps & 0x00000080 != 0)
                 .unwrap_or(false),
             power8 => self.lookup(linux::AT::HWCAP2)
@@ -78,7 +78,7 @@ impl linux::FeatureQuery for linux::CpuInfo {
         use self::__Feature::*;
         match *x {
             altivec => self.field("cpu").has("altivec"),
-            _ => false
+            _ => false,
         }
     }
 }

--- a/stdsimd-test/src/lib.rs
+++ b/stdsimd-test/src/lib.rs
@@ -223,9 +223,9 @@ fn parse_dumpbin(output: &str) -> HashMap<String, Vec<Function>> {
             let parts = instruction
                 .split_whitespace()
                 .skip(1)
-                .skip_while(
-                    |s| s.len() == 2 && usize::from_str_radix(s, 16).is_ok(),
-                )
+                .skip_while(|s| {
+                    s.len() == 2 && usize::from_str_radix(s, 16).is_ok()
+                })
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>();
             instructions.push(Instruction { parts });
@@ -301,7 +301,10 @@ pub fn assert(fnptr: usize, fnname: &str, expected: &str) {
 
     // Help debug by printing out the found disassembly, and then panic as we
     // didn't find the instruction.
-    println!("disassembly for {}: ", sym.as_ref().expect("symbol not found"));
+    println!(
+        "disassembly for {}: ",
+        sym.as_ref().expect("symbol not found")
+    );
     for (i, instr) in function.instrs.iter().enumerate() {
         print!("\t{:2}: ", i);
         for part in &instr.parts {
@@ -311,7 +314,10 @@ pub fn assert(fnptr: usize, fnname: &str, expected: &str) {
     }
 
     if !found {
-        panic!("failed to find instruction `{}` in the disassembly", expected);
+        panic!(
+            "failed to find instruction `{}` in the disassembly",
+            expected
+        );
     } else if !probably_only_one_instruction {
         panic!("too many instructions in the disassembly");
     }


### PR DESCRIPTION
After this rustfmt works again and the builds are green.

Hopefully we will be able to use it reliably some day soon. There have been some improvements upstream:

- `rustfmt` already lets us fix a particular version
-  we can install this version using `cargo install rustfmt-nightly --version x.y.z.`
-  but for that we need a particular nightly compiler.

It is easy to hardcode this on travis, but as a user this is still a pain to set up.