### PR TITLE
Verify Intel intrinsics against upstream definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
     - env: DOCUMENTATION
       install: true
       script: ci/dox.sh
+    - script: cargo test --manifest-path stdsimd-verify/Cargo.toml
+      install: true
     - env: RUSTFMT=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
       script: |
         cargo install rustfmt-nightly --force
@@ -40,6 +42,8 @@ install:
 
 script:
   - cargo generate-lockfile
+  # FIXME (travis-ci/travis-ci#8920) shouldn't be necessary...
+  - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
   - ci/run-docker.sh $TARGET $FEATURES
 
 notifications:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["hardware-support"]
 license = "MIT/Apache-2.0"
 
 [workspace]
+members = ["stdsimd-verify"]
 
 [badges]
 travis-ci = { repository = "BurntSushi/stdsimd" }

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -22,7 +22,9 @@ echo "FEATURES=${FEATURES}"
 echo "OBJDUMP=${OBJDUMP}"
 
 cargo_test() {
-    cmd="cargo test --all --target=$TARGET --features $FEATURES --verbose $1 -- --nocapture $2"
+    cmd="cargo test --target=$TARGET --features $FEATURES $1"
+    cmd="$cmd -p coresimd -p stdsimd"
+    cmd="$cmd -- $2"
     $cmd
 }
 

--- a/coresimd/src/x86/i586/abm.rs
+++ b/coresimd/src/x86/i586/abm.rs
@@ -44,16 +44,16 @@ pub unsafe fn _lzcnt_u64(x: u64) -> u64 {
 #[inline(always)]
 #[target_feature = "+popcnt"]
 #[cfg_attr(test, assert_instr(popcnt))]
-pub unsafe fn _popcnt32(x: u32) -> u32 {
-    x.count_ones()
+pub unsafe fn _popcnt32(x: i32) -> i32 {
+    x.count_ones() as i32
 }
 
 /// Counts the bits that are set.
 #[inline(always)]
 #[target_feature = "+popcnt"]
 #[cfg_attr(test, assert_instr(popcnt))]
-pub unsafe fn _popcnt64(x: u64) -> u64 {
-    x.count_ones() as u64
+pub unsafe fn _popcnt64(x: i64) -> i32 {
+    x.count_ones() as i32
 }
 
 #[cfg(test)]
@@ -64,21 +64,21 @@ mod tests {
 
     #[simd_test = "lzcnt"]
     unsafe fn _lzcnt_u32() {
-        assert_eq!(abm::_lzcnt_u32(0b0101_1010u32), 25u32);
+        assert_eq!(abm::_lzcnt_u32(0b0101_1010), 25);
     }
 
     #[simd_test = "lzcnt"]
     unsafe fn _lzcnt_u64() {
-        assert_eq!(abm::_lzcnt_u64(0b0101_1010u64), 57u64);
+        assert_eq!(abm::_lzcnt_u64(0b0101_1010), 57);
     }
 
     #[simd_test = "popcnt"]
     unsafe fn _popcnt32() {
-        assert_eq!(abm::_popcnt32(0b0101_1010u32), 4);
+        assert_eq!(abm::_popcnt32(0b0101_1010), 4);
     }
 
     #[simd_test = "popcnt"]
     unsafe fn _popcnt64() {
-        assert_eq!(abm::_popcnt64(0b0101_1010u64), 4);
+        assert_eq!(abm::_popcnt64(0b0101_1010), 4);
     }
 }

--- a/coresimd/src/x86/i586/avx.rs
+++ b/coresimd/src/x86/i586/avx.rs
@@ -607,69 +607,69 @@ pub unsafe fn _mm256_xor_ps(a: f32x8, b: f32x8) -> f32x8 {
 }
 
 /// Equal (ordered, non-signaling)
-pub const _CMP_EQ_OQ: u8 = 0x00;
+pub const _CMP_EQ_OQ: i32 = 0x00;
 /// Less-than (ordered, signaling)
-pub const _CMP_LT_OS: u8 = 0x01;
+pub const _CMP_LT_OS: i32 = 0x01;
 /// Less-than-or-equal (ordered, signaling)
-pub const _CMP_LE_OS: u8 = 0x02;
+pub const _CMP_LE_OS: i32 = 0x02;
 /// Unordered (non-signaling)
-pub const _CMP_UNORD_Q: u8 = 0x03;
+pub const _CMP_UNORD_Q: i32 = 0x03;
 /// Not-equal (unordered, non-signaling)
-pub const _CMP_NEQ_UQ: u8 = 0x04;
+pub const _CMP_NEQ_UQ: i32 = 0x04;
 /// Not-less-than (unordered, signaling)
-pub const _CMP_NLT_US: u8 = 0x05;
+pub const _CMP_NLT_US: i32 = 0x05;
 /// Not-less-than-or-equal (unordered, signaling)
-pub const _CMP_NLE_US: u8 = 0x06;
+pub const _CMP_NLE_US: i32 = 0x06;
 /// Ordered (non-signaling)
-pub const _CMP_ORD_Q: u8 = 0x07;
+pub const _CMP_ORD_Q: i32 = 0x07;
 /// Equal (unordered, non-signaling)
-pub const _CMP_EQ_UQ: u8 = 0x08;
+pub const _CMP_EQ_UQ: i32 = 0x08;
 /// Not-greater-than-or-equal (unordered, signaling)
-pub const _CMP_NGE_US: u8 = 0x09;
+pub const _CMP_NGE_US: i32 = 0x09;
 /// Not-greater-than (unordered, signaling)
-pub const _CMP_NGT_US: u8 = 0x0a;
+pub const _CMP_NGT_US: i32 = 0x0a;
 /// False (ordered, non-signaling)
-pub const _CMP_FALSE_OQ: u8 = 0x0b;
+pub const _CMP_FALSE_OQ: i32 = 0x0b;
 /// Not-equal (ordered, non-signaling)
-pub const _CMP_NEQ_OQ: u8 = 0x0c;
+pub const _CMP_NEQ_OQ: i32 = 0x0c;
 /// Greater-than-or-equal (ordered, signaling)
-pub const _CMP_GE_OS: u8 = 0x0d;
+pub const _CMP_GE_OS: i32 = 0x0d;
 /// Greater-than (ordered, signaling)
-pub const _CMP_GT_OS: u8 = 0x0e;
+pub const _CMP_GT_OS: i32 = 0x0e;
 /// True (unordered, non-signaling)
-pub const _CMP_TRUE_UQ: u8 = 0x0f;
+pub const _CMP_TRUE_UQ: i32 = 0x0f;
 /// Equal (ordered, signaling)
-pub const _CMP_EQ_OS: u8 = 0x10;
+pub const _CMP_EQ_OS: i32 = 0x10;
 /// Less-than (ordered, non-signaling)
-pub const _CMP_LT_OQ: u8 = 0x11;
+pub const _CMP_LT_OQ: i32 = 0x11;
 /// Less-than-or-equal (ordered, non-signaling)
-pub const _CMP_LE_OQ: u8 = 0x12;
+pub const _CMP_LE_OQ: i32 = 0x12;
 /// Unordered (signaling)
-pub const _CMP_UNORD_S: u8 = 0x13;
+pub const _CMP_UNORD_S: i32 = 0x13;
 /// Not-equal (unordered, signaling)
-pub const _CMP_NEQ_US: u8 = 0x14;
+pub const _CMP_NEQ_US: i32 = 0x14;
 /// Not-less-than (unordered, non-signaling)
-pub const _CMP_NLT_UQ: u8 = 0x15;
+pub const _CMP_NLT_UQ: i32 = 0x15;
 /// Not-less-than-or-equal (unordered, non-signaling)
-pub const _CMP_NLE_UQ: u8 = 0x16;
+pub const _CMP_NLE_UQ: i32 = 0x16;
 /// Ordered (signaling)
-pub const _CMP_ORD_S: u8 = 0x17;
+pub const _CMP_ORD_S: i32 = 0x17;
 /// Equal (unordered, signaling)
-pub const _CMP_EQ_US: u8 = 0x18;
+pub const _CMP_EQ_US: i32 = 0x18;
 /// Not-greater-than-or-equal (unordered, non-signaling)
-pub const _CMP_NGE_UQ: u8 = 0x19;
+pub const _CMP_NGE_UQ: i32 = 0x19;
 /// Not-greater-than (unordered, non-signaling)
-pub const _CMP_NGT_UQ: u8 = 0x1a;
+pub const _CMP_NGT_UQ: i32 = 0x1a;
 /// False (ordered, signaling)
-pub const _CMP_FALSE_OS: u8 = 0x1b;
+pub const _CMP_FALSE_OS: i32 = 0x1b;
 /// Not-equal (ordered, signaling)
-pub const _CMP_NEQ_OS: u8 = 0x1c;
+pub const _CMP_NEQ_OS: i32 = 0x1c;
 /// Greater-than-or-equal (ordered, non-signaling)
-pub const _CMP_GE_OQ: u8 = 0x1d;
+pub const _CMP_GE_OQ: i32 = 0x1d;
 /// Greater-than (ordered, non-signaling)
-pub const _CMP_GT_OQ: u8 = 0x1e;
+pub const _CMP_GT_OQ: i32 = 0x1e;
 /// True (unordered, signaling)
-pub const _CMP_TRUE_US: u8 = 0x1f;
+pub const _CMP_TRUE_US: i32 = 0x1f;
 
 /// Compare packed double-precision (64-bit) floating-point
 /// elements in `a` and `b` based on the comparison operand
@@ -677,7 +677,7 @@ pub const _CMP_TRUE_US: u8 = 0x1f;
 #[inline(always)]
 #[target_feature = "+avx,+sse2"]
 #[cfg_attr(test, assert_instr(vcmpeqpd, imm8 = 0))] // TODO Validate vcmppd
-pub unsafe fn _mm_cmp_pd(a: f64x2, b: f64x2, imm8: u8) -> f64x2 {
+pub unsafe fn _mm_cmp_pd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
     macro_rules! call {
         ($imm8:expr) => { vcmppd(a, b, $imm8) }
     }
@@ -690,7 +690,7 @@ pub unsafe fn _mm_cmp_pd(a: f64x2, b: f64x2, imm8: u8) -> f64x2 {
 #[inline(always)]
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vcmpeqpd, imm8 = 0))] // TODO Validate vcmppd
-pub unsafe fn _mm256_cmp_pd(a: f64x4, b: f64x4, imm8: u8) -> f64x4 {
+pub unsafe fn _mm256_cmp_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
     macro_rules! call {
         ($imm8:expr) => { vcmppd256(a, b, $imm8) }
     }
@@ -703,7 +703,7 @@ pub unsafe fn _mm256_cmp_pd(a: f64x4, b: f64x4, imm8: u8) -> f64x4 {
 #[inline(always)]
 #[target_feature = "+avx,+sse"]
 #[cfg_attr(test, assert_instr(vcmpeqps, imm8 = 0))] // TODO Validate vcmpps
-pub unsafe fn _mm_cmp_ps(a: f32x4, b: f32x4, imm8: u8) -> f32x4 {
+pub unsafe fn _mm_cmp_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => { vcmpps(a, b, $imm8) }
     }
@@ -716,7 +716,7 @@ pub unsafe fn _mm_cmp_ps(a: f32x4, b: f32x4, imm8: u8) -> f32x4 {
 #[inline(always)]
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vcmpeqps, imm8 = 0))] // TODO Validate vcmpps
-pub unsafe fn _mm256_cmp_ps(a: f32x8, b: f32x8, imm8: u8) -> f32x8 {
+pub unsafe fn _mm256_cmp_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
     macro_rules! call {
         ($imm8:expr) => { vcmpps256(a, b, $imm8) }
     }
@@ -731,7 +731,7 @@ pub unsafe fn _mm256_cmp_ps(a: f32x8, b: f32x8, imm8: u8) -> f32x8 {
 #[inline(always)]
 #[target_feature = "+avx,+sse2"]
 #[cfg_attr(test, assert_instr(vcmpeqsd, imm8 = 0))] // TODO Validate vcmpsd
-pub unsafe fn _mm_cmp_sd(a: f64x2, b: f64x2, imm8: u8) -> f64x2 {
+pub unsafe fn _mm_cmp_sd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
     macro_rules! call {
         ($imm8:expr) => { vcmpsd(a, b, $imm8) }
     }
@@ -746,7 +746,7 @@ pub unsafe fn _mm_cmp_sd(a: f64x2, b: f64x2, imm8: u8) -> f64x2 {
 #[inline(always)]
 #[target_feature = "+avx,+sse"]
 #[cfg_attr(test, assert_instr(vcmpeqss, imm8 = 0))] // TODO Validate vcmpss
-pub unsafe fn _mm_cmp_ss(a: f32x4, b: f32x4, imm8: u8) -> f32x4 {
+pub unsafe fn _mm_cmp_ss(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => { vcmpss(a, b, $imm8) }
     }
@@ -860,48 +860,6 @@ pub unsafe fn _mm256_extractf128_si256(a: __m256i, imm8: i32) -> __m128i {
         _ => simd_shuffle2(i64x4::from(a), b, [2, 3]),
     };
     __m128i::from(dst)
-}
-
-/// Extract an 8-bit integer from `a`, selected with `imm8`. Returns a 32-bit
-/// integer containing the zero-extended integer data.
-///
-/// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
-#[inline(always)]
-#[target_feature = "+avx"]
-// This intrinsic has no corresponding instruction.
-pub unsafe fn _mm256_extract_epi8(a: i8x32, imm8: i32) -> i32 {
-    let imm8 = (imm8 & 31) as u32;
-    (a.extract_unchecked(imm8) as i32) & 0xFF
-}
-
-/// Extract a 16-bit integer from `a`, selected with `imm8`. Returns a 32-bit
-/// integer containing the zero-extended integer data.
-///
-/// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
-#[inline(always)]
-#[target_feature = "+avx"]
-// This intrinsic has no corresponding instruction.
-pub unsafe fn _mm256_extract_epi16(a: i16x16, imm8: i32) -> i32 {
-    let imm8 = (imm8 & 15) as u32;
-    (a.extract_unchecked(imm8) as i32) & 0xFFFF
-}
-
-/// Extract a 32-bit integer from `a`, selected with `imm8`.
-#[inline(always)]
-#[target_feature = "+avx"]
-// This intrinsic has no corresponding instruction.
-pub unsafe fn _mm256_extract_epi32(a: i32x8, imm8: i32) -> i32 {
-    let imm8 = (imm8 & 7) as u32;
-    a.extract_unchecked(imm8)
-}
-
-/// Extract a 64-bit integer from `a`, selected with `imm8`.
-#[inline(always)]
-#[target_feature = "+avx"]
-// This intrinsic has no corresponding instruction.
-pub unsafe fn _mm256_extract_epi64(a: i64x4, imm8: i32) -> i64 {
-    let imm8 = (imm8 & 3) as u32;
-    a.extract_unchecked(imm8)
 }
 
 /// Zero the contents of all XMM or YMM registers.
@@ -1138,7 +1096,7 @@ pub unsafe fn _mm_permute_pd(a: f64x2, imm8: i32) -> f64x2 {
 #[inline(always)]
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x5))]
-pub unsafe fn _mm256_permute2f128_ps(a: f32x8, b: f32x8, imm8: i8) -> f32x8 {
+pub unsafe fn _mm256_permute2f128_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
     macro_rules! call {
         ($imm8:expr) => { vperm2f128ps256(a, b, $imm8) }
     }
@@ -1150,7 +1108,7 @@ pub unsafe fn _mm256_permute2f128_ps(a: f32x8, b: f32x8, imm8: i8) -> f32x8 {
 #[inline(always)]
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x31))]
-pub unsafe fn _mm256_permute2f128_pd(a: f64x4, b: f64x4, imm8: i8) -> f64x4 {
+pub unsafe fn _mm256_permute2f128_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
     macro_rules! call {
         ($imm8:expr) => { vperm2f128pd256(a, b, $imm8) }
     }
@@ -1163,7 +1121,7 @@ pub unsafe fn _mm256_permute2f128_pd(a: f64x4, b: f64x4, imm8: i8) -> f64x4 {
 #[target_feature = "+avx"]
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x31))]
 pub unsafe fn _mm256_permute2f128_si256(
-    a: i32x8, b: i32x8, imm8: i8
+    a: i32x8, b: i32x8, imm8: i32
 ) -> i32x8 {
     macro_rules! call {
         ($imm8:expr) => { vperm2f128si256(a, b, $imm8) }
@@ -3144,47 +3102,6 @@ mod tests {
         let r = avx::_mm256_extractf128_si256(__m256i::from(a), 0);
         let e = i64x2::new(4, 3);
         assert_eq!(r, __m128i::from(e));
-    }
-
-    #[simd_test = "avx"]
-    unsafe fn _mm256_extract_epi8() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
-        let a = i8x32::new(
-            -1, 1, 2, 3, 4, 5, 6, 7,
-            8, 9, 10, 11, 12, 13, 14, 15,
-            16, 17, 18, 19, 20, 21, 22, 23,
-            24, 25, 26, 27, 28, 29, 30, 31
-        );
-        let r1 = avx::_mm256_extract_epi8(a, 0);
-        let r2 = avx::_mm256_extract_epi8(a, 35);
-        assert_eq!(r1, 0xFF);
-        assert_eq!(r2, 3);
-    }
-
-    #[simd_test = "avx"]
-    unsafe fn _mm256_extract_epi16() {
-        let a =
-            i16x16::new(-1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-        let r1 = avx::_mm256_extract_epi16(a, 0);
-        let r2 = avx::_mm256_extract_epi16(a, 19);
-        assert_eq!(r1, 0xFFFF);
-        assert_eq!(r2, 3);
-    }
-
-    #[simd_test = "avx"]
-    unsafe fn _mm256_extract_epi32() {
-        let a = i32x8::new(-1, 1, 2, 3, 4, 5, 6, 7);
-        let r1 = avx::_mm256_extract_epi32(a, 0);
-        let r2 = avx::_mm256_extract_epi32(a, 11);
-        assert_eq!(r1, -1);
-        assert_eq!(r2, 3);
-    }
-
-    #[simd_test = "avx"]
-    unsafe fn _mm256_extract_epi64() {
-        let a = i64x4::new(0, 1, 2, 3);
-        let r = avx::_mm256_extract_epi64(a, 3);
-        assert_eq!(r, 3);
     }
 
     #[simd_test = "avx"]

--- a/coresimd/src/x86/i586/avx2.rs
+++ b/coresimd/src/x86/i586/avx2.rs
@@ -713,7 +713,7 @@ pub unsafe fn _mm256_hsubs_epi16(a: i16x16, b: i16x16) -> i16x16 {
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 pub unsafe fn _mm_i32gather_epi32(
-    slice: *const i32, offsets: i32x4, scale: i8
+    slice: *const i32, offsets: i32x4, scale: i32
 ) -> i32x4 {
     macro_rules! call {
         ($imm8:expr) => (pgatherdd(i32x4::splat(0), slice as *const i8, offsets, i32x4::splat(-1), $imm8))
@@ -729,7 +729,7 @@ pub unsafe fn _mm_i32gather_epi32(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 pub unsafe fn _mm_mask_i32gather_epi32(
-    src: i32x4, slice: *const i32, offsets: i32x4, mask: i32x4, scale: i8
+    src: i32x4, slice: *const i32, offsets: i32x4, mask: i32x4, scale: i32
 ) -> i32x4 {
     macro_rules! call {
         ($imm8:expr) => (pgatherdd(src, slice as *const i8, offsets, mask, $imm8))
@@ -744,7 +744,7 @@ pub unsafe fn _mm_mask_i32gather_epi32(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 pub unsafe fn _mm256_i32gather_epi32(
-    slice: *const i32, offsets: i32x8, scale: i8
+    slice: *const i32, offsets: i32x8, scale: i32
 ) -> i32x8 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherdd(i32x8::splat(0), slice as *const i8, offsets, i32x8::splat(-1), $imm8))
@@ -760,7 +760,7 @@ pub unsafe fn _mm256_i32gather_epi32(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 pub unsafe fn _mm256_mask_i32gather_epi32(
-    src: i32x8, slice: *const i32, offsets: i32x8, mask: i32x8, scale: i8
+    src: i32x8, slice: *const i32, offsets: i32x8, mask: i32x8, scale: i32
 ) -> i32x8 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherdd(src, slice as *const i8, offsets, mask, $imm8))
@@ -775,7 +775,7 @@ pub unsafe fn _mm256_mask_i32gather_epi32(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 pub unsafe fn _mm_i32gather_ps(
-    slice: *const f32, offsets: i32x4, scale: i8
+    slice: *const f32, offsets: i32x4, scale: i32
 ) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => (pgatherdps(f32x4::splat(0.0), slice as *const i8, offsets, f32x4::splat(-1.0), $imm8))
@@ -791,7 +791,7 @@ pub unsafe fn _mm_i32gather_ps(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 pub unsafe fn _mm_mask_i32gather_ps(
-    src: f32x4, slice: *const f32, offsets: i32x4, mask: f32x4, scale: i8
+    src: f32x4, slice: *const f32, offsets: i32x4, mask: f32x4, scale: i32
 ) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => (pgatherdps(src, slice as *const i8, offsets, mask, $imm8))
@@ -806,7 +806,7 @@ pub unsafe fn _mm_mask_i32gather_ps(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 pub unsafe fn _mm256_i32gather_ps(
-    slice: *const f32, offsets: i32x8, scale: i8
+    slice: *const f32, offsets: i32x8, scale: i32
 ) -> f32x8 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherdps(f32x8::splat(0.0), slice as *const i8, offsets, f32x8::splat(-1.0), $imm8))
@@ -822,7 +822,7 @@ pub unsafe fn _mm256_i32gather_ps(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 pub unsafe fn _mm256_mask_i32gather_ps(
-    src: f32x8, slice: *const f32, offsets: i32x8, mask: f32x8, scale: i8
+    src: f32x8, slice: *const f32, offsets: i32x8, mask: f32x8, scale: i32
 ) -> f32x8 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherdps(src, slice as *const i8, offsets, mask, $imm8))
@@ -837,7 +837,7 @@ pub unsafe fn _mm256_mask_i32gather_ps(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 pub unsafe fn _mm_i32gather_epi64(
-    slice: *const i64, offsets: i32x4, scale: i8
+    slice: *const i64, offsets: i32x4, scale: i32
 ) -> i64x2 {
     macro_rules! call {
         ($imm8:expr) => (pgatherdq(i64x2::splat(0), slice as *const i8, offsets, i64x2::splat(-1), $imm8))
@@ -853,7 +853,7 @@ pub unsafe fn _mm_i32gather_epi64(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 pub unsafe fn _mm_mask_i32gather_epi64(
-    src: i64x2, slice: *const i64, offsets: i32x4, mask: i64x2, scale: i8
+    src: i64x2, slice: *const i64, offsets: i32x4, mask: i64x2, scale: i32
 ) -> i64x2 {
     macro_rules! call {
         ($imm8:expr) => (pgatherdq(src, slice as *const i8, offsets, mask, $imm8))
@@ -868,7 +868,7 @@ pub unsafe fn _mm_mask_i32gather_epi64(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 pub unsafe fn _mm256_i32gather_epi64(
-    slice: *const i64, offsets: i32x4, scale: i8
+    slice: *const i64, offsets: i32x4, scale: i32
 ) -> i64x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherdq(i64x4::splat(0), slice as *const i8, offsets, i64x4::splat(-1), $imm8))
@@ -884,7 +884,7 @@ pub unsafe fn _mm256_i32gather_epi64(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 pub unsafe fn _mm256_mask_i32gather_epi64(
-    src: i64x4, slice: *const i64, offsets: i32x4, mask: i64x4, scale: i8
+    src: i64x4, slice: *const i64, offsets: i32x4, mask: i64x4, scale: i32
 ) -> i64x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherdq(src, slice as *const i8, offsets, mask, $imm8))
@@ -899,7 +899,7 @@ pub unsafe fn _mm256_mask_i32gather_epi64(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 pub unsafe fn _mm_i32gather_pd(
-    slice: *const f64, offsets: i32x4, scale: i8
+    slice: *const f64, offsets: i32x4, scale: i32
 ) -> f64x2 {
     macro_rules! call {
         ($imm8:expr) => (pgatherdpd(f64x2::splat(0.0), slice as *const i8, offsets, f64x2::splat(-1.0), $imm8))
@@ -915,7 +915,7 @@ pub unsafe fn _mm_i32gather_pd(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 pub unsafe fn _mm_mask_i32gather_pd(
-    src: f64x2, slice: *const f64, offsets: i32x4, mask: f64x2, scale: i8
+    src: f64x2, slice: *const f64, offsets: i32x4, mask: f64x2, scale: i32
 ) -> f64x2 {
     macro_rules! call {
         ($imm8:expr) => (pgatherdpd(src, slice as *const i8, offsets, mask, $imm8))
@@ -930,7 +930,7 @@ pub unsafe fn _mm_mask_i32gather_pd(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 pub unsafe fn _mm256_i32gather_pd(
-    slice: *const f64, offsets: i32x4, scale: i8
+    slice: *const f64, offsets: i32x4, scale: i32
 ) -> f64x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherdpd(f64x4::splat(0.0), slice as *const i8, offsets, f64x4::splat(-1.0), $imm8))
@@ -946,7 +946,7 @@ pub unsafe fn _mm256_i32gather_pd(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 pub unsafe fn _mm256_mask_i32gather_pd(
-    src: f64x4, slice: *const f64, offsets: i32x4, mask: f64x4, scale: i8
+    src: f64x4, slice: *const f64, offsets: i32x4, mask: f64x4, scale: i32
 ) -> f64x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherdpd(src, slice as *const i8, offsets, mask, $imm8))
@@ -961,7 +961,7 @@ pub unsafe fn _mm256_mask_i32gather_pd(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 pub unsafe fn _mm_i64gather_epi32(
-    slice: *const i32, offsets: i64x2, scale: i8
+    slice: *const i32, offsets: i64x2, scale: i32
 ) -> i32x4 {
     macro_rules! call {
         ($imm8:expr) => (pgatherqd(i32x4::splat(0), slice as *const i8, offsets, i32x4::splat(-1), $imm8))
@@ -977,7 +977,7 @@ pub unsafe fn _mm_i64gather_epi32(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 pub unsafe fn _mm_mask_i64gather_epi32(
-    src: i32x4, slice: *const i32, offsets: i64x2, mask: i32x4, scale: i8
+    src: i32x4, slice: *const i32, offsets: i64x2, mask: i32x4, scale: i32
 ) -> i32x4 {
     macro_rules! call {
         ($imm8:expr) => (pgatherqd(src, slice as *const i8, offsets, mask, $imm8))
@@ -992,7 +992,7 @@ pub unsafe fn _mm_mask_i64gather_epi32(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 pub unsafe fn _mm256_i64gather_epi32(
-    slice: *const i32, offsets: i64x4, scale: i8
+    slice: *const i32, offsets: i64x4, scale: i32
 ) -> i32x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherqd(i32x4::splat(0), slice as *const i8, offsets, i32x4::splat(-1), $imm8))
@@ -1008,7 +1008,7 @@ pub unsafe fn _mm256_i64gather_epi32(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 pub unsafe fn _mm256_mask_i64gather_epi32(
-    src: i32x4, slice: *const i32, offsets: i64x4, mask: i32x4, scale: i8
+    src: i32x4, slice: *const i32, offsets: i64x4, mask: i32x4, scale: i32
 ) -> i32x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherqd(src, slice as *const i8, offsets, mask, $imm8))
@@ -1023,7 +1023,7 @@ pub unsafe fn _mm256_mask_i64gather_epi32(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 pub unsafe fn _mm_i64gather_ps(
-    slice: *const f32, offsets: i64x2, scale: i8
+    slice: *const f32, offsets: i64x2, scale: i32
 ) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => (pgatherqps(f32x4::splat(0.0), slice as *const i8, offsets, f32x4::splat(-1.0), $imm8))
@@ -1039,7 +1039,7 @@ pub unsafe fn _mm_i64gather_ps(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 pub unsafe fn _mm_mask_i64gather_ps(
-    src: f32x4, slice: *const f32, offsets: i64x2, mask: f32x4, scale: i8
+    src: f32x4, slice: *const f32, offsets: i64x2, mask: f32x4, scale: i32
 ) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => (pgatherqps(src, slice as *const i8, offsets, mask, $imm8))
@@ -1054,7 +1054,7 @@ pub unsafe fn _mm_mask_i64gather_ps(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 pub unsafe fn _mm256_i64gather_ps(
-    slice: *const f32, offsets: i64x4, scale: i8
+    slice: *const f32, offsets: i64x4, scale: i32
 ) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherqps(f32x4::splat(0.0), slice as *const i8, offsets, f32x4::splat(-1.0), $imm8))
@@ -1070,7 +1070,7 @@ pub unsafe fn _mm256_i64gather_ps(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 pub unsafe fn _mm256_mask_i64gather_ps(
-    src: f32x4, slice: *const f32, offsets: i64x4, mask: f32x4, scale: i8
+    src: f32x4, slice: *const f32, offsets: i64x4, mask: f32x4, scale: i32
 ) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherqps(src, slice as *const i8, offsets, mask, $imm8))
@@ -1085,7 +1085,7 @@ pub unsafe fn _mm256_mask_i64gather_ps(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 pub unsafe fn _mm_i64gather_epi64(
-    slice: *const i64, offsets: i64x2, scale: i8
+    slice: *const i64, offsets: i64x2, scale: i32
 ) -> i64x2 {
     macro_rules! call {
         ($imm8:expr) => (pgatherqq(i64x2::splat(0), slice as *const i8, offsets, i64x2::splat(-1), $imm8))
@@ -1101,7 +1101,7 @@ pub unsafe fn _mm_i64gather_epi64(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 pub unsafe fn _mm_mask_i64gather_epi64(
-    src: i64x2, slice: *const i64, offsets: i64x2, mask: i64x2, scale: i8
+    src: i64x2, slice: *const i64, offsets: i64x2, mask: i64x2, scale: i32
 ) -> i64x2 {
     macro_rules! call {
         ($imm8:expr) => (pgatherqq(src, slice as *const i8, offsets, mask, $imm8))
@@ -1116,7 +1116,7 @@ pub unsafe fn _mm_mask_i64gather_epi64(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 pub unsafe fn _mm256_i64gather_epi64(
-    slice: *const i64, offsets: i64x4, scale: i8
+    slice: *const i64, offsets: i64x4, scale: i32
 ) -> i64x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherqq(i64x4::splat(0), slice as *const i8, offsets, i64x4::splat(-1), $imm8))
@@ -1132,7 +1132,7 @@ pub unsafe fn _mm256_i64gather_epi64(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 pub unsafe fn _mm256_mask_i64gather_epi64(
-    src: i64x4, slice: *const i64, offsets: i64x4, mask: i64x4, scale: i8
+    src: i64x4, slice: *const i64, offsets: i64x4, mask: i64x4, scale: i32
 ) -> i64x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherqq(src, slice as *const i8, offsets, mask, $imm8))
@@ -1147,7 +1147,7 @@ pub unsafe fn _mm256_mask_i64gather_epi64(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 pub unsafe fn _mm_i64gather_pd(
-    slice: *const f64, offsets: i64x2, scale: i8
+    slice: *const f64, offsets: i64x2, scale: i32
 ) -> f64x2 {
     macro_rules! call {
         ($imm8:expr) => (pgatherqpd(f64x2::splat(0.0), slice as *const i8, offsets, f64x2::splat(-1.0), $imm8))
@@ -1163,7 +1163,7 @@ pub unsafe fn _mm_i64gather_pd(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 pub unsafe fn _mm_mask_i64gather_pd(
-    src: f64x2, slice: *const f64, offsets: i64x2, mask: f64x2, scale: i8
+    src: f64x2, slice: *const f64, offsets: i64x2, mask: f64x2, scale: i32
 ) -> f64x2 {
     macro_rules! call {
         ($imm8:expr) => (pgatherqpd(src, slice as *const i8, offsets, mask, $imm8))
@@ -1178,7 +1178,7 @@ pub unsafe fn _mm_mask_i64gather_pd(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 pub unsafe fn _mm256_i64gather_pd(
-    slice: *const f64, offsets: i64x4, scale: i8
+    slice: *const f64, offsets: i64x4, scale: i32
 ) -> f64x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherqpd(f64x4::splat(0.0), slice as *const i8, offsets, f64x4::splat(-1.0), $imm8))
@@ -1194,7 +1194,7 @@ pub unsafe fn _mm256_i64gather_pd(
 #[target_feature = "+avx2"]
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 pub unsafe fn _mm256_mask_i64gather_pd(
-    src: f64x4, slice: *const f64, offsets: i64x4, mask: f64x4, scale: i8
+    src: f64x4, slice: *const f64, offsets: i64x4, mask: f64x4, scale: i32
 ) -> f64x4 {
     macro_rules! call {
         ($imm8:expr) => (vpgatherqpd(src, slice as *const i8, offsets, mask, $imm8))
@@ -2654,6 +2654,48 @@ pub unsafe fn _mm256_unpacklo_epi64(a: i64x4, b: i64x4) -> i64x4 {
 #[cfg_attr(test, assert_instr(vxorps))]
 pub unsafe fn _mm256_xor_si256(a: __m256i, b: __m256i) -> __m256i {
     __m256i::from(i8x32::from(a) ^ i8x32::from(b))
+}
+
+/// Extract an 8-bit integer from `a`, selected with `imm8`. Returns a 32-bit
+/// integer containing the zero-extended integer data.
+///
+/// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
+#[inline(always)]
+#[target_feature = "+avx2"]
+// This intrinsic has no corresponding instruction.
+pub unsafe fn _mm256_extract_epi8(a: i8x32, imm8: i32) -> i8 {
+    let imm8 = (imm8 & 31) as u32;
+    a.extract_unchecked(imm8)
+}
+
+/// Extract a 16-bit integer from `a`, selected with `imm8`. Returns a 32-bit
+/// integer containing the zero-extended integer data.
+///
+/// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
+#[inline(always)]
+#[target_feature = "+avx2"]
+// This intrinsic has no corresponding instruction.
+pub unsafe fn _mm256_extract_epi16(a: i16x16, imm8: i32) -> i16 {
+    let imm8 = (imm8 & 15) as u32;
+    a.extract_unchecked(imm8)
+}
+
+/// Extract a 32-bit integer from `a`, selected with `imm8`.
+#[inline(always)]
+#[target_feature = "+avx2"]
+// This intrinsic has no corresponding instruction.
+pub unsafe fn _mm256_extract_epi32(a: i32x8, imm8: i32) -> i32 {
+    let imm8 = (imm8 & 7) as u32;
+    a.extract_unchecked(imm8)
+}
+
+/// Extract a 64-bit integer from `a`, selected with `imm8`.
+#[inline(always)]
+#[target_feature = "+avx2"]
+// This intrinsic has no corresponding instruction.
+pub unsafe fn _mm256_extract_epi64(a: i64x4, imm8: i32) -> i64 {
+    let imm8 = (imm8 & 3) as u32;
+    a.extract_unchecked(imm8)
 }
 
 #[allow(improper_ctypes)]
@@ -4923,4 +4965,44 @@ mod tests {
         assert_eq!(r, f64x4::new(0.0, 16.0, 64.0, 256.0));
     }
 
+    #[simd_test = "avx"]
+    unsafe fn _mm256_extract_epi8() {
+        #[cfg_attr(rustfmt, rustfmt_skip)]
+        let a = i8x32::new(
+            -1, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31
+        );
+        let r1 = avx2::_mm256_extract_epi8(a, 0);
+        let r2 = avx2::_mm256_extract_epi8(a, 35);
+        assert_eq!(r1, -1);
+        assert_eq!(r2, 3);
+    }
+
+    #[simd_test = "avx2"]
+    unsafe fn _mm256_extract_epi16() {
+        let a =
+            i16x16::new(-1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+        let r1 = avx2::_mm256_extract_epi16(a, 0);
+        let r2 = avx2::_mm256_extract_epi16(a, 19);
+        assert_eq!(r1, -1);
+        assert_eq!(r2, 3);
+    }
+
+    #[simd_test = "avx2"]
+    unsafe fn _mm256_extract_epi32() {
+        let a = i32x8::new(-1, 1, 2, 3, 4, 5, 6, 7);
+        let r1 = avx2::_mm256_extract_epi32(a, 0);
+        let r2 = avx2::_mm256_extract_epi32(a, 11);
+        assert_eq!(r1, -1);
+        assert_eq!(r2, 3);
+    }
+
+    #[simd_test = "avx2"]
+    unsafe fn _mm256_extract_epi64() {
+        let a = i64x4::new(0, 1, 2, 3);
+        let r = avx2::_mm256_extract_epi64(a, 3);
+        assert_eq!(r, 3);
+    }
 }

--- a/coresimd/src/x86/i586/bmi.rs
+++ b/coresimd/src/x86/i586/bmi.rs
@@ -27,8 +27,8 @@ pub unsafe fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
 #[target_feature = "+bmi"]
 #[cfg_attr(test, assert_instr(bextr))]
 #[cfg(not(target_arch = "x86"))]
-pub unsafe fn _bextr_u64(a: u64, start: u64, len: u64) -> u64 {
-    _bextr2_u64(a, (start & 0xff_u64) | ((len & 0xff_u64) << 8_u64))
+pub unsafe fn _bextr_u64(a: u64, start: u32, len: u32) -> u64 {
+    _bextr2_u64(a, ((start & 0xff) | ((len & 0xff) << 8)) as u64)
 }
 
 /// Extracts bits of `a` specified by `control` into
@@ -133,16 +133,6 @@ pub unsafe fn _blsr_u64(x: u64) -> u64 {
 #[inline(always)]
 #[target_feature = "+bmi"]
 #[cfg_attr(test, assert_instr(tzcnt))]
-pub unsafe fn _tzcnt_u16(x: u16) -> u16 {
-    x.trailing_zeros() as u16
-}
-
-/// Counts the number of trailing least significant zero bits.
-///
-/// When the source operand is 0, it returns its size in bits.
-#[inline(always)]
-#[target_feature = "+bmi"]
-#[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _tzcnt_u32(x: u32) -> u32 {
     x.trailing_zeros()
 }
@@ -163,8 +153,8 @@ pub unsafe fn _tzcnt_u64(x: u64) -> u64 {
 #[inline(always)]
 #[target_feature = "+bmi"]
 #[cfg_attr(test, assert_instr(tzcnt))]
-pub unsafe fn _mm_tzcnt_u32(x: u32) -> u32 {
-    x.trailing_zeros()
+pub unsafe fn _mm_tzcnt_32(x: u32) -> i32 {
+    x.trailing_zeros() as i32
 }
 
 /// Counts the number of trailing least significant zero bits.
@@ -173,8 +163,8 @@ pub unsafe fn _mm_tzcnt_u32(x: u32) -> u32 {
 #[inline(always)]
 #[target_feature = "+bmi"]
 #[cfg_attr(test, assert_instr(tzcnt))]
-pub unsafe fn _mm_tzcnt_u64(x: u64) -> u64 {
-    x.trailing_zeros() as u64
+pub unsafe fn _mm_tzcnt_64(x: u64) -> i64 {
+    x.trailing_zeros() as i64
 }
 
 #[allow(dead_code)]
@@ -288,13 +278,6 @@ mod tests {
         // TODO: test the behavior when the input is 0
         let r = bmi::_blsr_u64(0b0011_0000u64);
         assert_eq!(r, 0b0010_0000u64);
-    }
-
-    #[simd_test = "bmi"]
-    unsafe fn _tzcnt_u16() {
-        assert_eq!(bmi::_tzcnt_u16(0b0000_0001u16), 0u16);
-        assert_eq!(bmi::_tzcnt_u16(0b0000_0000u16), 16u16);
-        assert_eq!(bmi::_tzcnt_u16(0b1001_0000u16), 4u16);
     }
 
     #[simd_test = "bmi"]

--- a/coresimd/src/x86/i586/sse2.rs
+++ b/coresimd/src/x86/i586/sse2.rs
@@ -2933,9 +2933,9 @@ mod tests {
         let b =
             i8x16::new(15, 14, 2, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = sse2::_mm_cmpeq_epi8(a, b);
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             r,
-            #[cfg_attr(rustfmt, rustfmt_skip)]
             i8x16::new(
                 0, 0, 0xFFu8 as i8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
             )
@@ -3219,9 +3219,9 @@ mod tests {
         let a = i16x8::new(0x80, -0x81, 0, 0, 0, 0, 0, 0);
         let b = i16x8::new(0, 0, 0, 0, 0, 0, -0x81, 0x80);
         let r = sse2::_mm_packs_epi16(a, b);
+        #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq!(
             r,
-            #[cfg_attr(rustfmt, rustfmt_skip)]
             i8x16::new(
                 0x7F, -0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0x80, 0x7F
             )
@@ -3268,7 +3268,8 @@ mod tests {
 
     #[simd_test = "sse2"]
     unsafe fn _mm_movemask_epi8() {
-        let a = i8x16::from(#[cfg_attr(rustfmt, rustfmt_skip)] u8x16::new(
+        #[cfg_attr(rustfmt, rustfmt_skip)]
+        let a = i8x16::from(u8x16::new(
             0b1000_0000, 0b0, 0b1000_0000, 0b01, 0b0101, 0b1111_0000, 0, 0,
                 0, 0, 0b1111_0000, 0b0101, 0b01, 0b1000_0000, 0b0, 0b1000_0000, ));
         let r = sse2::_mm_movemask_epi8(a);

--- a/coresimd/src/x86/i586/sse41.rs
+++ b/coresimd/src/x86/i586/sse41.rs
@@ -61,7 +61,7 @@ pub unsafe fn _mm_blendv_epi8(a: i8x16, b: i8x16, mask: i8x16) -> i8x16 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(pblendw, imm8 = 0xF0))]
-pub unsafe fn _mm_blend_epi16(a: i16x8, b: i16x8, imm8: u8) -> i16x8 {
+pub unsafe fn _mm_blend_epi16(a: i16x8, b: i16x8, imm8: i32) -> i16x8 {
     macro_rules! call {
         ($imm8:expr) => { pblendw(a, b, $imm8) }
     }
@@ -91,7 +91,7 @@ pub unsafe fn _mm_blendv_ps(a: f32x4, b: f32x4, mask: f32x4) -> f32x4 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(blendpd, imm2 = 0b10))]
-pub unsafe fn _mm_blend_pd(a: f64x2, b: f64x2, imm2: u8) -> f64x2 {
+pub unsafe fn _mm_blend_pd(a: f64x2, b: f64x2, imm2: i32) -> f64x2 {
     macro_rules! call {
         ($imm2:expr) => { blendpd(a, b, $imm2) }
     }
@@ -103,7 +103,7 @@ pub unsafe fn _mm_blend_pd(a: f64x2, b: f64x2, imm2: u8) -> f64x2 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(blendps, imm4 = 0b0101))]
-pub unsafe fn _mm_blend_ps(a: f32x4, b: f32x4, imm4: u8) -> f32x4 {
+pub unsafe fn _mm_blend_ps(a: f32x4, b: f32x4, imm4: i32) -> f32x4 {
     macro_rules! call {
         ($imm4:expr) => { blendps(a, b, $imm4) }
     }
@@ -116,7 +116,7 @@ pub unsafe fn _mm_blend_ps(a: f32x4, b: f32x4, imm4: u8) -> f32x4 {
 #[target_feature = "+sse4.1"]
 // TODO: Add test for Windows
 #[cfg_attr(all(test, not(windows)), assert_instr(extractps, imm8 = 0))]
-pub unsafe fn _mm_extract_ps(a: f32x4, imm8: u8) -> i32 {
+pub unsafe fn _mm_extract_ps(a: f32x4, imm8: i32) -> i32 {
     mem::transmute(a.extract(imm8 as u32 & 0b11))
 }
 
@@ -167,7 +167,7 @@ pub unsafe fn _mm_extract_epi32(a: i32x4, imm8: i32) -> i32 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(insertps, imm8 = 0b1010))]
-pub unsafe fn _mm_insert_ps(a: f32x4, b: f32x4, imm8: u8) -> f32x4 {
+pub unsafe fn _mm_insert_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => { insertps(a, b, $imm8) }
     }
@@ -179,7 +179,7 @@ pub unsafe fn _mm_insert_ps(a: f32x4, b: f32x4, imm8: u8) -> f32x4 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(pinsrb, imm8 = 0))]
-pub unsafe fn _mm_insert_epi8(a: i8x16, i: i8, imm8: u8) -> i8x16 {
+pub unsafe fn _mm_insert_epi8(a: i8x16, i: i8, imm8: i32) -> i8x16 {
     a.replace((imm8 & 0b1111) as u32, i)
 }
 
@@ -188,7 +188,7 @@ pub unsafe fn _mm_insert_epi8(a: i8x16, i: i8, imm8: u8) -> i8x16 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(pinsrd, imm8 = 0))]
-pub unsafe fn _mm_insert_epi32(a: i32x4, i: i32, imm8: u8) -> i32x4 {
+pub unsafe fn _mm_insert_epi32(a: i32x4, i: i32, imm8: i32) -> i32x4 {
     a.replace((imm8 & 0b11) as u32, i)
 }
 
@@ -391,7 +391,7 @@ pub unsafe fn _mm_cvtepu32_epi64(a: u32x4) -> i64x2 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(dppd, imm8 = 0))]
-pub unsafe fn _mm_dp_pd(a: f64x2, b: f64x2, imm8: u8) -> f64x2 {
+pub unsafe fn _mm_dp_pd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
     macro_rules! call {
         ($imm8:expr) => { dppd(a, b, $imm8) }
     }
@@ -408,7 +408,7 @@ pub unsafe fn _mm_dp_pd(a: f64x2, b: f64x2, imm8: u8) -> f64x2 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(dpps, imm8 = 0))]
-pub unsafe fn _mm_dp_ps(a: f32x4, b: f32x4, imm8: u8) -> f32x4 {
+pub unsafe fn _mm_dp_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
     macro_rules! call {
         ($imm8:expr) => { dpps(a, b, $imm8) }
     }
@@ -705,7 +705,7 @@ pub unsafe fn _mm_mullo_epi32(a: i32x4, b: i32x4) -> i32x4 {
 #[inline(always)]
 #[target_feature = "+sse4.1"]
 #[cfg_attr(test, assert_instr(mpsadbw, imm8 = 0))]
-pub unsafe fn _mm_mpsadbw_epu8(a: u8x16, b: u8x16, imm8: u8) -> u16x8 {
+pub unsafe fn _mm_mpsadbw_epu8(a: u8x16, b: u8x16, imm8: i32) -> u16x8 {
     macro_rules! call {
         ($imm8:expr) => { mpsadbw(a, b, $imm8) }
     }

--- a/coresimd/src/x86/i586/sse42.rs
+++ b/coresimd/src/x86/i586/sse42.rs
@@ -8,49 +8,49 @@ use stdsimd_test::assert_instr;
 use v128::*;
 
 /// String contains unsigned 8-bit characters *(Default)*
-pub const _SIDD_UBYTE_OPS: i8 = 0b0000_0000;
+pub const _SIDD_UBYTE_OPS: i32 = 0b0000_0000;
 /// String contains unsigned 16-bit characters
-pub const _SIDD_UWORD_OPS: i8 = 0b0000_0001;
+pub const _SIDD_UWORD_OPS: i32 = 0b0000_0001;
 /// String contains signed 8-bit characters
-pub const _SIDD_SBYTE_OPS: i8 = 0b0000_0010;
+pub const _SIDD_SBYTE_OPS: i32 = 0b0000_0010;
 /// String contains unsigned 16-bit characters
-pub const _SIDD_SWORD_OPS: i8 = 0b0000_0011;
+pub const _SIDD_SWORD_OPS: i32 = 0b0000_0011;
 
 /// For each character in `a`, find if it is in `b` *(Default)*
-pub const _SIDD_CMP_EQUAL_ANY: i8 = 0b0000_0000;
+pub const _SIDD_CMP_EQUAL_ANY: i32 = 0b0000_0000;
 /// For each character in `a`, determine if
 /// `b[0] <= c <= b[1] or b[1] <= c <= b[2]...`
-pub const _SIDD_CMP_RANGES: i8 = 0b0000_0100;
+pub const _SIDD_CMP_RANGES: i32 = 0b0000_0100;
 /// The strings defined by `a` and `b` are equal
-pub const _SIDD_CMP_EQUAL_EACH: i8 = 0b0000_1000;
+pub const _SIDD_CMP_EQUAL_EACH: i32 = 0b0000_1000;
 /// Search for the defined substring in the target
-pub const _SIDD_CMP_EQUAL_ORDERED: i8 = 0b0000_1100;
+pub const _SIDD_CMP_EQUAL_ORDERED: i32 = 0b0000_1100;
 
 /// Do not negate results *(Default)*
-pub const _SIDD_POSITIVE_POLARITY: i8 = 0b0000_0000;
+pub const _SIDD_POSITIVE_POLARITY: i32 = 0b0000_0000;
 /// Negate results
-pub const _SIDD_NEGATIVE_POLARITY: i8 = 0b0001_0000;
+pub const _SIDD_NEGATIVE_POLARITY: i32 = 0b0001_0000;
 /// Do not negate results before the end of the string
-pub const _SIDD_MASKED_POSITIVE_POLARITY: i8 = 0b0010_0000;
+pub const _SIDD_MASKED_POSITIVE_POLARITY: i32 = 0b0010_0000;
 /// Negate results only before the end of the string
-pub const _SIDD_MASKED_NEGATIVE_POLARITY: i8 = 0b0011_0000;
+pub const _SIDD_MASKED_NEGATIVE_POLARITY: i32 = 0b0011_0000;
 
 /// **Index only**: return the least significant bit *(Default)*
-pub const _SIDD_LEAST_SIGNIFICANT: i8 = 0b0000_0000;
+pub const _SIDD_LEAST_SIGNIFICANT: i32 = 0b0000_0000;
 /// **Index only**: return the most significant bit
-pub const _SIDD_MOST_SIGNIFICANT: i8 = 0b0100_0000;
+pub const _SIDD_MOST_SIGNIFICANT: i32 = 0b0100_0000;
 
 /// **Mask only**: return the bit mask
-pub const _SIDD_BIT_MASK: i8 = 0b0000_0000;
+pub const _SIDD_BIT_MASK: i32 = 0b0000_0000;
 /// **Mask only**: return the byte mask
-pub const _SIDD_UNIT_MASK: i8 = 0b0100_0000;
+pub const _SIDD_UNIT_MASK: i32 = 0b0100_0000;
 
 /// Compare packed strings with implicit lengths in `a` and `b` using the
 /// control in `imm8`, and return the generated mask.
 #[inline(always)]
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpistrm, imm8 = 0))]
-pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> __m128i {
+pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => { __m128i::from(pcmpistrm128(i8x16::from(a), i8x16::from(b), $imm8)) }
     }
@@ -270,7 +270,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i8) -> __m128i {
 #[inline(always)]
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
-pub unsafe fn _mm_cmpistri(a: __m128i, b: __m128i, imm8: i8) -> i32 {
+pub unsafe fn _mm_cmpistri(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpistri128(i8x16::from(a), i8x16::from(b), $imm8) }
     }
@@ -283,7 +283,7 @@ pub unsafe fn _mm_cmpistri(a: __m128i, b: __m128i, imm8: i8) -> i32 {
 #[inline(always)]
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
-pub unsafe fn _mm_cmpistrz(a: __m128i, b: __m128i, imm8: i8) -> i32 {
+pub unsafe fn _mm_cmpistrz(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpistriz128(i8x16::from(a),
                                         i8x16::from(b),
@@ -298,7 +298,7 @@ pub unsafe fn _mm_cmpistrz(a: __m128i, b: __m128i, imm8: i8) -> i32 {
 #[inline(always)]
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
-pub unsafe fn _mm_cmpistrc(a: __m128i, b: __m128i, imm8: i8) -> i32 {
+pub unsafe fn _mm_cmpistrc(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpistric128(i8x16::from(a), i8x16::from(b), $imm8) }
     }
@@ -311,7 +311,7 @@ pub unsafe fn _mm_cmpistrc(a: __m128i, b: __m128i, imm8: i8) -> i32 {
 #[inline(always)]
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
-pub unsafe fn _mm_cmpistrs(a: __m128i, b: __m128i, imm8: i8) -> i32 {
+pub unsafe fn _mm_cmpistrs(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpistris128(i8x16::from(a), i8x16::from(b), $imm8) }
     }
@@ -323,7 +323,7 @@ pub unsafe fn _mm_cmpistrs(a: __m128i, b: __m128i, imm8: i8) -> i32 {
 #[inline(always)]
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
-pub unsafe fn _mm_cmpistro(a: __m128i, b: __m128i, imm8: i8) -> i32 {
+pub unsafe fn _mm_cmpistro(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpistrio128(i8x16::from(a), i8x16::from(b), $imm8) }
     }
@@ -336,7 +336,7 @@ pub unsafe fn _mm_cmpistro(a: __m128i, b: __m128i, imm8: i8) -> i32 {
 #[inline(always)]
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
-pub unsafe fn _mm_cmpistra(a: __m128i, b: __m128i, imm8: i8) -> i32 {
+pub unsafe fn _mm_cmpistra(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpistria128(i8x16::from(a), i8x16::from(b), $imm8) }
     }
@@ -349,7 +349,7 @@ pub unsafe fn _mm_cmpistra(a: __m128i, b: __m128i, imm8: i8) -> i32 {
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpestrm, imm8 = 0))]
 pub unsafe fn _mm_cmpestrm(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8
+    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32
 ) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => { __m128i::from(pcmpestrm128(i8x16::from(a), la,
@@ -445,7 +445,7 @@ pub unsafe fn _mm_cmpestrm(
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestri(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8
+    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32
 ) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpestri128(i8x16::from(a), la, i8x16::from(b), lb, $imm8) }
@@ -460,7 +460,7 @@ pub unsafe fn _mm_cmpestri(
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestrz(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8
+    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32
 ) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpestriz128(i8x16::from(a), la, i8x16::from(b), lb, $imm8) }
@@ -475,7 +475,7 @@ pub unsafe fn _mm_cmpestrz(
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestrc(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8
+    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32
 ) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpestric128(i8x16::from(a), la, i8x16::from(b), lb, $imm8) }
@@ -490,7 +490,7 @@ pub unsafe fn _mm_cmpestrc(
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestrs(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8
+    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32
 ) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpestris128(i8x16::from(a), la, i8x16::from(b), lb, $imm8) }
@@ -505,7 +505,7 @@ pub unsafe fn _mm_cmpestrs(
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestro(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8
+    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32
 ) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpestrio128(i8x16::from(a), la, i8x16::from(b), lb, $imm8) }
@@ -521,7 +521,7 @@ pub unsafe fn _mm_cmpestro(
 #[target_feature = "+sse4.2"]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestra(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8
+    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32
 ) -> i32 {
     macro_rules! call {
         ($imm8:expr) => { pcmpestria128(i8x16::from(a), la, i8x16::from(b), lb, $imm8) }

--- a/coresimd/src/x86/i586/xsave.rs
+++ b/coresimd/src/x86/i586/xsave.rs
@@ -36,7 +36,7 @@ extern "C" {
 #[inline(always)]
 #[target_feature = "+xsave"]
 #[cfg_attr(test, assert_instr(xsave))]
-pub unsafe fn _xsave(mem_addr: *mut u8, save_mask: u64) -> () {
+pub unsafe fn _xsave(mem_addr: *mut u8, save_mask: u64) {
     xsave(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
 }
 
@@ -49,7 +49,7 @@ pub unsafe fn _xsave(mem_addr: *mut u8, save_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave"]
 #[cfg_attr(test, assert_instr(xrstor))]
-pub unsafe fn _xrstor(mem_addr: *const u8, rs_mask: u64) -> () {
+pub unsafe fn _xrstor(mem_addr: *const u8, rs_mask: u64) {
     xrstor(mem_addr, (rs_mask >> 32) as u32, rs_mask as u32);
 }
 
@@ -65,7 +65,7 @@ const _XCR_XFEATURE_ENABLED_MASK: u32 = 0;
 #[inline(always)]
 #[target_feature = "+xsave"]
 #[cfg_attr(test, assert_instr(xsetbv))]
-pub unsafe fn _xsetbv(a: u32, val: u64) -> () {
+pub unsafe fn _xsetbv(a: u32, val: u64) {
     xsetbv(a, (val >> 32) as u32, val as u32);
 }
 
@@ -88,7 +88,7 @@ pub unsafe fn _xgetbv(xcr_no: u32) -> u64 {
 #[inline(always)]
 #[target_feature = "+xsave,+xsaveopt"]
 #[cfg_attr(test, assert_instr(xsaveopt))]
-pub unsafe fn _xsaveopt(mem_addr: *mut u8, save_mask: u64) -> () {
+pub unsafe fn _xsaveopt(mem_addr: *mut u8, save_mask: u64) {
     xsaveopt(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
 }
 
@@ -101,7 +101,7 @@ pub unsafe fn _xsaveopt(mem_addr: *mut u8, save_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave,+xsavec"]
 #[cfg_attr(test, assert_instr(xsavec))]
-pub unsafe fn _xsavec(mem_addr: *mut u8, save_mask: u64) -> () {
+pub unsafe fn _xsavec(mem_addr: *mut u8, save_mask: u64) {
     xsavec(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
 }
 
@@ -115,7 +115,7 @@ pub unsafe fn _xsavec(mem_addr: *mut u8, save_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave,+xsaves"]
 #[cfg_attr(test, assert_instr(xsaves))]
-pub unsafe fn _xsaves(mem_addr: *mut u8, save_mask: u64) -> () {
+pub unsafe fn _xsaves(mem_addr: *mut u8, save_mask: u64) {
     xsaves(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
 }
 
@@ -131,7 +131,7 @@ pub unsafe fn _xsaves(mem_addr: *mut u8, save_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave,+xsaves"]
 #[cfg_attr(test, assert_instr(xrstors))]
-pub unsafe fn _xrstors(mem_addr: *const u8, rs_mask: u64) -> () {
+pub unsafe fn _xrstors(mem_addr: *const u8, rs_mask: u64) {
     xrstors(mem_addr, (rs_mask >> 32) as u32, rs_mask as u32);
 }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -8,7 +8,7 @@
 //!
 //! [intel64_ref]: http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
 
-use v64::{__m64, i16x4, i32x2, i8x8};
+use v64::*;
 use core::mem;
 
 #[cfg(test)]

--- a/coresimd/src/x86/i686/sse2.rs
+++ b/coresimd/src/x86/i686/sse2.rs
@@ -2,7 +2,7 @@
 
 use core::mem;
 use v128::*;
-use v64::{__m64, i32x2, u32x2};
+use v64::*;
 
 #[cfg(test)]
 use stdsimd_test::assert_instr;
@@ -22,8 +22,8 @@ pub unsafe fn _mm_add_si64(a: __m64, b: __m64) -> __m64 {
 #[inline(always)]
 #[target_feature = "+sse2"]
 #[cfg_attr(test, assert_instr(pmuludq))]
-pub unsafe fn _mm_mul_su32(a: u32x2, b: u32x2) -> u64 {
-    mem::transmute(pmuludq(mem::transmute(a), mem::transmute(b)))
+pub unsafe fn _mm_mul_su32(a: u32x2, b: u32x2) -> __m64 {
+    pmuludq(mem::transmute(a), mem::transmute(b))
 }
 
 /// Subtracts signed or unsigned 64-bit integer values and writes the
@@ -102,8 +102,8 @@ pub unsafe fn _mm_cvtsi128_si64x(a: i64x2) -> i64 {
 #[inline(always)]
 #[target_feature = "+sse2"]
 // no particular instruction to test
-pub unsafe fn _mm_set_epi64(e1: i64, e0: i64) -> i64x2 {
-    i64x2::new(e0, e1)
+pub unsafe fn _mm_set_epi64(e1: __m64, e0: __m64) -> i64x2 {
+    i64x2::new(mem::transmute(e0), mem::transmute(e1))
 }
 
 /// Initializes both values in a 128-bit vector of [2 x i64] with the
@@ -111,8 +111,8 @@ pub unsafe fn _mm_set_epi64(e1: i64, e0: i64) -> i64x2 {
 #[inline(always)]
 #[target_feature = "+sse2"]
 // no particular instruction to test
-pub unsafe fn _mm_set1_epi64(a: i64) -> i64x2 {
-    i64x2::new(a, a)
+pub unsafe fn _mm_set1_epi64(a: __m64) -> i64x2 {
+    i64x2::new(mem::transmute(a), mem::transmute(a))
 }
 
 /// Constructs a 128-bit integer vector, initialized in reverse order
@@ -120,26 +120,26 @@ pub unsafe fn _mm_set1_epi64(a: i64) -> i64x2 {
 #[inline(always)]
 #[target_feature = "+sse2"]
 // no particular instruction to test
-pub unsafe fn _mm_setr_epi64(e1: i64, e0: i64) -> i64x2 {
-    i64x2::new(e1, e0)
+pub unsafe fn _mm_setr_epi64(e1: __m64, e0: __m64) -> i64x2 {
+    i64x2::new(mem::transmute(e1), mem::transmute(e0))
 }
 
 /// Returns the lower 64 bits of a 128-bit integer vector as a 64-bit
 /// integer.
 #[inline(always)]
 #[target_feature = "+sse2"]
-// no particular instruction to test
-pub unsafe fn _mm_movepi64_pi64(a: i64x2) -> i64 {
-    a.extract(0)
+// #[cfg_attr(test, assert_instr(movdq2q))] // FIXME: llvm codegens wrong instr?
+pub unsafe fn _mm_movepi64_pi64(a: i64x2) -> __m64 {
+    mem::transmute(a.extract(0))
 }
 
 /// Moves the 64-bit operand to a 128-bit integer vector, zeroing the
 /// upper bits.
 #[inline(always)]
 #[target_feature = "+sse2"]
-// #[cfg_attr(test, assert_instr(movq2dq))] FIXME
-pub unsafe fn _mm_movpi64_epi64(a: i64) -> i64x2 {
-    i64x2::new(a, 0)
+// #[cfg_attr(test, assert_instr(movq2dq))] // FIXME: llvm codegens wrong instr?
+pub unsafe fn _mm_movpi64_epi64(a: __m64) -> i64x2 {
+    i64x2::new(mem::transmute(a), 0)
 }
 
 /// Converts the two double-precision floating-point elements of a
@@ -182,15 +182,12 @@ extern "C" {
 
 #[cfg(test)]
 mod tests {
+    use std::mem;
+
     use stdsimd_test::simd_test;
 
-    #[cfg(not(windows))]
-    use core::mem;
     use v128::*;
-    #[cfg(not(windows))]
-    use v64::{__m64, i32x2, u32x2};
-    #[cfg(windows)]
-    use v64::i32x2;
+    use v64::*;
     use x86::i686::sse2;
 
     #[simd_test = "sse2"]
@@ -210,7 +207,7 @@ mod tests {
         let b = u32x2::new(3, 4);
         let expected = 3u64;
         let r = sse2::_mm_mul_su32(a, b);
-        assert_eq!(r, expected);
+        assert_eq!(r, mem::transmute(expected));
     }
 
     #[simd_test = "sse2"]
@@ -252,31 +249,31 @@ mod tests {
 
     #[simd_test = "sse2"]
     unsafe fn _mm_set_epi64() {
-        let r = sse2::_mm_set_epi64(1, 2);
+        let r = sse2::_mm_set_epi64(mem::transmute(1i64), mem::transmute(2i64));
         assert_eq!(r, i64x2::new(2, 1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn _mm_set1_epi64() {
-        let r = sse2::_mm_set1_epi64(1);
+        let r = sse2::_mm_set1_epi64(mem::transmute(1i64));
         assert_eq!(r, i64x2::new(1, 1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn _mm_setr_epi64() {
-        let r = sse2::_mm_setr_epi64(1, 2);
+        let r = sse2::_mm_setr_epi64(mem::transmute(1i64), mem::transmute(2i64));
         assert_eq!(r, i64x2::new(1, 2));
     }
 
     #[simd_test = "sse2"]
     unsafe fn _mm_movepi64_pi64() {
         let r = sse2::_mm_movepi64_pi64(i64x2::new(5, 0));
-        assert_eq!(r, 5);
+        assert_eq!(r, mem::transmute(i8x8::new(5, 0, 0, 0, 0, 0, 0, 0)));
     }
 
     #[simd_test = "sse2"]
     unsafe fn _mm_movpi64_epi64() {
-        let r = sse2::_mm_movpi64_epi64(5);
+        let r = sse2::_mm_movpi64_epi64(mem::transmute(i8x8::new(5, 0, 0, 0, 0, 0, 0, 0)));
         assert_eq!(r, i64x2::new(5, 0));
     }
 

--- a/coresimd/src/x86/i686/sse41.rs
+++ b/coresimd/src/x86/i686/sse41.rs
@@ -15,31 +15,6 @@ extern "C" {
     fn ptestnzc(a: i64x2, mask: i64x2) -> i32;
 }
 
-/// Extract an 64-bit integer from `a` selected with `imm8`
-#[inline(always)]
-#[target_feature = "+sse4.1"]
-// TODO: Add test for Windows
-#[cfg_attr(all(test, not(windows), target_arch = "x86_64"),
-           assert_instr(pextrq, imm8 = 1))]
-// On x86 this emits 2 pextrd instructions
-#[cfg_attr(all(test, not(windows), target_arch = "x86"),
-           assert_instr(pextrd, imm8 = 1))]
-pub unsafe fn _mm_extract_epi64(a: i64x2, imm8: i32) -> i64 {
-    let imm8 = (imm8 & 1) as u32;
-    a.extract_unchecked(imm8)
-}
-
-/// Return a copy of `a` with the 64-bit integer from `i` inserted at a
-/// location specified by `imm8`.
-#[inline(always)]
-#[target_feature = "+sse4.1"]
-#[cfg_attr(all(test, target_arch = "x86_64"), assert_instr(pinsrq, imm8 = 0))]
-// On x86 this emits 2 pinsrd instructions
-#[cfg_attr(all(test, target_arch = "x86"), assert_instr(pinsrd, imm8 = 0))]
-pub unsafe fn _mm_insert_epi64(a: i64x2, i: i64, imm8: u8) -> i64x2 {
-    a.replace((imm8 & 0b1) as u32, i)
-}
-
 /// Tests whether the specified bits in a 128-bit integer vector are all
 /// zeros.
 ///
@@ -164,25 +139,6 @@ mod tests {
     use stdsimd_test::simd_test;
     use x86::i686::sse41;
     use v128::*;
-
-    #[simd_test = "sse4.1"]
-    unsafe fn _mm_extract_epi64() {
-        let a = i64x2::new(0, 1);
-        let r = sse41::_mm_extract_epi64(a, 1);
-        assert_eq!(r, 1);
-        let r = sse41::_mm_extract_epi64(a, 3);
-        assert_eq!(r, 1);
-    }
-
-    #[simd_test = "sse4.1"]
-    unsafe fn _mm_insert_epi64() {
-        let a = i64x2::splat(0);
-        let e = i64x2::splat(0).replace(1, 32);
-        let r = sse41::_mm_insert_epi64(a, 32, 1);
-        assert_eq!(r, e);
-        let r = sse41::_mm_insert_epi64(a, 32, 3);
-        assert_eq!(r, e);
-    }
 
     #[simd_test = "sse4.1"]
     unsafe fn _mm_testz_si128() {

--- a/coresimd/src/x86/i686/ssse3.rs
+++ b/coresimd/src/x86/i686/ssse3.rs
@@ -47,7 +47,7 @@ pub unsafe fn _mm_shuffle_pi8(a: u8x8, b: u8x8) -> u8x8 {
 #[inline(always)]
 #[target_feature = "+ssse3"]
 #[cfg_attr(test, assert_instr(palignr, n = 15))]
-pub unsafe fn _mm_alignr_pi8(a: u8x8, b: u8x8, n: u8) -> u8x8 {
+pub unsafe fn _mm_alignr_pi8(a: u8x8, b: u8x8, n: i32) -> u8x8 {
     macro_rules! call {
         ($imm8:expr) => {
             mem::transmute(palignrb(mem::transmute(a), mem::transmute(b), $imm8))

--- a/coresimd/src/x86/x86_64/mod.rs
+++ b/coresimd/src/x86/x86_64/mod.rs
@@ -9,6 +9,9 @@ pub use self::sse::*;
 mod sse2;
 pub use self::sse2::*;
 
+mod sse41;
+pub use self::sse41::*;
+
 mod sse42;
 pub use self::sse42::*;
 

--- a/coresimd/src/x86/x86_64/sse2.rs
+++ b/coresimd/src/x86/x86_64/sse2.rs
@@ -58,6 +58,40 @@ pub unsafe fn _mm_stream_si64(mem_addr: *mut i64, a: i64) {
     ::core::intrinsics::nontemporal_store(mem_addr, a);
 }
 
+/// Return a vector whose lowest element is `a` and all higher elements are
+/// `0`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(all(test, not(windows)), assert_instr(movq))]
+pub unsafe fn _mm_cvtsi64_si128(a: i64) -> i64x2 {
+    i64x2::new(a, 0)
+}
+
+/// Return a vector whose lowest element is `a` and all higher elements are
+/// `0`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(all(test, not(windows)), assert_instr(movq))]
+pub unsafe fn _mm_cvtsi64x_si128(a: i64) -> i64x2 {
+    _mm_cvtsi64_si128(a)
+}
+
+/// Return the lowest element of `a`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(all(test, not(windows)), assert_instr(movq))]
+pub unsafe fn _mm_cvtsi128_si64(a: i64x2) -> i64 {
+    a.extract(0)
+}
+
+/// Return the lowest element of `a`.
+#[inline(always)]
+#[target_feature = "+sse2"]
+#[cfg_attr(all(test, not(windows)), assert_instr(movq))]
+pub unsafe fn _mm_cvtsi128_si64x(a: i64x2) -> i64 {
+    _mm_cvtsi128_si64(a)
+}
+
 #[cfg(test)]
 mod tests {
     use stdsimd_test::simd_test;
@@ -106,5 +140,17 @@ mod tests {
         let mut mem = ::std::boxed::Box::<i64>::new(-1);
         sse2::_mm_stream_si64(&mut *mem as *mut i64, a);
         assert_eq!(a, *mem);
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsi64_si128() {
+        let r = sse2::_mm_cvtsi64_si128(5);
+        assert_eq!(r, i64x2::new(5, 0));
+    }
+
+    #[simd_test = "sse2"]
+    unsafe fn _mm_cvtsi128_si64() {
+        let r = sse2::_mm_cvtsi128_si64(i64x2::new(5, 0));
+        assert_eq!(r, 5);
     }
 }

--- a/coresimd/src/x86/x86_64/sse41.rs
+++ b/coresimd/src/x86/x86_64/sse41.rs
@@ -1,0 +1,49 @@
+use v128::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Extract an 64-bit integer from `a` selected with `imm8`
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+// TODO: Add test for Windows
+#[cfg_attr(all(test, not(windows)), assert_instr(pextrq, imm8 = 1))]
+pub unsafe fn _mm_extract_epi64(a: i64x2, imm8: i32) -> i64 {
+    let imm8 = (imm8 & 1) as u32;
+    a.extract_unchecked(imm8)
+}
+
+/// Return a copy of `a` with the 64-bit integer from `i` inserted at a
+/// location specified by `imm8`.
+#[inline(always)]
+#[target_feature = "+sse4.1"]
+#[cfg_attr(test, assert_instr(pinsrq, imm8 = 0))]
+pub unsafe fn _mm_insert_epi64(a: i64x2, i: i64, imm8: i32) -> i64x2 {
+    a.replace((imm8 & 0b1) as u32, i)
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+    use x86::x86_64::sse41;
+    use v128::*;
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_extract_epi64() {
+        let a = i64x2::new(0, 1);
+        let r = sse41::_mm_extract_epi64(a, 1);
+        assert_eq!(r, 1);
+        let r = sse41::_mm_extract_epi64(a, 3);
+        assert_eq!(r, 1);
+    }
+
+    #[simd_test = "sse4.1"]
+    unsafe fn _mm_insert_epi64() {
+        let a = i64x2::splat(0);
+        let e = i64x2::splat(0).replace(1, 32);
+        let r = sse41::_mm_insert_epi64(a, 32, 1);
+        assert_eq!(r, e);
+        let r = sse41::_mm_insert_epi64(a, 32, 3);
+        assert_eq!(r, e);
+    }
+}

--- a/coresimd/src/x86/x86_64/xsave.rs
+++ b/coresimd/src/x86/x86_64/xsave.rs
@@ -32,7 +32,7 @@ extern "C" {
 #[inline(always)]
 #[target_feature = "+xsave"]
 #[cfg_attr(test, assert_instr(xsave64))]
-pub unsafe fn _xsave64(mem_addr: *mut u8, save_mask: u64) -> () {
+pub unsafe fn _xsave64(mem_addr: *mut u8, save_mask: u64) {
     xsave64(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
 }
 
@@ -45,7 +45,7 @@ pub unsafe fn _xsave64(mem_addr: *mut u8, save_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave"]
 #[cfg_attr(test, assert_instr(xrstor64))]
-pub unsafe fn _xrstor64(mem_addr: *const u8, rs_mask: u64) -> () {
+pub unsafe fn _xrstor64(mem_addr: *const u8, rs_mask: u64) {
     xrstor64(mem_addr, (rs_mask >> 32) as u32, rs_mask as u32);
 }
 
@@ -59,7 +59,7 @@ pub unsafe fn _xrstor64(mem_addr: *const u8, rs_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave,+xsaveopt"]
 #[cfg_attr(test, assert_instr(xsaveopt64))]
-pub unsafe fn _xsaveopt64(mem_addr: *mut u8, save_mask: u64) -> () {
+pub unsafe fn _xsaveopt64(mem_addr: *mut u8, save_mask: u64) {
     xsaveopt64(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
 }
 
@@ -72,7 +72,7 @@ pub unsafe fn _xsaveopt64(mem_addr: *mut u8, save_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave,+xsavec"]
 #[cfg_attr(test, assert_instr(xsavec64))]
-pub unsafe fn _xsavec64(mem_addr: *mut u8, save_mask: u64) -> () {
+pub unsafe fn _xsavec64(mem_addr: *mut u8, save_mask: u64) {
     xsavec64(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
 }
 
@@ -86,7 +86,7 @@ pub unsafe fn _xsavec64(mem_addr: *mut u8, save_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave,+xsaves"]
 #[cfg_attr(test, assert_instr(xsaves64))]
-pub unsafe fn _xsaves64(mem_addr: *mut u8, save_mask: u64) -> () {
+pub unsafe fn _xsaves64(mem_addr: *mut u8, save_mask: u64) {
     xsaves64(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
 }
 
@@ -102,7 +102,7 @@ pub unsafe fn _xsaves64(mem_addr: *mut u8, save_mask: u64) -> () {
 #[inline(always)]
 #[target_feature = "+xsave,+xsaves"]
 #[cfg_attr(test, assert_instr(xrstors64))]
-pub unsafe fn _xrstors64(mem_addr: *const u8, rs_mask: u64) -> () {
+pub unsafe fn _xrstors64(mem_addr: *const u8, rs_mask: u64) {
     xrstors64(mem_addr, (rs_mask >> 32) as u32, rs_mask as u32);
 }
 

--- a/stdsimd-test/assert-instr-macro/src/lib.rs
+++ b/stdsimd-test/assert-instr-macro/src/lib.rs
@@ -40,10 +40,10 @@ pub fn assert_instr(
     };
     let name = &func.ident;
     let assert_name = syn::Ident::from(
-        &format!("assert_{}_{}", name.sym.as_str(), instr.sym.as_str())[..],
+        &format!("assert_{}_{}", name.as_ref(), instr.as_ref())[..],
     );
     let shim_name =
-        syn::Ident::from(&format!("{}_shim", name.sym.as_str())[..]);
+        syn::Ident::from(format!("{}_shim", name.as_ref()));
     let (to_test, test_name) = if invoc.args.len() == 0 {
         (TokenStream::empty(), &func.ident)
     } else {
@@ -59,7 +59,7 @@ pub fn assert_instr(
                 syn::Pat::Ident(ref i) => &i.ident,
                 _ => panic!("must have bare arguments"),
             };
-            match invoc.args.iter().find(|a| a.0 == ident.sym.as_str()) {
+            match invoc.args.iter().find(|a| a.0 == ident.as_ref()) {
                 Some(&(_, ref tts)) => {
                     input_vals.push(quote! { #tts });
                 }
@@ -78,8 +78,7 @@ pub fn assert_instr(
                     .get(0)
                     .item()
                     .ident
-                    .sym
-                    .as_str()
+                    .as_ref()
                     .starts_with("target")
             })
             .collect::<Vec<_>>();

--- a/stdsimd-verify/.gitattributes
+++ b/stdsimd-verify/.gitattributes
@@ -1,0 +1,1 @@
+*.xml binary

--- a/stdsimd-verify/Cargo.toml
+++ b/stdsimd-verify/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "stdsimd-verify"
+version = "0.1.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+
+[dependencies]
+proc-macro2 = { version = "0.1", features = ["unstable"] }
+quote = { git = 'https://github.com/dtolnay/quote' }
+syn = { git = 'https://github.com/dtolnay/syn', features =["full"] }
+
+[lib]
+proc-macro = true
+test = false
+
+[dev-dependencies]
+serde = "1.0"
+serde_derive = "1.0"
+serde-xml-rs = "0.2"

--- a/stdsimd-verify/build.rs
+++ b/stdsimd-verify/build.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+fn main() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root = dir.parent().unwrap();
+    let root = root.join("coresimd/src/x86");
+    walk(&root);
+}
+
+fn walk(root: &Path) {
+    for file in root.read_dir().unwrap() {
+        let file = file.unwrap();
+        if file.file_type().unwrap().is_dir() {
+            walk(&file.path());
+            continue
+        }
+        let path = file.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue
+        }
+
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}

--- a/stdsimd-verify/src/lib.rs
+++ b/stdsimd-verify/src/lib.rs
@@ -1,0 +1,244 @@
+#![feature(proc_macro)]
+
+extern crate proc_macro;
+extern crate proc_macro2;
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+use std::path::Path;
+use std::fs::File;
+use std::io::Read;
+
+use proc_macro::TokenStream;
+use quote::Tokens;
+
+macro_rules! my_quote {
+    ($($t:tt)*) => (quote_spanned!(proc_macro2::Span::call_site(), $($t)*))
+}
+
+#[proc_macro]
+pub fn x86_functions(input: TokenStream) -> TokenStream {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root = dir.parent().unwrap();
+    let root = root.join("coresimd/src/x86");
+
+    let mut files = Vec::new();
+    walk(&root, &mut files);
+
+    let mut functions = Vec::new();
+    for file in files {
+        for item in file.items {
+            match item {
+                syn::Item::Fn(f) => functions.push(f),
+                _ => {}
+            }
+        }
+    }
+
+    functions.retain(|f| {
+        match f.vis {
+            syn::Visibility::Public(_) => {}
+            _ => return false,
+        }
+        if f.unsafety.is_none() {
+            return false
+        }
+        f.attrs.iter()
+            .filter_map(|a| a.meta_item())
+            .any(|a| {
+                match a {
+                    syn::MetaItem::NameValue(i) => i.ident == "target_feature",
+                    _ => false,
+                }
+            })
+    });
+
+    let input = proc_macro2::TokenStream::from(input);
+
+    let functions = functions.iter()
+        .map(|f| {
+            let name = f.ident;
+            // println!("{}", name);
+            let mut arguments = Vec::new();
+            for input in f.decl.inputs.iter().map(|s| s.into_item()) {
+                let ty = match *input {
+                    syn::FnArg::Captured(ref c) => &c.ty,
+                    _ => panic!("invalid argument on {}", name),
+                };
+                arguments.push(to_type(ty));
+            }
+            let ret = match f.decl.output {
+                syn::ReturnType::Default => my_quote! { None },
+                syn::ReturnType::Type(_, ref t) => {
+                    let ty = to_type(t);
+                    my_quote! { Some(#ty) }
+                }
+            };
+            let instrs = find_instrs(&f.attrs);
+            let target_feature = find_target_feature(f.ident, &f.attrs);
+            my_quote! {
+                Function {
+                    name: stringify!(#name),
+                    arguments: &[#(#arguments),*],
+                    ret: #ret,
+                    target_feature: #target_feature,
+                    instrs: &[#(stringify!(#instrs)),*],
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let ret = my_quote! { #input: &[Function] = &[#(#functions),*]; };
+    // println!("{}", ret);
+    ret.into()
+}
+
+fn to_type(t: &syn::Type) -> Tokens {
+    match *t {
+        syn::Type::Path(ref p) => {
+            match extract_path_ident(&p.path).as_ref() {
+                "__m128i" => my_quote! { &I8x16 },
+                "__m256i" => my_quote! { &I8x32 },
+                "__m64" => my_quote! { &I8x8 },
+                "bool" => my_quote! { &BOOL },
+                "f32" => my_quote! { &F32 },
+                "f32x4" => my_quote! { &F32x4 },
+                "f32x8" => my_quote! { &F32x8 },
+                "f64" => my_quote! { &F64 },
+                "f64x2" => my_quote! { &F64x2 },
+                "f64x4" => my_quote! { &F64x4 },
+                "i16" => my_quote! { &I16 },
+                "i16x16" => my_quote! { &I16x16 },
+                "i16x4" => my_quote! { &I16x4 },
+                "i16x8" => my_quote! { &I16x8 },
+                "i32" => my_quote! { &I32 },
+                "i32x2" => my_quote! { &I32x2 },
+                "i32x4" => my_quote! { &I32x4 },
+                "i32x8" => my_quote! { &I32x8 },
+                "i64" => my_quote! { &I64 },
+                "i64x2" => my_quote! { &I64x2 },
+                "i64x4" => my_quote! { &I64x4 },
+                "i8" => my_quote! { &I8 },
+                "i8x16" => my_quote! { &I8x16 },
+                "i8x32" => my_quote! { &I8x32 },
+                "i8x8" => my_quote! { &I8x8 },
+                "u16x4" => my_quote! { &U16x4 },
+                "u16x8" => my_quote! { &U16x8 },
+                "u32" => my_quote! { &U32 },
+                "u32x2" => my_quote! { &U32x2 },
+                "u32x4" => my_quote! { &U32x4 },
+                "u32x8" => my_quote! { &U32x8 },
+                "u64" => my_quote! { &U64 },
+                "u64x2" => my_quote! { &U64x2 },
+                "u64x4" => my_quote! { &U64x4 },
+                "u8" => my_quote! { &U8 },
+                "u16" => my_quote! { &U16 },
+                "u8x16" => my_quote! { &U8x16 },
+                "u8x32" => my_quote! { &U8x32 },
+                "u16x16" => my_quote! { &U16x16 },
+                "u8x8" => my_quote! { &U8x8 },
+                s => panic!("unspported type: {}", s),
+            }
+        }
+        syn::Type::Ptr(syn::TypePtr { ref elem, .. }) |
+        syn::Type::Reference(syn::TypeReference { ref elem, .. }) => {
+            let tokens = to_type(&elem);
+            my_quote! { &Type::Ptr(#tokens) }
+        }
+        syn::Type::Slice(_) => panic!("unsupported slice"),
+        syn::Type::Array(_) => panic!("unsupported array"),
+        syn::Type::Tuple(_) => panic!("unsupported tup"),
+        _ => panic!("unsupported type"),
+    }
+}
+
+fn extract_path_ident(path: &syn::Path) -> syn::Ident {
+    if path.leading_colon.is_some() {
+        panic!("unsupported leading colon in path")
+    }
+    if path.segments.len() != 1 {
+        panic!("unsupported path that needs name resolution")
+    }
+    match path.segments.get(0).item().arguments {
+        syn::PathArguments::None => {}
+        _ => panic!("unsupported path that has path arguments")
+    }
+    path.segments.get(0).item().ident
+}
+
+fn walk(root: &Path, files: &mut Vec<syn::File>) {
+    for file in root.read_dir().unwrap() {
+        let file = file.unwrap();
+        if file.file_type().unwrap().is_dir() {
+            walk(&file.path(), files);
+            continue
+        }
+        let path = file.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue
+        }
+
+        let mut contents = String::new();
+        File::open(&path).unwrap().read_to_string(&mut contents).unwrap();
+
+        files.push(syn::parse_str::<syn::File>(&contents).expect("failed to parse"));
+    }
+}
+
+fn find_instrs(attrs: &[syn::Attribute]) -> Vec<syn::Ident> {
+    attrs.iter()
+        .filter_map(|a| a.meta_item())
+        .filter_map(|a| {
+            match a {
+                syn::MetaItem::List(i) => {
+                    if i.ident == "cfg_attr" {
+                        Some(i.nested.into_vec())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        })
+        .filter_map(|list| list.into_iter().nth(1))
+        .filter_map(|nested| {
+            match nested {
+                syn::NestedMetaItem::MetaItem(syn::MetaItem::List(i)) => {
+                    if i.ident == "assert_instr" {
+                        Some(i.nested.into_vec())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        })
+        .filter_map(|list| list.into_iter().next())
+        .filter_map(|nested| {
+            match nested {
+                syn::NestedMetaItem::MetaItem(syn::MetaItem::Term(i)) => Some(i),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn find_target_feature(name: syn::Ident, attrs: &[syn::Attribute]) -> syn::Lit {
+    attrs.iter()
+        .filter_map(|a| a.meta_item())
+        .filter_map(|a| {
+            match a {
+                syn::MetaItem::NameValue(i) => {
+                    if i.ident == "target_feature" {
+                        Some(i.lit)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        })
+        .next()
+        .expect(&format!("failed to find target_feature for {}",name))
+}

--- a/stdsimd-verify/tests/x86-intel.rs
+++ b/stdsimd-verify/tests/x86-intel.rs
@@ -1,0 +1,310 @@
+#![feature(proc_macro)]
+#![allow(bad_style)]
+
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_xml_rs;
+extern crate stdsimd_verify;
+
+use std::collections::HashMap;
+
+use stdsimd_verify::x86_functions;
+
+struct Function {
+    name: &'static str,
+    arguments: &'static [&'static Type],
+    ret: Option<&'static Type>,
+    target_feature: &'static str,
+    instrs: &'static [&'static str],
+}
+
+static BOOL: Type = Type::Bool;
+static F32: Type = Type::PrimFloat(32);
+static F32x4: Type = Type::Float(32, 4);
+static F32x8: Type = Type::Float(32, 8);
+static F64: Type = Type::PrimFloat(64);
+static F64x2: Type = Type::Float(64, 2);
+static F64x4: Type = Type::Float(64, 4);
+static I16: Type = Type::PrimSigned(16);
+static I16x16: Type = Type::Signed(16, 16);
+static I16x4: Type = Type::Signed(16, 4);
+static I16x8: Type = Type::Signed(16, 8);
+static I32: Type = Type::PrimSigned(32);
+static I32x2: Type = Type::Signed(32, 2);
+static I32x4: Type = Type::Signed(32, 4);
+static I32x8: Type = Type::Signed(32, 8);
+static I64: Type = Type::PrimSigned(64);
+static I64x2: Type = Type::Signed(64, 2);
+static I64x4: Type = Type::Signed(64, 4);
+static I8: Type = Type::PrimSigned(8);
+static I8x16: Type = Type::Signed(8, 16);
+static I8x32: Type = Type::Signed(8, 32);
+static I8x8: Type = Type::Signed(8, 8);
+static U16: Type = Type::PrimUnsigned(16);
+static U16x16: Type = Type::Unsigned(16, 16);
+static U16x4: Type = Type::Unsigned(16, 4);
+static U16x8: Type = Type::Unsigned(16, 8);
+static U32: Type = Type::PrimUnsigned(32);
+static U32x2: Type = Type::Unsigned(32, 2);
+static U32x4: Type = Type::Unsigned(32, 4);
+static U32x8: Type = Type::Unsigned(32, 8);
+static U64: Type = Type::PrimUnsigned(64);
+static U64x2: Type = Type::Unsigned(64, 2);
+static U64x4: Type = Type::Unsigned(64, 4);
+static U8: Type = Type::PrimUnsigned(8);
+static U8x16: Type = Type::Unsigned(8, 16);
+static U8x32: Type = Type::Unsigned(8, 32);
+static U8x8: Type = Type::Unsigned(8, 8);
+
+#[derive(Debug)]
+enum Type {
+    Float(u8, u8),
+    PrimFloat(u8),
+    PrimSigned(u8),
+    PrimUnsigned(u8),
+    Ptr(&'static Type),
+    Signed(u8, u8),
+    Unsigned(u8, u8),
+    Bool,
+}
+
+x86_functions!(static FUNCTIONS);
+
+#[derive(Deserialize)]
+struct Data {
+    #[serde(rename = "intrinsic", default)]
+    intrinsics: Vec<Intrinsic>,
+}
+
+#[derive(Deserialize)]
+struct Intrinsic {
+    rettype: String,
+    name: String,
+    tech: String,
+    #[serde(rename = "CPUID", default)]
+    cpuid: Vec<String>,
+    #[serde(rename = "parameter", default)]
+    parameters: Vec<Parameter>,
+    #[serde(default)]
+    instruction: Vec<Instruction>,
+}
+
+#[derive(Deserialize)]
+struct Parameter {
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Deserialize)]
+struct Instruction {
+    name: String,
+}
+
+#[test]
+fn verify_all_signatures() {
+    // This XML document was downloaded from Intel's site. To update this you
+    // can visit intel's intrinsics guide online documentation:
+    //
+    //   https://software.intel.com/sites/landingpage/IntrinsicsGuide/#
+    //
+    // Open up the network console and you'll see an xml file was downloaded
+    // (currently called data-3.4.xml). That's the file we downloaded
+    // here.
+    let xml = include_bytes!("../x86-intel.xml");
+
+    let xml = &xml[..];
+    let data: Data = serde_xml_rs::deserialize(xml).expect("failed to deserialize xml");
+    let mut map = HashMap::new();
+    for intrinsic in data.intrinsics.iter() {
+        // This intrinsic has multiple definitions in the XML, so just ignore it.
+        if intrinsic.name == "_mm_prefetch" {
+            continue
+        }
+
+        // These'll need to get added eventually, but right now they have some
+        // duplicate names in the XML which we're not dealing with yet
+        if intrinsic.tech == "AVX-512" {
+            continue
+        }
+
+        assert!(map.insert(&intrinsic.name[..], intrinsic).is_none());
+    }
+
+    for rust in FUNCTIONS {
+        // This was ignored above, we ignore it here as well.
+        if rust.name == "_mm_prefetch" {
+            continue
+        }
+
+        // these are all AMD-specific intrinsics
+        if rust.target_feature.contains("sse4a") ||
+            rust.target_feature.contains("tbm") {
+            continue
+        }
+
+        let intel = match map.get(rust.name) {
+            Some(i) => i,
+            None => panic!("missing intel definition for {}", rust.name),
+        };
+
+        // Verify that all `#[target_feature]` annotations are correct, ensuring
+        // that we've actually enabled the right instruction set for this
+        // intrinsic.
+        assert!(intel.cpuid.len() > 0, "missing cpuid for {}", rust.name);
+        for cpuid in intel.cpuid.iter() {
+            // this is needed by _xsave and probably some related intrinsics,
+            // but let's just skip it for now.
+            if *cpuid == "XSS" {
+                continue
+            }
+
+            let cpuid = cpuid
+                .chars()
+                .flat_map(|c| c.to_lowercase())
+                .collect::<String>();
+
+            // Normalize `bmi1` to `bmi` as apparently that's what we're calling
+            // it.
+            let cpuid = if cpuid == "bmi1" {
+                String::from("bmi")
+            } else {
+                cpuid
+            };
+
+            assert!(rust.target_feature.contains(&cpuid),
+                    "intel cpuid `{}` not in `{}` for {}",
+                    cpuid,
+                    rust.target_feature,
+                    rust.name);
+        }
+
+        // TODO: we should test this, but it generates too many failures right
+        // now
+        if false {
+            if rust.instrs.len() == 0 {
+                assert_eq!(intel.instruction.len(), 0,
+                           "instruction not listed for {}", rust.name);
+
+            // If intel doesn't list any instructions and we do then don't
+            // bother trying to look for instructions in intel, we've just got
+            // some extra assertions on our end.
+            } else if intel.instruction.len() > 0 {
+                for instr in rust.instrs.iter() {
+                    assert!(intel.instruction.iter().any(|a| a.name.starts_with(instr)),
+                            "intel failed to list `{}` as an instruction for `{}`",
+                            instr, rust.name);
+                }
+            }
+        }
+
+        // Make sure we've got the right return type.
+        match rust.ret {
+            Some(t) => equate(t, &intel.rettype, &rust.name),
+            None => {
+                assert!(intel.rettype == "" || intel.rettype == "void",
+                        "{} returns `{}` with intel, void in rust",
+                        rust.name, intel.rettype);
+            }
+        }
+
+        // If there's no arguments on Rust's side intel may list one "void"
+        // argument, so handle that here.
+        if rust.arguments.len() == 0 {
+            if intel.parameters.len() == 1 {
+                assert_eq!(intel.parameters[0].type_, "void");
+                continue
+            }
+        }
+
+        // Otherwise we want all parameters to be exactly the same
+        assert_eq!(rust.arguments.len(), intel.parameters.len(),
+                   "wrong number of arguments on {}", rust.name);
+        for (a, b) in intel.parameters.iter().zip(rust.arguments) {
+            equate(b, &a.type_, &intel.name);
+        }
+    }
+}
+
+fn equate(t: &Type, intel: &str, intrinsic: &str) {
+    let intel = intel.replace(" *", "*");
+    let intel = intel.replace(" const*", "*");
+    match (t, &intel[..]) {
+        (&Type::PrimFloat(32), "float") => {}
+        (&Type::PrimFloat(64), "double") => {}
+        (&Type::PrimSigned(16), "__int16") => {}
+        (&Type::PrimSigned(16), "short") => {}
+        (&Type::PrimSigned(32), "__int32") => {}
+        (&Type::PrimSigned(32), "const int") => {}
+        (&Type::PrimSigned(32), "int") => {}
+        (&Type::PrimSigned(64), "__int64") => {}
+        (&Type::PrimSigned(64), "long long") => {}
+        (&Type::PrimSigned(8), "__int8") => {}
+        (&Type::PrimSigned(8), "char") => {}
+        (&Type::PrimUnsigned(16), "unsigned short") => {}
+        (&Type::PrimUnsigned(32), "unsigned int") => {}
+        (&Type::PrimUnsigned(64), "unsigned __int64") => {}
+        (&Type::PrimUnsigned(8), "unsigned char") => {}
+
+        (&Type::Ptr(&Type::PrimFloat(32)), "float*") => {}
+        (&Type::Ptr(&Type::PrimFloat(64)), "double*") => {}
+        (&Type::Ptr(&Type::PrimSigned(32)), "int*") => {}
+        (&Type::Ptr(&Type::PrimSigned(64)), "__int64*") => {}
+        (&Type::Ptr(&Type::PrimSigned(8)), "char*") => {}
+        (&Type::Ptr(&Type::PrimUnsigned(32)), "unsigned int*") => {}
+        (&Type::Ptr(&Type::PrimUnsigned(64)), "unsigned __int64*") => {}
+        (&Type::Ptr(&Type::PrimUnsigned(8)), "const void*") => {}
+        (&Type::Ptr(&Type::PrimUnsigned(8)), "void*") => {}
+
+        (&Type::Signed(a, b), "__m128i") |
+        (&Type::Unsigned(a, b), "__m128i") |
+        (&Type::Ptr(&Type::Signed(a, b)), "__m128i*") |
+        (&Type::Ptr(&Type::Unsigned(a, b)), "__m128i*") if a * b == 128 => {}
+
+        (&Type::Signed(a, b), "__m256i") |
+        (&Type::Unsigned(a, b), "__m256i") |
+        (&Type::Ptr(&Type::Signed(a, b)), "__m256i*") |
+        (&Type::Ptr(&Type::Unsigned(a, b)), "__m256i*") if (a as u32) * (b as u32) == 256 => {}
+
+        (&Type::Signed(a, b), "__m64") |
+        (&Type::Unsigned(a, b), "__m64") |
+        (&Type::Ptr(&Type::Signed(a, b)), "__m64*") |
+        (&Type::Ptr(&Type::Unsigned(a, b)), "__m64*") if a * b == 64 => {}
+
+        (&Type::Float(32, 4), "__m128") => {}
+        (&Type::Ptr(&Type::Float(32, 4)), "__m128*") => {}
+
+        (&Type::Float(64, 2), "__m128d") => {}
+        (&Type::Ptr(&Type::Float(64, 2)), "__m128d*") => {}
+
+        (&Type::Float(32, 8), "__m256") => {}
+        (&Type::Ptr(&Type::Float(32, 8)), "__m256*") => {}
+
+        (&Type::Float(64, 4), "__m256d") => {}
+        (&Type::Ptr(&Type::Float(64, 4)), "__m256d*") => {}
+
+        // These two intrinsics return a 16-bit element but in Intel's
+        // intrinsics they're listed as returning an `int`.
+        (&Type::PrimSigned(16), "int") if intrinsic == "_mm_extract_pi16" => {}
+        (&Type::PrimSigned(16), "int") if intrinsic == "_m_pextrw" => {}
+
+        // This intrinsic takes an `i8` to get inserted into an i8 vector, but
+        // Intel says the argument is i32...
+        (&Type::PrimSigned(8), "int") if intrinsic == "_mm_insert_epi8" => {}
+
+        // This is a macro (?) in C which seems to mutate its arguments, but that
+        // means that we're taking pointers to arguments in rust as we're not
+        // exposing it as a macro.
+        (&Type::Ptr(&Type::Float(32, 4)), "__m128") if intrinsic == "_MM_TRANSPOSE4_PS" => {}
+
+        // These intrinsics return an `int` in C but they're always either the
+        // bit 1 or 0 so we switch it to returning `bool` in rust
+        (&Type::Bool, "int")
+            if intrinsic.starts_with("_mm_comi") && intrinsic.ends_with("_sd")
+            => {}
+        (&Type::Bool, "int")
+            if intrinsic.starts_with("_mm_ucomi") && intrinsic.ends_with("_sd")
+                => {}
+
+        _ => panic!("failed to equate: `{}` and {:?} for {}", intel, t, intrinsic),
+    }
+}


### PR DESCRIPTION
This commit adds a new crate for testing that the intrinsics listed in this
crate do indeed match the upstream definition of each intrinsic. A
pre-downloaded XML description of all Intel intrinsics is checked in which is
then parsed in the `stdsimd-verify` crate to verify that everything we write
down is matched against the upstream definitions.

Currently the checks are pretty loose to get this compiling but a few intrinsics
were fixed as a result of this. For example:

* `_mm256_extract_epi8` - AVX2 intrinsic erroneously listed under AVX
* `_mm256_extract_epi16` - AVX2 intrinsic erroneously listed under AVX
* `_mm256_extract_epi32` - AVX2 intrinsic erroneously listed under AVX
* `_mm256_extract_epi64` - AVX2 intrinsic erroneously listed under AVX
* `_mm_tzcnt_32` - erroneously had `u32` in the name
* `_mm_tzcnt_64` - erroneously had `u64` in the name
* `_mm_cvtsi64_si128` - erroneously available on 32-bit platforms
* `_mm_cvtsi64x_si128` - erroneously available on 32-bit platforms
* `_mm_cvtsi128_si64` - erroneously available on 32-bit platforms
* `_mm_cvtsi128_si64x` - erroneously available on 32-bit platforms
* `_mm_extract_epi64` - erroneously available on 32-bit platforms
* `_mm_insert_epi64` - erroneously available on 32-bit platforms
* `_mm256_extract_epi16` - erroneously returned i32 instead of i16
* `_mm256_extract_epi8` - erroneously returned i32 instead of i8
* `_mm_shuffle_ps` - the mask argument was erroneously i32 instead of u32
* `_popcnt32` - the signededness of the argument and return were flipped
* `_popcnt64` - the signededness of the argument was flipped and the argument
  was too large bit-wise
* `_mm_tzcnt_32` - the return value's sign was flipped
* `_mm_tzcnt_64` - the return value's sign was flipped
* A good number of intrinsics used `imm8: i8` or `imm8: u8` instead of `imm8:
  i32` which Intel was using. (we were also internally inconsistent)
* A number of intrinsics working with `__m64` were instead working with i64/u64,
  so they're now corrected to operate with the vector types instead.

Currently the verifications performed are:

* Each name in Rust is defined in the XML document
* The arguments/return values all agree.
* The CPUID features listed in the XML document are all enabled in Rust as well.

The type matching right now is pretty loose and has a lot of questionable
changes. Future commits will touch these up to be more strict and require closer
adherence with Intel's own types. Otherwise types like `i32x8` (or any integers
with 256 bits) all match up to `__m256i` right now, althoguh this may want to
change in the future.

Finally we're also not testing the instruction listed in the XML right now.
There's a huge number of discrepancies between the instruction listed in the XML
and the instruction listed in `assert_instr`, and those'll need to be taken care
of in a future commit.

Closes #240