### PR TITLE
Add bswap

### DIFF
--- a/coresimd/src/x86/i586/bswap.rs
+++ b/coresimd/src/x86/i586/bswap.rs
@@ -1,0 +1,45 @@
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Return an integer with the reversed byte order of x
+#[inline(always)]
+#[cfg_attr(test, assert_instr(bswap))]
+pub unsafe fn _bswap(x: i32) -> i32 {
+    bswap_i32(x)
+}
+
+/// Return an integer with the reversed byte order of x
+#[inline(always)]
+#[cfg_attr(test, assert_instr(bswap))]
+pub unsafe fn _bswap64(x: i64) -> i64 {
+    bswap_i64(x)
+}
+
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.bswap.i64"]
+    fn bswap_i64(x: i64) -> i64;
+    #[link_name = "llvm.bswap.i32"]
+    fn bswap_i32(x: i32) -> i32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bswap() {
+        unsafe {
+            assert_eq!(_bswap(0x0EADBE0F), 0x0FBEAD0E);
+            assert_eq!(_bswap(0x00000000), 0x00000000);
+        }
+    }
+
+    #[test]
+    fn test_bswap64() {
+        unsafe {
+            assert_eq!(_bswap64(0x0EADBEEFFADECA0E), 0x0ECADEFAEFBEAD0E);
+            assert_eq!(_bswap64(0x0000000000000000), 0x0000000000000000);
+        }
+    }
+}

--- a/coresimd/src/x86/i586/mod.rs
+++ b/coresimd/src/x86/i586/mod.rs
@@ -3,6 +3,8 @@
 pub use self::cpuid::*;
 pub use self::xsave::*;
 
+pub use self::bswap::*;
+
 pub use self::sse::*;
 pub use self::sse2::*;
 pub use self::sse3::*;
@@ -21,6 +23,8 @@ pub use self::tbm::*;
 
 mod cpuid;
 mod xsave;
+
+mod bswap;
 
 mod sse;
 mod sse2;


### PR DESCRIPTION
This uses LLVM's architecture-independent bswap intrinsic to mimic Intel's _bswap and _bswap64 intrinsics.

`bswap` was added to the 486, so I've added it to the i586 module.