### PR TITLE
Implement all addition MMX intrinsics

### DIFF
--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -40,6 +40,14 @@ pub unsafe fn _mm_add_pi16(a: __m64, b: __m64) -> __m64 {
     paddw(a, b)
 }
 
+/// Add packed 32-bit integers in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddd))]
+pub unsafe fn _mm_add_pi32(a: __m64, b: __m64) -> __m64 {
+    paddd(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -151,6 +159,8 @@ extern "C" {
     fn paddb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.padd.w"]
     fn paddw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.padd.d"]
+    fn paddd(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -207,6 +217,15 @@ mod tests {
         );
         let r = i16x4::from(mmx::_mm_add_pi16(a.into(), b.into()));
         let e = i16x4::new(i16::min_value(), 30000, -30000, i16::max_value());
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _mm_add_pi32() {
+        let a = i32x2::new(1, -1);
+        let b = i32x2::new(i32::max_value() - 1, i32::min_value() + 1);
+        let r = i32x2::from(mmx::_mm_add_pi32(a.into(), b.into()));
+        let e = i32x2::new(i32::max_value(), i32::min_value());
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -48,6 +48,14 @@ pub unsafe fn _mm_add_pi32(a: __m64, b: __m64) -> __m64 {
     paddd(a, b)
 }
 
+/// Add packed 8-bit integers in `a` and `b` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddsb))]
+pub unsafe fn _mm_adds_pi8(a: __m64, b: __m64) -> __m64 {
+    paddsb(a, b)
+}
+
 /// Add packed 16-bit integers in `a` and `b` using saturation.
 #[inline(always)]
 #[target_feature = "+mmx"]
@@ -169,6 +177,8 @@ extern "C" {
     fn paddw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.padd.d"]
     fn paddd(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.padds.b"]
+    fn paddsb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.padds.w"]
     fn paddsw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
@@ -236,6 +246,16 @@ mod tests {
         let b = i32x2::new(i32::max_value() - 1, i32::min_value() + 1);
         let r = i32x2::from(mmx::_mm_add_pi32(a.into(), b.into()));
         let e = i32x2::new(i32::max_value(), i32::min_value());
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _mm_adds_pi8() {
+        let a = i8x8::new(-100, -1, 1, 100, -1, 0, 1, 0);
+        let b = i8x8::new(-100, 1, -1, 100, 0, -1, 0, 1);
+        let r = i8x8::from(mmx::_mm_adds_pi8(a.into(), b.into()));
+        let e =
+            i8x8::new(i8::min_value(), 0, 0, i8::max_value(), -1, -1, 1, 1);
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -64,6 +64,14 @@ pub unsafe fn _mm_adds_pi16(a: __m64, b: __m64) -> __m64 {
     paddsw(a, b)
 }
 
+/// Add packed unsigned 8-bit integers in `a` and `b` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddusb))]
+pub unsafe fn _mm_adds_pu8(a: __m64, b: __m64) -> __m64 {
+    paddusb(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -181,6 +189,8 @@ extern "C" {
     fn paddsb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.padds.w"]
     fn paddsw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.paddus.b"]
+    fn paddusb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -207,7 +217,7 @@ extern "C" {
 
 #[cfg(test)]
 mod tests {
-    use v64::{__m64, i16x4, i32x2, i8x8};
+    use v64::{__m64, i16x4, i32x2, i8x8, u8x8};
     use x86::i686::mmx;
     use stdsimd_test::simd_test;
 
@@ -265,6 +275,15 @@ mod tests {
         let b = i16x4::new(-32000, 32000, -5, 1);
         let r = i16x4::from(mmx::_mm_adds_pi16(a.into(), b.into()));
         let e = i16x4::new(i16::min_value(), i16::max_value(), -1, 1);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _mm_adds_pu8() {
+        let a = u8x8::new(0, 1, 2, 3, 4, 5, 6, 200);
+        let b = u8x8::new(0, 10, 20, 30, 40, 50, 60, 200);
+        let r = u8x8::from(mmx::_mm_adds_pu8(a.into(), b.into()));
+        let e = u8x8::new(0, 11, 22, 33, 44, 55, 66, u8::max_value());
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -24,6 +24,14 @@ pub unsafe fn _mm_setzero_si64() -> __m64 {
     mem::transmute(0_i64)
 }
 
+/// Add packed 16-bit integers in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddw))]
+pub unsafe fn _mm_add_pi16(a: __m64, b: __m64) -> __m64 {
+    paddw(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -131,6 +139,8 @@ pub unsafe fn _mm_unpacklo_pi32(a: __m64, b: __m64) -> __m64 {
 
 #[allow(improper_ctypes)]
 extern "C" {
+    #[link_name = "llvm.x86.mmx.padd.w"]
+    fn paddw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -165,6 +175,15 @@ mod tests {
     unsafe fn _mm_setzero_si64() {
         let r: __m64 = ::std::mem::transmute(0_i64);
         assert_eq!(r, mmx::_mm_setzero_si64());
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _mm_add_pi16() {
+        let a = i16x4::new(-1, -1, 1, 1);
+        let b = i16x4::new(-65535, 30001, -30001, 65534);
+        let r = i16x4::from(mmx::_mm_add_pi16(a.into(), b.into()));
+        let e = i16x4::new(-65536, 30000, -30000, 65535);
+        assert_eq!(r, e);
     }
 
     #[simd_test = "mmx"]

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -48,6 +48,14 @@ pub unsafe fn _mm_add_pi32(a: __m64, b: __m64) -> __m64 {
     paddd(a, b)
 }
 
+/// Add packed 16-bit integers in `a` and `b` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddsw))]
+pub unsafe fn _mm_adds_pi16(a: __m64, b: __m64) -> __m64 {
+    paddsw(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -161,6 +169,8 @@ extern "C" {
     fn paddw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.padd.d"]
     fn paddd(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.padds.w"]
+    fn paddsw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -226,6 +236,15 @@ mod tests {
         let b = i32x2::new(i32::max_value() - 1, i32::min_value() + 1);
         let r = i32x2::from(mmx::_mm_add_pi32(a.into(), b.into()));
         let e = i32x2::new(i32::max_value(), i32::min_value());
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _mm_adds_pi16() {
+        let a = i16x4::new(-32000, 32000, 4, 0);
+        let b = i16x4::new(-32000, 32000, -5, 1);
+        let r = i16x4::from(mmx::_mm_adds_pi16(a.into(), b.into()));
+        let e = i16x4::new(i16::min_value(), i16::max_value(), -1, 1);
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -72,6 +72,14 @@ pub unsafe fn _mm_adds_pu8(a: __m64, b: __m64) -> __m64 {
     paddusb(a, b)
 }
 
+/// Add packed unsigned 16-bit integers in `a` and `b` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddusw))]
+pub unsafe fn _mm_adds_pu16(a: __m64, b: __m64) -> __m64 {
+    paddusw(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -191,6 +199,8 @@ extern "C" {
     fn paddsw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.paddus.b"]
     fn paddusb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.paddus.w"]
+    fn paddusw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -217,7 +227,7 @@ extern "C" {
 
 #[cfg(test)]
 mod tests {
-    use v64::{__m64, i16x4, i32x2, i8x8, u8x8};
+    use v64::{__m64, i16x4, i32x2, i8x8, u16x4, u8x8};
     use x86::i686::mmx;
     use stdsimd_test::simd_test;
 
@@ -284,6 +294,15 @@ mod tests {
         let b = u8x8::new(0, 10, 20, 30, 40, 50, 60, 200);
         let r = u8x8::from(mmx::_mm_adds_pu8(a.into(), b.into()));
         let e = u8x8::new(0, 11, 22, 33, 44, 55, 66, u8::max_value());
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _mm_adds_pu16() {
+        let a = u16x4::new(0, 1, 2, 60000);
+        let b = u16x4::new(0, 10, 20, 60000);
+        let r = u16x4::from(mmx::_mm_adds_pu16(a.into(), b.into()));
+        let e = u16x4::new(0, 11, 22, u16::max_value());
         assert_eq!(r, e);
     }
 


### PR DESCRIPTION
Regarding Issue #40.
* Implements all x86 MMX intrinsics regarding addition and adds basic unit tests for them.
    - `_mm_add_pi{8, 16, 32}`
    - `_mm_adds_pi{8, 16}`
    - `_mm_adds_pu{8, 16}`