### PR TITLE
MMX subtraction instructions

### DIFF
--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -131,6 +131,15 @@ pub unsafe fn _m_psubusb(a: __m64, b: __m64) -> __m64 {
     psubusb(a, b)
 }
 
+/// Subtract packed unsigned 16-bit integers in `b` from packed unsigned
+/// 16-bit integers in `a` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubusw))]
+pub unsafe fn _m_psubusw(a: __m64, b: __m64) -> __m64 {
+    psubusw(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -333,6 +342,8 @@ extern "C" {
     fn psubsw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.psubus.b"]
     fn psubusb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psubus.w"]
+    fn psubusw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -498,6 +509,15 @@ mod tests {
         let b = u8x8::new(60, 20, 30, 40, 30, 20, 10, 0);
         let r = u8x8::from(mmx::_m_psubusb(a.into(), b.into()));
         let e = u8x8::new(0, 0, 0, 0, 10, 40, 60, 80);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _m_psubusw() {
+        let a = u16x4::new(10000, 200, 0, 44444);
+        let b = u16x4::new(20000, 300, 1, 11111);
+        let r = u16x4::from(mmx::_m_psubusw(a.into(), b.into()));
+        let e = u16x4::new(0, 0, 0, 33333);
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -122,6 +122,15 @@ pub unsafe fn _m_psubsw(a: __m64, b: __m64) -> __m64 {
     psubsw(a, b)
 }
 
+/// Subtract packed unsigned 8-bit integers in `b` from packed unsigned 8-bit
+/// integers in `a` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubusb))]
+pub unsafe fn _m_psubusb(a: __m64, b: __m64) -> __m64 {
+    psubusb(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -322,6 +331,8 @@ extern "C" {
     fn psubsb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.psubs.w"]
     fn psubsw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psubus.b"]
+    fn psubusb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -478,6 +489,15 @@ mod tests {
         let b = i16x4::new(20000, -20000, -1, 1);
         let r = i16x4::from(mmx::_m_psubsw(a.into(), b.into()));
         let e = i16x4::new(i16::min_value(), i16::max_value(), 1, -1);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _m_psubusb() {
+        let a = u8x8::new(50, 10, 20, 30, 40, 60, 70, 80);
+        let b = u8x8::new(60, 20, 30, 40, 30, 20, 10, 0);
+        let r = u8x8::from(mmx::_m_psubusb(a.into(), b.into()));
+        let e = u8x8::new(0, 0, 0, 0, 10, 40, 60, 80);
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -113,6 +113,15 @@ pub unsafe fn _m_psubsb(a: __m64, b: __m64) -> __m64 {
     psubsb(a, b)
 }
 
+/// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`
+/// using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubsw))]
+pub unsafe fn _m_psubsw(a: __m64, b: __m64) -> __m64 {
+    psubsw(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -235,7 +244,9 @@ pub unsafe fn _mm_set_pi32(e1: i32, e0: i32) -> __m64 {
 /// Set packed 8-bit integers in dst with the supplied values.
 #[inline(always)]
 #[target_feature = "+mmx"]
-pub unsafe fn _mm_set_pi8(e7: i8, e6: i8, e5: i8, e4: i8, e3: i8, e2: i8, e1: i8, e0: i8) -> __m64 {
+pub unsafe fn _mm_set_pi8(
+    e7: i8, e6: i8, e5: i8, e4: i8, e3: i8, e2: i8, e1: i8, e0: i8
+) -> __m64 {
     _mm_setr_pi8(e0, e1, e2, e3, e4, e5, e6, e7)
 }
 
@@ -260,14 +271,16 @@ pub unsafe fn _mm_set1_pi8(a: i8) -> __m64 {
     _mm_setr_pi8(a, a, a, a, a, a, a, a)
 }
 
-/// Set packed 16-bit integers in dst with the supplied values in reverse order.
+/// Set packed 16-bit integers in dst with the supplied values in reverse
+/// order.
 #[inline(always)]
 #[target_feature = "+mmx"]
 pub unsafe fn _mm_setr_pi16(e0: i16, e1: i16, e2: i16, e3: i16) -> __m64 {
     mem::transmute(i16x4::new(e0, e1, e2, e3))
 }
 
-/// Set packed 32-bit integers in dst with the supplied values in reverse order.
+/// Set packed 32-bit integers in dst with the supplied values in reverse
+/// order.
 #[inline(always)]
 #[target_feature = "+mmx"]
 pub unsafe fn _mm_setr_pi32(e0: i32, e1: i32) -> __m64 {
@@ -277,7 +290,9 @@ pub unsafe fn _mm_setr_pi32(e0: i32, e1: i32) -> __m64 {
 /// Set packed 8-bit integers in dst with the supplied values in reverse order.
 #[inline(always)]
 #[target_feature = "+mmx"]
-pub unsafe fn _mm_setr_pi8(e0: i8, e1: i8, e2: i8, e3: i8, e4: i8, e5: i8, e6: i8, e7: i8) -> __m64 {
+pub unsafe fn _mm_setr_pi8(
+    e0: i8, e1: i8, e2: i8, e3: i8, e4: i8, e5: i8, e6: i8, e7: i8
+) -> __m64 {
     mem::transmute(i8x8::new(e0, e1, e2, e3, e4, e5, e6, e7))
 }
 
@@ -305,6 +320,8 @@ extern "C" {
     fn psubd(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.psubs.b"]
     fn psubsb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psubs.w"]
+    fn psubsw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -452,6 +469,15 @@ mod tests {
             -8,
             8,
         );
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _m_psubsw() {
+        let a = i16x4::new(-20000, 20000, 0, 0);
+        let b = i16x4::new(20000, -20000, -1, 1);
+        let r = i16x4::from(mmx::_m_psubsw(a.into(), b.into()));
+        let e = i16x4::new(i16::min_value(), i16::max_value(), 1, -1);
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -104,6 +104,15 @@ pub unsafe fn _m_psubd(a: __m64, b: __m64) -> __m64 {
     psubd(a, b)
 }
 
+/// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`
+/// using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubsb))]
+pub unsafe fn _m_psubsb(a: __m64, b: __m64) -> __m64 {
+    psubsb(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -294,6 +303,8 @@ extern "C" {
     fn psubw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.psub.d"]
     fn psubd(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psubs.b"]
+    fn psubsb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -423,6 +434,24 @@ mod tests {
         let b = i32x2::new(500_000, 500_000);
         let r = i32x2::from(mmx::_m_psubd(a.into(), b.into()));
         let e = i32x2::new(0, -1_000_000);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _m_psubsb() {
+        let a = i8x8::new(-100, 100, 0, 0, 0, 0, -5, 5);
+        let b = i8x8::new(100, -100, i8::min_value(), 127, -1, 1, 3, -3);
+        let r = i8x8::from(mmx::_m_psubsb(a.into(), b.into()));
+        let e = i8x8::new(
+            i8::min_value(),
+            i8::max_value(),
+            i8::max_value(),
+            -127,
+            1,
+            -1,
+            -8,
+            8,
+        );
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -96,6 +96,14 @@ pub unsafe fn _m_psubw(a: __m64, b: __m64) -> __m64 {
     psubw(a, b)
 }
 
+/// Subtract packed 32-bit integers in `b` from packed 32-bit integers in `a`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubd))]
+pub unsafe fn _m_psubd(a: __m64, b: __m64) -> __m64 {
+    psubd(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -284,6 +292,8 @@ extern "C" {
     fn psubb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.psub.w"]
     fn psubw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psub.d"]
+    fn psubd(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -404,6 +414,15 @@ mod tests {
         let b = i16x4::new(-10000, 10000, -10000, 30000);
         let r = i16x4::from(mmx::_m_psubw(a.into(), b.into()));
         let e = i16x4::new(-10000, -30000, 30000, 0);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _m_psubd() {
+        let a = i32x2::new(500_000, -500_000);
+        let b = i32x2::new(500_000, 500_000);
+        let r = i32x2::from(mmx::_m_psubd(a.into(), b.into()));
+        let e = i32x2::new(0, -1_000_000);
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -80,6 +80,14 @@ pub unsafe fn _mm_adds_pu16(a: __m64, b: __m64) -> __m64 {
     paddusw(a, b)
 }
 
+/// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubb))]
+pub unsafe fn _m_psubb(a: __m64, b: __m64) -> __m64 {
+    psubb(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -264,6 +272,8 @@ extern "C" {
     fn paddusb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.paddus.w"]
     fn paddusw(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psub.b"]
+    fn psubb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -366,6 +376,15 @@ mod tests {
         let b = u16x4::new(0, 10, 20, 60000);
         let r = u16x4::from(mmx::_mm_adds_pu16(a.into(), b.into()));
         let e = u16x4::new(0, 11, 22, u16::max_value());
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _m_psubb() {
+        let a = i8x8::new(0, 0, 1, 1, -1, -1, 0, 0);
+        let b = i8x8::new(-1, 1, -2, 2, 100, -100, -127, 127);
+        let r = i8x8::from(mmx::_m_psubb(a.into(), b.into()));
+        let e = i8x8::new(1, -1, 3, -1, -101, 99, 127, -127);
         assert_eq!(r, e);
     }
 

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -88,6 +88,14 @@ pub unsafe fn _mm_sub_pi8(a: __m64, b: __m64) -> __m64 {
     psubb(a, b)
 }
 
+/// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubb))]
+pub unsafe fn _m_psubb(a: __m64, b: __m64) -> __m64 {
+    _mm_sub_pi8(a, b)
+}
+
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`.
 #[inline(always)]
 #[target_feature = "+mmx"]
@@ -96,12 +104,28 @@ pub unsafe fn _mm_sub_pi16(a: __m64, b: __m64) -> __m64 {
     psubw(a, b)
 }
 
+/// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubw))]
+pub unsafe fn _m_psubw(a: __m64, b: __m64) -> __m64 {
+    _mm_sub_pi16(a, b)
+}
+
 /// Subtract packed 32-bit integers in `b` from packed 32-bit integers in `a`.
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(psubd))]
 pub unsafe fn _mm_sub_pi32(a: __m64, b: __m64) -> __m64 {
     psubd(a, b)
+}
+
+/// Subtract packed 32-bit integers in `b` from packed 32-bit integers in `a`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubd))]
+pub unsafe fn _m_psubd(a: __m64, b: __m64) -> __m64 {
+    _mm_sub_pi32(a, b)
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`
@@ -113,6 +137,15 @@ pub unsafe fn _mm_subs_pi8(a: __m64, b: __m64) -> __m64 {
     psubsb(a, b)
 }
 
+/// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`
+/// using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubsb))]
+pub unsafe fn _m_psubsb(a: __m64, b: __m64) -> __m64 {
+    _mm_subs_pi8(a, b)
+}
+
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`
 /// using saturation.
 #[inline(always)]
@@ -120,6 +153,15 @@ pub unsafe fn _mm_subs_pi8(a: __m64, b: __m64) -> __m64 {
 #[cfg_attr(test, assert_instr(psubsw))]
 pub unsafe fn _mm_subs_pi16(a: __m64, b: __m64) -> __m64 {
     psubsw(a, b)
+}
+
+/// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`
+/// using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubsw))]
+pub unsafe fn _m_psubsw(a: __m64, b: __m64) -> __m64 {
+    _mm_subs_pi16(a, b)
 }
 
 /// Subtract packed unsigned 8-bit integers in `b` from packed unsigned 8-bit
@@ -131,6 +173,15 @@ pub unsafe fn _mm_subs_pu8(a: __m64, b: __m64) -> __m64 {
     psubusb(a, b)
 }
 
+/// Subtract packed unsigned 8-bit integers in `b` from packed unsigned 8-bit
+/// integers in `a` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubusb))]
+pub unsafe fn _m_psubusb(a: __m64, b: __m64) -> __m64 {
+    _mm_subs_pu8(a, b)
+}
+
 /// Subtract packed unsigned 16-bit integers in `b` from packed unsigned
 /// 16-bit integers in `a` using saturation.
 #[inline(always)]
@@ -138,6 +189,15 @@ pub unsafe fn _mm_subs_pu8(a: __m64, b: __m64) -> __m64 {
 #[cfg_attr(test, assert_instr(psubusw))]
 pub unsafe fn _mm_subs_pu16(a: __m64, b: __m64) -> __m64 {
     psubusw(a, b)
+}
+
+/// Subtract packed unsigned 16-bit integers in `b` from packed unsigned
+/// 16-bit integers in `a` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubusw))]
+pub unsafe fn _m_psubusw(a: __m64, b: __m64) -> __m64 {
+    _mm_subs_pu16(a, b)
 }
 
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
@@ -453,34 +513,33 @@ mod tests {
     unsafe fn _mm_sub_pi8() {
         let a = i8x8::new(0, 0, 1, 1, -1, -1, 0, 0);
         let b = i8x8::new(-1, 1, -2, 2, 100, -100, -127, 127);
-        let r = i8x8::from(mmx::_mm_sub_pi8(a.into(), b.into()));
         let e = i8x8::new(1, -1, 3, -1, -101, 99, 127, -127);
-        assert_eq!(r, e);
+        assert_eq!(e, i8x8::from(mmx::_mm_sub_pi8(a.into(), b.into())));
+        assert_eq!(e, i8x8::from(mmx::_m_psubb(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
-    unsafe fn _m_psubw() {
+    unsafe fn _mm_sub_pi16() {
         let a = i16x4::new(-20000, -20000, 20000, 30000);
         let b = i16x4::new(-10000, 10000, -10000, 30000);
-        let r = i16x4::from(mmx::_mm_sub_pi16(a.into(), b.into()));
         let e = i16x4::new(-10000, -30000, 30000, 0);
-        assert_eq!(r, e);
+        assert_eq!(e, i16x4::from(mmx::_mm_sub_pi16(a.into(), b.into())));
+        assert_eq!(e, i16x4::from(mmx::_m_psubw(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_sub_pi32() {
         let a = i32x2::new(500_000, -500_000);
         let b = i32x2::new(500_000, 500_000);
-        let r = i32x2::from(mmx::_mm_sub_pi32(a.into(), b.into()));
         let e = i32x2::new(0, -1_000_000);
-        assert_eq!(r, e);
+        assert_eq!(e, i32x2::from(mmx::_mm_sub_pi32(a.into(), b.into())));
+        assert_eq!(e, i32x2::from(mmx::_m_psubd(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_subs_pi8() {
         let a = i8x8::new(-100, 100, 0, 0, 0, 0, -5, 5);
         let b = i8x8::new(100, -100, i8::min_value(), 127, -1, 1, 3, -3);
-        let r = i8x8::from(mmx::_mm_subs_pi8(a.into(), b.into()));
         let e = i8x8::new(
             i8::min_value(),
             i8::max_value(),
@@ -491,34 +550,35 @@ mod tests {
             -8,
             8,
         );
-        assert_eq!(r, e);
+        assert_eq!(e, i8x8::from(mmx::_mm_subs_pi8(a.into(), b.into())));
+        assert_eq!(e, i8x8::from(mmx::_m_psubsb(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_subs_pi16() {
         let a = i16x4::new(-20000, 20000, 0, 0);
         let b = i16x4::new(20000, -20000, -1, 1);
-        let r = i16x4::from(mmx::_mm_subs_pi16(a.into(), b.into()));
         let e = i16x4::new(i16::min_value(), i16::max_value(), 1, -1);
-        assert_eq!(r, e);
+        assert_eq!(e, i16x4::from(mmx::_mm_subs_pi16(a.into(), b.into())));
+        assert_eq!(e, i16x4::from(mmx::_m_psubsw(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_subs_pu8() {
         let a = u8x8::new(50, 10, 20, 30, 40, 60, 70, 80);
         let b = u8x8::new(60, 20, 30, 40, 30, 20, 10, 0);
-        let r = u8x8::from(mmx::_mm_subs_pu8(a.into(), b.into()));
         let e = u8x8::new(0, 0, 0, 0, 10, 40, 60, 80);
-        assert_eq!(r, e);
+        assert_eq!(e, u8x8::from(mmx::_mm_subs_pu8(a.into(), b.into())));
+        assert_eq!(e, u8x8::from(mmx::_m_psubusb(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_subs_pu16() {
         let a = u16x4::new(10000, 200, 0, 44444);
         let b = u16x4::new(20000, 300, 1, 11111);
-        let r = u16x4::from(mmx::_mm_subs_pu16(a.into(), b.into()));
         let e = u16x4::new(0, 0, 0, 33333);
-        assert_eq!(r, e);
+        assert_eq!(e, u16x4::from(mmx::_mm_subs_pu16(a.into(), b.into())));
+        assert_eq!(e, u16x4::from(mmx::_m_psubusw(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -84,7 +84,7 @@ pub unsafe fn _mm_adds_pu16(a: __m64, b: __m64) -> __m64 {
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(psubb))]
-pub unsafe fn _m_psubb(a: __m64, b: __m64) -> __m64 {
+pub unsafe fn _mm_sub_pi8(a: __m64, b: __m64) -> __m64 {
     psubb(a, b)
 }
 
@@ -92,7 +92,7 @@ pub unsafe fn _m_psubb(a: __m64, b: __m64) -> __m64 {
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(psubw))]
-pub unsafe fn _m_psubw(a: __m64, b: __m64) -> __m64 {
+pub unsafe fn _mm_sub_pi16(a: __m64, b: __m64) -> __m64 {
     psubw(a, b)
 }
 
@@ -100,7 +100,7 @@ pub unsafe fn _m_psubw(a: __m64, b: __m64) -> __m64 {
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(psubd))]
-pub unsafe fn _m_psubd(a: __m64, b: __m64) -> __m64 {
+pub unsafe fn _mm_sub_pi32(a: __m64, b: __m64) -> __m64 {
     psubd(a, b)
 }
 
@@ -109,7 +109,7 @@ pub unsafe fn _m_psubd(a: __m64, b: __m64) -> __m64 {
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(psubsb))]
-pub unsafe fn _m_psubsb(a: __m64, b: __m64) -> __m64 {
+pub unsafe fn _mm_subs_pi8(a: __m64, b: __m64) -> __m64 {
     psubsb(a, b)
 }
 
@@ -118,7 +118,7 @@ pub unsafe fn _m_psubsb(a: __m64, b: __m64) -> __m64 {
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(psubsw))]
-pub unsafe fn _m_psubsw(a: __m64, b: __m64) -> __m64 {
+pub unsafe fn _mm_subs_pi16(a: __m64, b: __m64) -> __m64 {
     psubsw(a, b)
 }
 
@@ -127,7 +127,7 @@ pub unsafe fn _m_psubsw(a: __m64, b: __m64) -> __m64 {
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(psubusb))]
-pub unsafe fn _m_psubusb(a: __m64, b: __m64) -> __m64 {
+pub unsafe fn _mm_subs_pu8(a: __m64, b: __m64) -> __m64 {
     psubusb(a, b)
 }
 
@@ -136,7 +136,7 @@ pub unsafe fn _m_psubusb(a: __m64, b: __m64) -> __m64 {
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(psubusw))]
-pub unsafe fn _m_psubusw(a: __m64, b: __m64) -> __m64 {
+pub unsafe fn _mm_subs_pu16(a: __m64, b: __m64) -> __m64 {
     psubusw(a, b)
 }
 
@@ -450,10 +450,10 @@ mod tests {
     }
 
     #[simd_test = "mmx"]
-    unsafe fn _m_psubb() {
+    unsafe fn _mm_sub_pi8() {
         let a = i8x8::new(0, 0, 1, 1, -1, -1, 0, 0);
         let b = i8x8::new(-1, 1, -2, 2, 100, -100, -127, 127);
-        let r = i8x8::from(mmx::_m_psubb(a.into(), b.into()));
+        let r = i8x8::from(mmx::_mm_sub_pi8(a.into(), b.into()));
         let e = i8x8::new(1, -1, 3, -1, -101, 99, 127, -127);
         assert_eq!(r, e);
     }
@@ -462,25 +462,25 @@ mod tests {
     unsafe fn _m_psubw() {
         let a = i16x4::new(-20000, -20000, 20000, 30000);
         let b = i16x4::new(-10000, 10000, -10000, 30000);
-        let r = i16x4::from(mmx::_m_psubw(a.into(), b.into()));
+        let r = i16x4::from(mmx::_mm_sub_pi16(a.into(), b.into()));
         let e = i16x4::new(-10000, -30000, 30000, 0);
         assert_eq!(r, e);
     }
 
     #[simd_test = "mmx"]
-    unsafe fn _m_psubd() {
+    unsafe fn _mm_sub_pi32() {
         let a = i32x2::new(500_000, -500_000);
         let b = i32x2::new(500_000, 500_000);
-        let r = i32x2::from(mmx::_m_psubd(a.into(), b.into()));
+        let r = i32x2::from(mmx::_mm_sub_pi32(a.into(), b.into()));
         let e = i32x2::new(0, -1_000_000);
         assert_eq!(r, e);
     }
 
     #[simd_test = "mmx"]
-    unsafe fn _m_psubsb() {
+    unsafe fn _mm_subs_pi8() {
         let a = i8x8::new(-100, 100, 0, 0, 0, 0, -5, 5);
         let b = i8x8::new(100, -100, i8::min_value(), 127, -1, 1, 3, -3);
-        let r = i8x8::from(mmx::_m_psubsb(a.into(), b.into()));
+        let r = i8x8::from(mmx::_mm_subs_pi8(a.into(), b.into()));
         let e = i8x8::new(
             i8::min_value(),
             i8::max_value(),
@@ -495,28 +495,28 @@ mod tests {
     }
 
     #[simd_test = "mmx"]
-    unsafe fn _m_psubsw() {
+    unsafe fn _mm_subs_pi16() {
         let a = i16x4::new(-20000, 20000, 0, 0);
         let b = i16x4::new(20000, -20000, -1, 1);
-        let r = i16x4::from(mmx::_m_psubsw(a.into(), b.into()));
+        let r = i16x4::from(mmx::_mm_subs_pi16(a.into(), b.into()));
         let e = i16x4::new(i16::min_value(), i16::max_value(), 1, -1);
         assert_eq!(r, e);
     }
 
     #[simd_test = "mmx"]
-    unsafe fn _m_psubusb() {
+    unsafe fn _mm_subs_pu8() {
         let a = u8x8::new(50, 10, 20, 30, 40, 60, 70, 80);
         let b = u8x8::new(60, 20, 30, 40, 30, 20, 10, 0);
-        let r = u8x8::from(mmx::_m_psubusb(a.into(), b.into()));
+        let r = u8x8::from(mmx::_mm_subs_pu8(a.into(), b.into()));
         let e = u8x8::new(0, 0, 0, 0, 10, 40, 60, 80);
         assert_eq!(r, e);
     }
 
     #[simd_test = "mmx"]
-    unsafe fn _m_psubusw() {
+    unsafe fn _mm_subs_pu16() {
         let a = u16x4::new(10000, 200, 0, 44444);
         let b = u16x4::new(20000, 300, 1, 11111);
-        let r = u16x4::from(mmx::_m_psubusw(a.into(), b.into()));
+        let r = u16x4::from(mmx::_mm_subs_pu16(a.into(), b.into()));
         let e = u16x4::new(0, 0, 0, 33333);
         assert_eq!(r, e);
     }

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -88,6 +88,14 @@ pub unsafe fn _m_psubb(a: __m64, b: __m64) -> __m64 {
     psubb(a, b)
 }
 
+/// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(psubw))]
+pub unsafe fn _m_psubw(a: __m64, b: __m64) -> __m64 {
+    psubw(a, b)
+}
+
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
 ///
@@ -274,6 +282,8 @@ extern "C" {
     fn paddusw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.psub.b"]
     fn psubb(a: __m64, b: __m64) -> __m64;
+    #[link_name = "llvm.x86.mmx.psub.w"]
+    fn psubw(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packsswb"]
     fn packsswb(a: __m64, b: __m64) -> __m64;
     #[link_name = "llvm.x86.mmx.packssdw"]
@@ -385,6 +395,15 @@ mod tests {
         let b = i8x8::new(-1, 1, -2, 2, 100, -100, -127, 127);
         let r = i8x8::from(mmx::_m_psubb(a.into(), b.into()));
         let e = i8x8::new(1, -1, 3, -1, -101, 99, 127, -127);
+        assert_eq!(r, e);
+    }
+
+    #[simd_test = "mmx"]
+    unsafe fn _m_psubw() {
+        let a = i16x4::new(-20000, -20000, 20000, 30000);
+        let b = i16x4::new(-10000, 10000, -10000, 30000);
+        let r = i16x4::from(mmx::_m_psubw(a.into(), b.into()));
+        let e = i16x4::new(-10000, -30000, 30000, 0);
         assert_eq!(r, e);
     }
 


### PR DESCRIPTION
Implement all MMX subtraction instructions
- `_m_psubb` and `_mm_sub_pi8`
- `_m_psubw` and `_mm_sub_pi16`
- `_m_psubd` and `_mm_sub_pi32`
- `_m_psubsb` and `_mm_subs_pi8`
- `_m_psubsw` and `_mm_subs_pi16`
- `_m_psubusb` and `_mm_subs_pu8`
- `_m_psubusw` and `_mm_subs_pu16`
