### PR TITLE
Implement MMX addition aliases

### DIFF
--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -32,12 +32,28 @@ pub unsafe fn _mm_add_pi8(a: __m64, b: __m64) -> __m64 {
     paddb(a, b)
 }
 
+/// Add packed 8-bit integers in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddb))]
+pub unsafe fn _m_paddb(a: __m64, b: __m64) -> __m64 {
+    _mm_add_pi8(a, b)
+}
+
 /// Add packed 16-bit integers in `a` and `b`.
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(paddw))]
 pub unsafe fn _mm_add_pi16(a: __m64, b: __m64) -> __m64 {
     paddw(a, b)
+}
+
+/// Add packed 16-bit integers in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddw))]
+pub unsafe fn _m_paddw(a: __m64, b: __m64) -> __m64 {
+    _mm_add_pi16(a, b)
 }
 
 /// Add packed 32-bit integers in `a` and `b`.
@@ -48,12 +64,28 @@ pub unsafe fn _mm_add_pi32(a: __m64, b: __m64) -> __m64 {
     paddd(a, b)
 }
 
+/// Add packed 32-bit integers in `a` and `b`.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddd))]
+pub unsafe fn _m_paddd(a: __m64, b: __m64) -> __m64 {
+    _mm_add_pi32(a, b)
+}
+
 /// Add packed 8-bit integers in `a` and `b` using saturation.
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(paddsb))]
 pub unsafe fn _mm_adds_pi8(a: __m64, b: __m64) -> __m64 {
     paddsb(a, b)
+}
+
+/// Add packed 8-bit integers in `a` and `b` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddsb))]
+pub unsafe fn _m_paddsb(a: __m64, b: __m64) -> __m64 {
+    _mm_adds_pi8(a, b)
 }
 
 /// Add packed 16-bit integers in `a` and `b` using saturation.
@@ -64,6 +96,14 @@ pub unsafe fn _mm_adds_pi16(a: __m64, b: __m64) -> __m64 {
     paddsw(a, b)
 }
 
+/// Add packed 16-bit integers in `a` and `b` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddsw))]
+pub unsafe fn _m_paddsw(a: __m64, b: __m64) -> __m64 {
+    _mm_adds_pi16(a, b)
+}
+
 /// Add packed unsigned 8-bit integers in `a` and `b` using saturation.
 #[inline(always)]
 #[target_feature = "+mmx"]
@@ -72,12 +112,28 @@ pub unsafe fn _mm_adds_pu8(a: __m64, b: __m64) -> __m64 {
     paddusb(a, b)
 }
 
+/// Add packed unsigned 8-bit integers in `a` and `b` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddusb))]
+pub unsafe fn _m_paddusb(a: __m64, b: __m64) -> __m64 {
+    _mm_adds_pu8(a, b)
+}
+
 /// Add packed unsigned 16-bit integers in `a` and `b` using saturation.
 #[inline(always)]
 #[target_feature = "+mmx"]
 #[cfg_attr(test, assert_instr(paddusw))]
 pub unsafe fn _mm_adds_pu16(a: __m64, b: __m64) -> __m64 {
     paddusw(a, b)
+}
+
+/// Add packed unsigned 16-bit integers in `a` and `b` using saturation.
+#[inline(always)]
+#[target_feature = "+mmx"]
+#[cfg_attr(test, assert_instr(paddusw))]
+pub unsafe fn _m_paddusw(a: __m64, b: __m64) -> __m64 {
+    _mm_adds_pu16(a, b)
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`.
@@ -444,9 +500,9 @@ mod tests {
     unsafe fn _mm_add_pi8() {
         let a = i8x8::new(-1, -1, 1, 1, -1, 0, 1, 0);
         let b = i8x8::new(-127, 101, 99, 126, 0, -1, 0, 1);
-        let r = i8x8::from(mmx::_mm_add_pi8(a.into(), b.into()));
         let e = i8x8::new(-128, 100, 100, 127, -1, -1, 1, 1);
-        assert_eq!(r, e);
+        assert_eq!(e, i8x8::from(mmx::_mm_add_pi8(a.into(), b.into())));
+        assert_eq!(e, i8x8::from(mmx::_m_paddb(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
@@ -458,55 +514,55 @@ mod tests {
             -30001,
             i16::max_value() - 1,
         );
-        let r = i16x4::from(mmx::_mm_add_pi16(a.into(), b.into()));
         let e = i16x4::new(i16::min_value(), 30000, -30000, i16::max_value());
-        assert_eq!(r, e);
+        assert_eq!(e, i16x4::from(mmx::_mm_add_pi16(a.into(), b.into())));
+        assert_eq!(e, i16x4::from(mmx::_m_paddw(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_add_pi32() {
         let a = i32x2::new(1, -1);
         let b = i32x2::new(i32::max_value() - 1, i32::min_value() + 1);
-        let r = i32x2::from(mmx::_mm_add_pi32(a.into(), b.into()));
         let e = i32x2::new(i32::max_value(), i32::min_value());
-        assert_eq!(r, e);
+        assert_eq!(e, i32x2::from(mmx::_mm_add_pi32(a.into(), b.into())));
+        assert_eq!(e, i32x2::from(mmx::_m_paddd(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_adds_pi8() {
         let a = i8x8::new(-100, -1, 1, 100, -1, 0, 1, 0);
         let b = i8x8::new(-100, 1, -1, 100, 0, -1, 0, 1);
-        let r = i8x8::from(mmx::_mm_adds_pi8(a.into(), b.into()));
         let e =
             i8x8::new(i8::min_value(), 0, 0, i8::max_value(), -1, -1, 1, 1);
-        assert_eq!(r, e);
+        assert_eq!(e, i8x8::from(mmx::_mm_adds_pi8(a.into(), b.into())));
+        assert_eq!(e, i8x8::from(mmx::_m_paddsb(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_adds_pi16() {
         let a = i16x4::new(-32000, 32000, 4, 0);
         let b = i16x4::new(-32000, 32000, -5, 1);
-        let r = i16x4::from(mmx::_mm_adds_pi16(a.into(), b.into()));
         let e = i16x4::new(i16::min_value(), i16::max_value(), -1, 1);
-        assert_eq!(r, e);
+        assert_eq!(e, i16x4::from(mmx::_mm_adds_pi16(a.into(), b.into())));
+        assert_eq!(e, i16x4::from(mmx::_m_paddsw(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_adds_pu8() {
         let a = u8x8::new(0, 1, 2, 3, 4, 5, 6, 200);
         let b = u8x8::new(0, 10, 20, 30, 40, 50, 60, 200);
-        let r = u8x8::from(mmx::_mm_adds_pu8(a.into(), b.into()));
         let e = u8x8::new(0, 11, 22, 33, 44, 55, 66, u8::max_value());
-        assert_eq!(r, e);
+        assert_eq!(e, u8x8::from(mmx::_mm_adds_pu8(a.into(), b.into())));
+        assert_eq!(e, u8x8::from(mmx::_m_paddusb(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]
     unsafe fn _mm_adds_pu16() {
         let a = u16x4::new(0, 1, 2, 60000);
         let b = u16x4::new(0, 10, 20, 60000);
-        let r = u16x4::from(mmx::_mm_adds_pu16(a.into(), b.into()));
         let e = u16x4::new(0, 11, 22, u16::max_value());
-        assert_eq!(r, e);
+        assert_eq!(e, u16x4::from(mmx::_mm_adds_pu16(a.into(), b.into())));
+        assert_eq!(e, u16x4::from(mmx::_m_paddusw(a.into(), b.into())));
     }
 
     #[simd_test = "mmx"]


### PR DESCRIPTION
- `_m_paddb` for `_mm_add_pi8`
- `_m_paddw` for `_mm_add_pi16`
- `_m_paddd` for `_mm_add_pi32`
- `_m_paddsb` for `_mm_adds_pi8`
- `_m_paddsw` for `_mm_adds_pi16`
- `_m_paddusb` for `_mm_adds_pu8`
- `_m_paddusw` for `_mm_adds_pu16`