### PR TITLE
Reduce implicit reliance on structure of __m* types

### DIFF
--- a/coresimd/src/x86/i586/sse2.rs
+++ b/coresimd/src/x86/i586/sse2.rs
@@ -948,7 +948,9 @@ pub unsafe fn _mm_stream_si32(mem_addr: *mut i32, a: i32) {
 #[cfg_attr(all(test, not(windows), target_arch = "x86_64"),
            assert_instr(movq))]
 pub unsafe fn _mm_move_epi64(a: __m128i) -> __m128i {
-    simd_shuffle2(a, _mm_setzero_si128(), [0, 2])
+    let zero = _mm_setzero_si128();
+    let r: i64x2 = simd_shuffle2(a.as_i64x2(), zero.as_i64x2(), [0, 2]);
+    mem::transmute(r)
 }
 
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
@@ -2088,7 +2090,7 @@ pub unsafe fn _mm_castpd_ps(a: __m128d) -> __m128 {
 #[inline(always)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_castpd_si128(a: __m128d) -> __m128i {
-    simd_cast(a)
+    mem::transmute::<i64x2, _>(simd_cast(a))
 }
 
 /// Casts a 128-bit floating-point vector of [4 x float] into a 128-bit
@@ -2112,7 +2114,7 @@ pub unsafe fn _mm_castps_si128(a: __m128) -> __m128i {
 #[inline(always)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_castsi128_pd(a: __m128i) -> __m128d {
-    simd_cast(a)
+    simd_cast(a.as_i64x2())
 }
 
 /// Casts a 128-bit integer vector into a 128-bit floating-point vector

--- a/coresimd/src/x86/i686/sse2.rs
+++ b/coresimd/src/x86/i686/sse2.rs
@@ -80,7 +80,7 @@ pub unsafe fn _mm_setr_epi64(e1: __m64, e0: __m64) -> __m128i {
 // #[cfg_attr(test, assert_instr(movdq2q))] // FIXME: llvm codegens wrong
 // instr?
 pub unsafe fn _mm_movepi64_pi64(a: __m128i) -> __m64 {
-    mem::transmute(simd_extract::<_, i64>(a, 0))
+    mem::transmute(simd_extract::<_, i64>(a.as_i64x2(), 0))
 }
 
 /// Moves the 64-bit operand to a 128-bit integer vector, zeroing the

--- a/coresimd/src/x86/i686/sse41.rs
+++ b/coresimd/src/x86/i686/sse41.rs
@@ -9,11 +9,11 @@ use stdsimd_test::assert_instr;
 #[allow(improper_ctypes)]
 extern "C" {
     #[link_name = "llvm.x86.sse41.ptestz"]
-    fn ptestz(a: __m128i, mask: __m128i) -> i32;
+    fn ptestz(a: i64x2, mask: i64x2) -> i32;
     #[link_name = "llvm.x86.sse41.ptestc"]
-    fn ptestc(a: __m128i, mask: __m128i) -> i32;
+    fn ptestc(a: i64x2, mask: i64x2) -> i32;
     #[link_name = "llvm.x86.sse41.ptestnzc"]
-    fn ptestnzc(a: __m128i, mask: __m128i) -> i32;
+    fn ptestnzc(a: i64x2, mask: i64x2) -> i32;
 }
 
 /// Tests whether the specified bits in a 128-bit integer vector are all
@@ -33,7 +33,7 @@ extern "C" {
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(ptest))]
 pub unsafe fn _mm_testz_si128(a: __m128i, mask: __m128i) -> i32 {
-    ptestz(a, mask)
+    ptestz(a.as_i64x2(), mask.as_i64x2())
 }
 
 /// Tests whether the specified bits in a 128-bit integer vector are all
@@ -53,7 +53,7 @@ pub unsafe fn _mm_testz_si128(a: __m128i, mask: __m128i) -> i32 {
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(ptest))]
 pub unsafe fn _mm_testc_si128(a: __m128i, mask: __m128i) -> i32 {
-    ptestc(a, mask)
+    ptestc(a.as_i64x2(), mask.as_i64x2())
 }
 
 /// Tests whether the specified bits in a 128-bit integer vector are
@@ -73,7 +73,7 @@ pub unsafe fn _mm_testc_si128(a: __m128i, mask: __m128i) -> i32 {
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(ptest))]
 pub unsafe fn _mm_testnzc_si128(a: __m128i, mask: __m128i) -> i32 {
-    ptestnzc(a, mask)
+    ptestnzc(a.as_i64x2(), mask.as_i64x2())
 }
 
 /// Tests whether the specified bits in a 128-bit integer vector are all

--- a/coresimd/src/x86/x86_64/sse2.rs
+++ b/coresimd/src/x86/x86_64/sse2.rs
@@ -82,7 +82,7 @@ pub unsafe fn _mm_cvtsi64x_si128(a: i64) -> __m128i {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movq))]
 pub unsafe fn _mm_cvtsi128_si64(a: __m128i) -> i64 {
-    simd_extract(a, 0)
+    simd_extract(a.as_i64x2(), 0)
 }
 
 /// Return the lowest element of `a`.


### PR DESCRIPTION
They need to be structured *somehow* to be the right bit width but ideally we
wouldn't have the intrinsics rely on the particulars about how they're
represented.