### PR TITLE
Remove PartialEq impls for x86 types

### DIFF
--- a/coresimd/src/x86/i586/avx.rs
+++ b/coresimd/src/x86/i586/avx.rs
@@ -3041,7 +3041,7 @@ mod tests {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let r = _mm256_cvtps_epi32(a);
         let e = _mm256_setr_epi32(4, 9, 16, 25, 4, 9, 16, 25);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3073,7 +3073,7 @@ mod tests {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let r = _mm256_cvttps_epi32(a);
         let e = _mm256_setr_epi32(4, 9, 16, 25, 4, 9, 16, 25);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3202,7 +3202,7 @@ mod tests {
         let b = _mm256_setr_epi32(5, 6, 7, 8, 5, 6, 7, 8);
         let r = _mm256_permute2f128_si256(a, b, 0x20);
         let e = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3266,7 +3266,7 @@ mod tests {
         let b = _mm_setr_epi64x(5, 6);
         let r = _mm256_insertf128_si256(a, b, 0);
         let e = _mm256_setr_epi64x(5, 6, 3, 4);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3286,7 +3286,7 @@ mod tests {
             17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 0,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3296,7 +3296,7 @@ mod tests {
         let r = _mm256_insert_epi16(a, 0, 15);
         let e =
             _mm256_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3304,7 +3304,7 @@ mod tests {
         let a = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_insert_epi32(a, 0, 7);
         let e = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3312,7 +3312,7 @@ mod tests {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let r = _mm256_insert_epi64(a, 0, 3);
         let e = _mm256_setr_epi64x(1, 2, 3, 0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3389,7 +3389,7 @@ mod tests {
         let p = &a as *const _;
         let r = _mm256_load_si256(p);
         let e = _mm256_setr_epi64x(1, 2, 3, 4);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3397,7 +3397,7 @@ mod tests {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let mut r = _mm256_undefined_si256();
         _mm256_store_si256(&mut r as *mut _, a);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx"]
@@ -3406,7 +3406,7 @@ mod tests {
         let p = &a as *const _;
         let r = _mm256_loadu_si256(black_box(p));
         let e = _mm256_setr_epi64x(1, 2, 3, 4);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3414,7 +3414,7 @@ mod tests {
         let a = _mm256_set1_epi8(9);
         let mut r = _mm256_undefined_si256();
         _mm256_storeu_si256(&mut r as *mut _, a);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx"]
@@ -3539,7 +3539,7 @@ mod tests {
             17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3547,7 +3547,7 @@ mod tests {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let mut r = _mm256_undefined_si256();
         _mm256_stream_si256(&mut r as *mut _, a);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx"]
@@ -3841,7 +3841,7 @@ mod tests {
     #[simd_test = "avx"]
     unsafe fn test_mm256_setzero_si256() {
         let r = _mm256_setzero_si256();
-        assert_eq!(r, _mm256_set1_epi8(0));
+        assert_eq_m256i(r, _mm256_set1_epi8(0));
     }
 
     #[simd_test = "avx"]
@@ -3872,7 +3872,7 @@ mod tests {
             16, 15, 14, 13, 12, 11, 10, 9,
             8, 7, 6, 5, 4, 3, 2, 1
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3882,7 +3882,7 @@ mod tests {
             1, 2, 3, 4, 5, 6, 7, 8,
             9, 10, 11, 12, 13, 14, 15, 16,
         );
-        assert_eq!(
+        assert_eq_m256i(
             r,
             _mm256_setr_epi16(16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
         );
@@ -3891,13 +3891,13 @@ mod tests {
     #[simd_test = "avx"]
     unsafe fn test_mm256_set_epi32() {
         let r = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
-        assert_eq!(r, _mm256_setr_epi32(8, 7, 6, 5, 4, 3, 2, 1));
+        assert_eq_m256i(r, _mm256_setr_epi32(8, 7, 6, 5, 4, 3, 2, 1));
     }
 
     #[simd_test = "avx"]
     unsafe fn test_mm256_set_epi64x() {
         let r = _mm256_set_epi64x(1, 2, 3, 4);
-        assert_eq!(r, _mm256_setr_epi64x(4, 3, 2, 1));
+        assert_eq_m256i(r, _mm256_setr_epi64x(4, 3, 2, 1));
     }
 
     #[simd_test = "avx"]
@@ -3929,7 +3929,7 @@ mod tests {
             25, 26, 27, 28, 29, 30, 31, 32
         );
 
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3939,7 +3939,7 @@ mod tests {
             1, 2, 3, 4, 5, 6, 7, 8,
             9, 10, 11, 12, 13, 14, 15, 16,
         );
-        assert_eq!(
+        assert_eq_m256i(
             r,
             _mm256_setr_epi16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
         );
@@ -3948,13 +3948,13 @@ mod tests {
     #[simd_test = "avx"]
     unsafe fn test_mm256_setr_epi32() {
         let r = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
-        assert_eq!(r, _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8));
+        assert_eq_m256i(r, _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8));
     }
 
     #[simd_test = "avx"]
     unsafe fn test_mm256_setr_epi64x() {
         let r = _mm256_setr_epi64x(1, 2, 3, 4);
-        assert_eq!(r, _mm256_setr_epi64x(1, 2, 3, 4));
+        assert_eq_m256i(r, _mm256_setr_epi64x(1, 2, 3, 4));
     }
 
     #[simd_test = "avx"]
@@ -3972,25 +3972,25 @@ mod tests {
     #[simd_test = "avx"]
     unsafe fn test_mm256_set1_epi8() {
         let r = _mm256_set1_epi8(1);
-        assert_eq!(r, _mm256_set1_epi8(1));
+        assert_eq_m256i(r, _mm256_set1_epi8(1));
     }
 
     #[simd_test = "avx"]
     unsafe fn test_mm256_set1_epi16() {
         let r = _mm256_set1_epi16(1);
-        assert_eq!(r, _mm256_set1_epi16(1));
+        assert_eq_m256i(r, _mm256_set1_epi16(1));
     }
 
     #[simd_test = "avx"]
     unsafe fn test_mm256_set1_epi32() {
         let r = _mm256_set1_epi32(1);
-        assert_eq!(r, _mm256_set1_epi32(1));
+        assert_eq_m256i(r, _mm256_set1_epi32(1));
     }
 
     #[simd_test = "avx"]
     unsafe fn test_mm256_set1_epi64x() {
         let r = _mm256_set1_epi64x(1);
-        assert_eq!(r, _mm256_set1_epi64x(1));
+        assert_eq_m256i(r, _mm256_set1_epi64x(1));
     }
 
     #[simd_test = "avx"]
@@ -4020,7 +4020,7 @@ mod tests {
             0, 0, -96, 64, 0, 0, -64, 64,
             0, 0, -32, 64, 0, 0, 0, 65,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -4085,7 +4085,7 @@ mod tests {
         let a = _mm_setr_epi64x(1, 2);
         let r = _mm256_zextsi128_si256(a);
         let e = _mm256_setr_epi64x(1, 2, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -4138,7 +4138,7 @@ mod tests {
             17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -4181,7 +4181,7 @@ mod tests {
             17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -4226,7 +4226,7 @@ mod tests {
             17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx"]

--- a/coresimd/src/x86/i586/avx.rs
+++ b/coresimd/src/x86/i586/avx.rs
@@ -3057,7 +3057,7 @@ mod tests {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let r = _mm256_cvttpd_epi32(a);
         let e = _mm_setr_epi32(4, 9, 16, 25);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3065,7 +3065,7 @@ mod tests {
         let a = _mm256_setr_pd(4., 9., 16., 25.);
         let r = _mm256_cvtpd_epi32(a);
         let e = _mm_setr_epi32(4, 9, 16, 25);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -3097,7 +3097,7 @@ mod tests {
         let a = _mm256_setr_epi64x(4, 3, 2, 5);
         let r = _mm256_extractf128_si256(a, 0);
         let e = _mm_setr_epi64x(4, 3);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx"]
@@ -4069,7 +4069,7 @@ mod tests {
     unsafe fn test_mm256_castsi256_si128() {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let r = _mm256_castsi256_si128(a);
-        assert_eq!(r, _mm_setr_epi64x(1, 2));
+        assert_eq_m128i(r, _mm_setr_epi64x(1, 2));
     }
 
     #[simd_test = "avx"]
@@ -4280,8 +4280,8 @@ mod tests {
             9, 10, 11, 12, 13, 14, 15, 16
         );
 
-        assert_eq!(hi, e_hi);
-        assert_eq!(lo, e_lo);
+        assert_eq_m128i(hi, e_hi);
+        assert_eq_m128i(lo, e_lo);
     }
 
     #[simd_test = "avx"]

--- a/coresimd/src/x86/i586/avx2.rs
+++ b/coresimd/src/x86/i586/avx2.rs
@@ -3452,10 +3452,10 @@ mod tests {
         let (a, b) = (_mm_set1_epi32(3), _mm_set1_epi32(9));
         let e = _mm_setr_epi32(9, 3, 3, 3);
         let r = _mm_blend_epi32(a, b, 0x01 as i32);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         let r = _mm_blend_epi32(b, a, 0x0E as i32);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3498,7 +3498,7 @@ mod tests {
     unsafe fn test_mm_broadcastb_epi8() {
         let a = _mm_insert_epi8(_mm_set1_epi8(0x00), 0x2a, 0);
         let res = _mm_broadcastb_epi8(a);
-        assert_eq!(res, _mm_set1_epi8(0x2a));
+        assert_eq_m128i(res, _mm_set1_epi8(0x2a));
     }
 
     #[simd_test = "avx2"]
@@ -3512,7 +3512,7 @@ mod tests {
     unsafe fn test_mm_broadcastd_epi32() {
         let a = _mm_setr_epi32(0x2a, 0x8000000, 0, 0);
         let res = _mm_broadcastd_epi32(a);
-        assert_eq!(res, _mm_set1_epi32(0x2a));
+        assert_eq_m128i(res, _mm_set1_epi32(0x2a));
     }
 
     #[simd_test = "avx2"]
@@ -3526,7 +3526,7 @@ mod tests {
     unsafe fn test_mm_broadcastq_epi64() {
         let a = _mm_setr_epi64x(0x1ffffffff, 0);
         let res = _mm_broadcastq_epi64(a);
-        assert_eq!(res, _mm_set1_epi64x(0x1ffffffff));
+        assert_eq_m128i(res, _mm_set1_epi64x(0x1ffffffff));
     }
 
     #[simd_test = "avx2"]
@@ -3581,7 +3581,7 @@ mod tests {
     unsafe fn test_mm_broadcastw_epi16() {
         let a = _mm_insert_epi16(_mm_set1_epi16(0x2a), 0x22b, 0);
         let res = _mm_broadcastw_epi16(a);
-        assert_eq!(res, _mm_set1_epi16(0x22b));
+        assert_eq_m128i(res, _mm_set1_epi16(0x22b));
     }
 
     #[simd_test = "avx2"]
@@ -3774,7 +3774,7 @@ mod tests {
         let a = _mm256_setr_epi64x(1, 2, 3, 4);
         let r = _mm256_extracti128_si256(a, 0b01);
         let e = _mm_setr_epi64x(3, 4);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3870,7 +3870,7 @@ mod tests {
         let mask = _mm_setr_epi32(-1, 0, 0, -1);
         let r = _mm_maskload_epi32(a, mask);
         let e = _mm_setr_epi32(1, 0, 0, 4);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3890,7 +3890,7 @@ mod tests {
         let mask = _mm_setr_epi64x(0, -1);
         let r = _mm_maskload_epi64(a, mask);
         let e = _mm_setr_epi64x(0, 2);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4308,7 +4308,7 @@ mod tests {
         let b = _mm_set1_epi32(1);
         let r = _mm_sllv_epi32(a, b);
         let e = _mm_set1_epi32(4);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4326,7 +4326,7 @@ mod tests {
         let b = _mm_set1_epi64x(1);
         let r = _mm_sllv_epi64(a, b);
         let e = _mm_set1_epi64x(4);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4376,7 +4376,7 @@ mod tests {
         let count = _mm_set1_epi32(1);
         let r = _mm_srav_epi32(a, count);
         let e = _mm_set1_epi32(2);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4462,7 +4462,7 @@ mod tests {
         let count = _mm_set1_epi32(1);
         let r = _mm_srlv_epi32(a, count);
         let e = _mm_set1_epi32(1);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4480,7 +4480,7 @@ mod tests {
         let count = _mm_set1_epi64x(1);
         let r = _mm_srlv_epi64(a, count);
         let e = _mm_set1_epi64x(1);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4699,7 +4699,7 @@ mod tests {
             _mm_setr_epi32(0, 16, 32, 48),
             4,
         );
-        assert_eq!(r, _mm_setr_epi32(0, 16, 32, 48));
+        assert_eq_m128i(r, _mm_setr_epi32(0, 16, 32, 48));
     }
 
     #[simd_test = "avx2"]
@@ -4716,7 +4716,7 @@ mod tests {
             _mm_setr_epi32(-1, -1, -1, 0),
             4,
         );
-        assert_eq!(r, _mm_setr_epi32(0, 16, 64, 256));
+        assert_eq_m128i(r, _mm_setr_epi32(0, 16, 64, 256));
     }
 
     #[simd_test = "avx2"]
@@ -4835,7 +4835,7 @@ mod tests {
             _mm_setr_epi32(0, 16, 0, 0),
             8,
         );
-        assert_eq!(r, _mm_setr_epi64x(0, 16));
+        assert_eq_m128i(r, _mm_setr_epi64x(0, 16));
     }
 
     #[simd_test = "avx2"]
@@ -4852,7 +4852,7 @@ mod tests {
             _mm_setr_epi64x(-1, 0),
             8,
         );
-        assert_eq!(r, _mm_setr_epi64x(16, 256));
+        assert_eq_m128i(r, _mm_setr_epi64x(16, 256));
     }
 
     #[simd_test = "avx2"]
@@ -4964,7 +4964,7 @@ mod tests {
         }
         // A multiplier of 4 is word-addressing
         let r = _mm_i64gather_epi32(arr.as_ptr(), _mm_setr_epi64x(0, 16), 4);
-        assert_eq!(r, _mm_setr_epi32(0, 16, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(0, 16, 0, 0));
     }
 
     #[simd_test = "avx2"]
@@ -4981,7 +4981,7 @@ mod tests {
             _mm_setr_epi32(-1, 0, -1, 0),
             4,
         );
-        assert_eq!(r, _mm_setr_epi32(0, 256, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(0, 256, 0, 0));
     }
 
     #[simd_test = "avx2"]
@@ -4996,7 +4996,7 @@ mod tests {
             _mm256_setr_epi64x(0, 16, 32, 48),
             4,
         );
-        assert_eq!(r, _mm_setr_epi32(0, 16, 32, 48));
+        assert_eq_m128i(r, _mm_setr_epi32(0, 16, 32, 48));
     }
 
     #[simd_test = "avx2"]
@@ -5013,7 +5013,7 @@ mod tests {
             _mm_setr_epi32(-1, -1, -1, 0),
             4,
         );
-        assert_eq!(r, _mm_setr_epi32(0, 16, 64, 256));
+        assert_eq_m128i(r, _mm_setr_epi32(0, 16, 64, 256));
     }
 
     #[simd_test = "avx2"]
@@ -5092,7 +5092,7 @@ mod tests {
         }
         // A multiplier of 8 is word-addressing for i64s
         let r = _mm_i64gather_epi64(arr.as_ptr(), _mm_setr_epi64x(0, 16), 8);
-        assert_eq!(r, _mm_setr_epi64x(0, 16));
+        assert_eq_m128i(r, _mm_setr_epi64x(0, 16));
     }
 
     #[simd_test = "avx2"]
@@ -5109,7 +5109,7 @@ mod tests {
             _mm_setr_epi64x(-1, 0),
             8,
         );
-        assert_eq!(r, _mm_setr_epi64x(16, 256));
+        assert_eq_m128i(r, _mm_setr_epi64x(16, 256));
     }
 
     #[simd_test = "avx2"]

--- a/coresimd/src/x86/i586/avx2.rs
+++ b/coresimd/src/x86/i586/avx2.rs
@@ -1967,8 +1967,8 @@ pub unsafe fn _mm256_shuffle_epi8(a: __m256i, b: __m256i) -> __m256i {
 /// let expected1 = _mm256_setr_epi32(1, 2, 3, 0, 5, 6, 7, 4);
 /// let expected2 = _mm256_setr_epi32(3, 2, 0, 1, 7, 6, 4, 5);
 ///
-/// assert_eq!(c1, expected1);
-/// assert_eq!(c2, expected2);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c1, expected1)), !0);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c2, expected2)), !0);
 /// #         }
 /// #         unsafe { worker(); }
 /// #     }
@@ -2553,7 +2553,7 @@ pub unsafe fn _mm256_subs_epu8(a: __m256i, b: __m256i) -> __m256i {
 /// let expected = _mm256_setr_epi8(8,-8, 9,-9, 10,-10, 11,-11, 12,-12, 13,-13,
 /// 14,-14, 15,-15, 24,-24, 25,-25, 26,-26, 27,-27, 28,-28, 29,-29, 30,-30,
 /// 31,-31);
-/// assert_eq!(c, expected);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c, expected)), !0);
 ///
 /// #         }
 /// #         unsafe { worker(); }
@@ -2598,7 +2598,7 @@ pub unsafe fn _mm256_unpackhi_epi8(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// let expected = _mm256_setr_epi8(0, 0, 1,-1, 2,-2, 3,-3, 4,-4, 5,-5, 6,-6, 7,-7,
 /// 16,-16, 17,-17, 18,-18, 19,-19, 20,-20, 21,-21, 22,-22, 23,-23);
-/// assert_eq!(c, expected);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c, expected)), !0);
 ///
 /// #         }
 /// #         unsafe { worker(); }
@@ -2641,7 +2641,7 @@ pub unsafe fn _mm256_unpacklo_epi8(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// let expected = _mm256_setr_epi16(4,-4, 5,-5, 6,-6, 7,-7, 12,-12, 13,-13, 14,-14,
 /// 15,-15);
-/// assert_eq!(c, expected);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c, expected)), !0);
 ///
 /// #         }
 /// #         unsafe { worker(); }
@@ -2682,7 +2682,7 @@ pub unsafe fn _mm256_unpackhi_epi16(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// let expected = _mm256_setr_epi16(0, 0, 1,-1, 2,-2, 3,-3, 8,-8, 9,-9, 10,-10,
 /// 11,-11);
-/// assert_eq!(c, expected);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c, expected)), !0);
 ///
 /// #         }
 /// #         unsafe { worker(); }
@@ -2722,7 +2722,7 @@ pub unsafe fn _mm256_unpacklo_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// let c = _mm256_unpackhi_epi32(a, b);
 ///
 /// let expected = _mm256_setr_epi32(2,-2, 3,-3, 6,-6, 7,-7);
-/// assert_eq!(c, expected);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c, expected)), !0);
 ///
 /// #         }
 /// #         unsafe { worker(); }
@@ -2758,7 +2758,7 @@ pub unsafe fn _mm256_unpackhi_epi32(a: __m256i, b: __m256i) -> __m256i {
 /// let c = _mm256_unpacklo_epi32(a, b);
 ///
 /// let expected = _mm256_setr_epi32(0, 0, 1,-1, 4,-4, 5,-5);
-/// assert_eq!(c, expected);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c, expected)), !0);
 ///
 /// #         }
 /// #         unsafe { worker(); }
@@ -2794,7 +2794,7 @@ pub unsafe fn _mm256_unpacklo_epi32(a: __m256i, b: __m256i) -> __m256i {
 /// let c = _mm256_unpackhi_epi64(a, b);
 ///
 /// let expected = _mm256_setr_epi64x(1,-1, 3,-3);
-/// assert_eq!(c, expected);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c, expected)), !0);
 ///
 /// #         }
 /// #         unsafe { worker(); }
@@ -2830,7 +2830,7 @@ pub unsafe fn _mm256_unpackhi_epi64(a: __m256i, b: __m256i) -> __m256i {
 /// let c = _mm256_unpacklo_epi64(a, b);
 ///
 /// let expected = _mm256_setr_epi64x(0, 0, 2,-2);
-/// assert_eq!(c, expected);
+/// assert_eq!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(c, expected)), !0);
 ///
 /// #         }
 /// #         unsafe { worker(); }
@@ -3178,7 +3178,7 @@ mod tests {
             0, 1, 1, std::i32::MAX,
             std::i32::MAX.wrapping_add(1), 100, 100, 32,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3194,7 +3194,7 @@ mod tests {
             0, 1, 1, 2, 2, 3, 3, 4,
             4, 5, 5, std::i16::MAX, std::i16::MAX.wrapping_add(1), 100, 100, 32,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3214,7 +3214,7 @@ mod tests {
             0, 1, 1, 2, 2, 3, 3, 4,
             4, 5, 5, std::i8::MAX, std::i8::MAX.wrapping_add(1), 100, 100, 32,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3223,7 +3223,7 @@ mod tests {
         let b = _mm256_setr_epi64x(-1, 0, 1, 2);
         let r = _mm256_add_epi64(a, b);
         let e = _mm256_setr_epi64x(-11, 0, 101, 1_000_000_002);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3232,7 +3232,7 @@ mod tests {
         let b = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_add_epi32(a, b);
         let e = _mm256_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3247,7 +3247,7 @@ mod tests {
             0, 2, 4, 6, 8, 10, 12, 14,
             16, 18, 20, 22, 24, 26, 28, 30,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3274,7 +3274,7 @@ mod tests {
             32, 34, 36, 38, 40, 42, 44, 46,
             48, 50, 52, 54, 56, 58, 60, 62,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3301,7 +3301,7 @@ mod tests {
             64, 66, 68, 70, 72, 74, 76, 78,
             80, 82, 84, 86, 88, 90, 92, 94,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3309,7 +3309,7 @@ mod tests {
         let a = _mm256_set1_epi8(0x7F);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_adds_epi8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -3317,7 +3317,7 @@ mod tests {
         let a = _mm256_set1_epi8(-0x80);
         let b = _mm256_set1_epi8(-1);
         let r = _mm256_adds_epi8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -3336,7 +3336,7 @@ mod tests {
             48, 50, 52, 54, 56, 58, 60, 62,
         );
 
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3344,7 +3344,7 @@ mod tests {
         let a = _mm256_set1_epi16(0x7FFF);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_adds_epi16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -3352,7 +3352,7 @@ mod tests {
         let a = _mm256_set1_epi16(-0x8000);
         let b = _mm256_set1_epi16(-1);
         let r = _mm256_adds_epi16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -3379,7 +3379,7 @@ mod tests {
             64, 66, 68, 70, 72, 74, 76, 78,
             80, 82, 84, 86, 88, 90, 92, 94,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3387,7 +3387,7 @@ mod tests {
         let a = _mm256_set1_epi8(!0);
         let b = _mm256_set1_epi8(1);
         let r = _mm256_adds_epu8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -3406,7 +3406,7 @@ mod tests {
             48, 50, 52, 54, 56, 58, 60, 62,
         );
 
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3414,7 +3414,7 @@ mod tests {
         let a = _mm256_set1_epi16(!0);
         let b = _mm256_set1_epi16(1);
         let r = _mm256_adds_epu16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -3422,7 +3422,7 @@ mod tests {
         let a = _mm256_set1_epi8(5);
         let b = _mm256_set1_epi8(3);
         let got = _mm256_and_si256(a, b);
-        assert_eq!(got, _mm256_set1_epi8(1));
+        assert_eq_m256i(got, _mm256_set1_epi8(1));
     }
 
     #[simd_test = "avx2"]
@@ -3430,21 +3430,21 @@ mod tests {
         let a = _mm256_set1_epi8(5);
         let b = _mm256_set1_epi8(3);
         let got = _mm256_andnot_si256(a, b);
-        assert_eq!(got, _mm256_set1_epi8(2));
+        assert_eq_m256i(got, _mm256_set1_epi8(2));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_avg_epu8() {
         let (a, b) = (_mm256_set1_epi8(3), _mm256_set1_epi8(9));
         let r = _mm256_avg_epu8(a, b);
-        assert_eq!(r, _mm256_set1_epi8(6));
+        assert_eq_m256i(r, _mm256_set1_epi8(6));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_avg_epu16() {
         let (a, b) = (_mm256_set1_epi16(3), _mm256_set1_epi16(9));
         let r = _mm256_avg_epu16(a, b);
-        assert_eq!(r, _mm256_set1_epi16(6));
+        assert_eq_m256i(r, _mm256_set1_epi16(6));
     }
 
     #[simd_test = "avx2"]
@@ -3463,15 +3463,15 @@ mod tests {
         let (a, b) = (_mm256_set1_epi32(3), _mm256_set1_epi32(9));
         let e = _mm256_setr_epi32(9, 3, 3, 3, 3, 3, 3, 3);
         let r = _mm256_blend_epi32(a, b, 0x01 as i32);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
 
         let e = _mm256_setr_epi32(3, 9, 3, 3, 3, 3, 3, 9);
         let r = _mm256_blend_epi32(a, b, 0x82 as i32);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
 
         let e = _mm256_setr_epi32(3, 3, 9, 9, 9, 9, 9, 3);
         let r = _mm256_blend_epi32(a, b, 0x7C as i32);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3479,10 +3479,10 @@ mod tests {
         let (a, b) = (_mm256_set1_epi16(3), _mm256_set1_epi16(9));
         let e = _mm256_setr_epi16(9, 3, 3, 3, 3, 3, 3, 3, 9, 3, 3,3, 3, 3, 3, 3);
         let r = _mm256_blend_epi16(a, b, 0x01 as i32);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
 
         let r = _mm256_blend_epi16(b, a, 0xFE as i32);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3491,7 +3491,7 @@ mod tests {
         let mask = _mm256_insert_epi8(_mm256_set1_epi8(0), -1, 2);
         let e = _mm256_insert_epi8(_mm256_set1_epi8(4), 2, 2);
         let r = _mm256_blendv_epi8(a, b, mask);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3505,7 +3505,7 @@ mod tests {
     unsafe fn test_mm256_broadcastb_epi8() {
         let a = _mm_insert_epi8(_mm_set1_epi8(0x00), 0x2a, 0);
         let res = _mm256_broadcastb_epi8(a);
-        assert_eq!(res, _mm256_set1_epi8(0x2a));
+        assert_eq_m256i(res, _mm256_set1_epi8(0x2a));
     }
 
     #[simd_test = "avx2"]
@@ -3519,7 +3519,7 @@ mod tests {
     unsafe fn test_mm256_broadcastd_epi32() {
         let a = _mm_setr_epi32(0x2a, 0x8000000, 0, 0);
         let res = _mm256_broadcastd_epi32(a);
-        assert_eq!(res, _mm256_set1_epi32(0x2a));
+        assert_eq_m256i(res, _mm256_set1_epi32(0x2a));
     }
 
     #[simd_test = "avx2"]
@@ -3533,7 +3533,7 @@ mod tests {
     unsafe fn test_mm256_broadcastq_epi64() {
         let a = _mm_setr_epi64x(0x1ffffffff, 0);
         let res = _mm256_broadcastq_epi64(a);
-        assert_eq!(res, _mm256_set1_epi64x(0x1ffffffff));
+        assert_eq_m256i(res, _mm256_set1_epi64x(0x1ffffffff));
     }
 
     #[simd_test = "avx2"]
@@ -3560,7 +3560,7 @@ mod tests {
             0x0987654321012334,
             0x5678909876543210,
         );
-        assert_eq!(res, retval);
+        assert_eq_m256i(res, retval);
     }
 
     #[simd_test = "avx2"]
@@ -3588,7 +3588,7 @@ mod tests {
     unsafe fn test_mm256_broadcastw_epi16() {
         let a = _mm_insert_epi16(_mm_set1_epi16(0x2a), 0x22b, 0);
         let res = _mm256_broadcastw_epi16(a);
-        assert_eq!(res, _mm256_set1_epi16(0x22b));
+        assert_eq_m256i(res, _mm256_set1_epi16(0x22b));
     }
 
     #[simd_test = "avx2"]
@@ -3608,7 +3608,7 @@ mod tests {
             7, 6, 5, 4, 3, 2, 1, 0,
         );
         let r = _mm256_cmpeq_epi8(a, b);
-        assert_eq!(r, _mm256_insert_epi8(_mm256_set1_epi8(0), !0, 2));
+        assert_eq_m256i(r, _mm256_insert_epi8(_mm256_set1_epi8(0), !0, 2));
     }
 
     #[simd_test = "avx2"]
@@ -3618,7 +3618,7 @@ mod tests {
         let b =
             _mm256_setr_epi16(15, 14, 2, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm256_cmpeq_epi16(a, b);
-        assert_eq!(r, _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 2));
+        assert_eq_m256i(r, _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 2));
     }
 
     #[simd_test = "avx2"]
@@ -3628,7 +3628,7 @@ mod tests {
         let r = _mm256_cmpeq_epi32(a, b);
         let e = _mm256_set1_epi32(0);
         let e = _mm256_insert_epi32(e, !0, 2);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3636,7 +3636,7 @@ mod tests {
         let a = _mm256_setr_epi64x(0, 1, 2, 3);
         let b = _mm256_setr_epi64x(3, 2, 2, 0);
         let r = _mm256_cmpeq_epi64(a, b);
-        assert_eq!(
+        assert_eq_m256i(
             r,
             _mm256_insert_epi64(_mm256_set1_epi64x(0), !0, 2),
         );
@@ -3647,7 +3647,7 @@ mod tests {
         let a = _mm256_insert_epi8(_mm256_set1_epi8(0), 5, 0);
         let b = _mm256_set1_epi8(0);
         let r = _mm256_cmpgt_epi8(a, b);
-        assert_eq!(r, _mm256_insert_epi8(_mm256_set1_epi8(0), !0, 0));
+        assert_eq_m256i(r, _mm256_insert_epi8(_mm256_set1_epi8(0), !0, 0));
     }
 
     #[simd_test = "avx2"]
@@ -3655,7 +3655,7 @@ mod tests {
         let a = _mm256_insert_epi16(_mm256_set1_epi16(0), 5, 0);
         let b = _mm256_set1_epi16(0);
         let r = _mm256_cmpgt_epi16(a, b);
-        assert_eq!(r, _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 0));
+        assert_eq_m256i(r, _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 0));
     }
 
     #[simd_test = "avx2"]
@@ -3663,7 +3663,7 @@ mod tests {
         let a = _mm256_insert_epi32(_mm256_set1_epi32(0), 5, 0);
         let b = _mm256_set1_epi32(0);
         let r = _mm256_cmpgt_epi32(a, b);
-        assert_eq!(r, _mm256_insert_epi32(_mm256_set1_epi32(0), !0, 0));
+        assert_eq_m256i(r, _mm256_insert_epi32(_mm256_set1_epi32(0), !0, 0));
     }
 
     #[simd_test = "avx2"]
@@ -3671,7 +3671,7 @@ mod tests {
         let a = _mm256_insert_epi64(_mm256_set1_epi64x(0), 5, 0);
         let b = _mm256_set1_epi64x(0);
         let r = _mm256_cmpgt_epi64(a, b);
-        assert_eq!(
+        assert_eq_m256i(
             r,
             _mm256_insert_epi64(_mm256_set1_epi64x(0), !0, 0),
         );
@@ -3683,7 +3683,7 @@ mod tests {
             _mm_setr_epi8(0, 0, -1, 1, -2, 2, -3, 3, -4, 4, -5, 5, -6, 6, -7, 7);
         let r =
             _mm256_setr_epi16(0, 0, -1, 1, -2, 2, -3, 3, -4, 4, -5, 5, -6, 6, -7, 7);
-        assert_eq!(r, _mm256_cvtepi8_epi16(a));
+        assert_eq_m256i(r, _mm256_cvtepi8_epi16(a));
     }
 
     #[simd_test = "avx2"]
@@ -3691,7 +3691,7 @@ mod tests {
         let a =
             _mm_setr_epi8(0, 0, -1, 1, -2, 2, -3, 3, -4, 4, -5, 5, -6, 6, -7, 7);
         let r = _mm256_setr_epi32(0, 0, -1, 1, -2, 2, -3, 3);
-        assert_eq!(r, _mm256_cvtepi8_epi32(a));
+        assert_eq_m256i(r, _mm256_cvtepi8_epi32(a));
     }
 
     #[simd_test = "avx2"]
@@ -3699,49 +3699,49 @@ mod tests {
         let a =
             _mm_setr_epi8(0, 0, -1, 1, -2, 2, -3, 3, -4, 4, -5, 5, -6, 6, -7, 7);
         let r = _mm256_setr_epi64x(0, 0, -1, 1);
-        assert_eq!(r, _mm256_cvtepi8_epi64(a));
+        assert_eq_m256i(r, _mm256_cvtepi8_epi64(a));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_cvtepi16_epi32() {
         let a = _mm_setr_epi16(0, 0, -1, 1, -2, 2, -3, 3);
         let r = _mm256_setr_epi32(0, 0, -1, 1, -2, 2, -3, 3);
-        assert_eq!(r, _mm256_cvtepi16_epi32(a));
+        assert_eq_m256i(r, _mm256_cvtepi16_epi32(a));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_cvtepi16_epi64() {
         let a = _mm_setr_epi16(0, 0, -1, 1, -2, 2, -3, 3);
         let r = _mm256_setr_epi64x(0, 0, -1, 1);
-        assert_eq!(r, _mm256_cvtepi16_epi64(a));
+        assert_eq_m256i(r, _mm256_cvtepi16_epi64(a));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_cvtepi32_epi64() {
         let a = _mm_setr_epi32(0, 0, -1, 1);
         let r = _mm256_setr_epi64x(0, 0, -1, 1);
-        assert_eq!(r, _mm256_cvtepi32_epi64(a));
+        assert_eq_m256i(r, _mm256_cvtepi32_epi64(a));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_cvtepu16_epi32() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
-        assert_eq!(r, _mm256_cvtepu16_epi32(a));
+        assert_eq_m256i(r, _mm256_cvtepu16_epi32(a));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_cvtepu16_epi64() {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm256_setr_epi64x(0, 1, 2, 3);
-        assert_eq!(r, _mm256_cvtepu16_epi64(a));
+        assert_eq_m256i(r, _mm256_cvtepu16_epi64(a));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_cvtepu32_epi64() {
         let a = _mm_setr_epi32(0, 1, 2, 3);
         let r = _mm256_setr_epi64x(0, 1, 2, 3);
-        assert_eq!(r, _mm256_cvtepu32_epi64(a));
+        assert_eq_m256i(r, _mm256_cvtepu32_epi64(a));
     }
 
     #[simd_test = "avx2"]
@@ -3750,7 +3750,7 @@ mod tests {
             _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r =
             _mm256_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-        assert_eq!(r, _mm256_cvtepu8_epi16(a));
+        assert_eq_m256i(r, _mm256_cvtepu8_epi16(a));
     }
 
     #[simd_test = "avx2"]
@@ -3758,7 +3758,7 @@ mod tests {
         let a =
             _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
-        assert_eq!(r, _mm256_cvtepu8_epi32(a));
+        assert_eq_m256i(r, _mm256_cvtepu8_epi32(a));
     }
 
     #[simd_test = "avx2"]
@@ -3766,7 +3766,7 @@ mod tests {
         let a =
             _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm256_setr_epi64x(0, 1, 2, 3);
-        assert_eq!(r, _mm256_cvtepu8_epi64(a));
+        assert_eq_m256i(r, _mm256_cvtepu8_epi64(a));
     }
 
     #[simd_test = "avx2"]
@@ -3783,7 +3783,7 @@ mod tests {
         let b = _mm256_set1_epi16(4);
         let r = _mm256_hadd_epi16(a, b);
         let e = _mm256_setr_epi16(4, 4, 4, 4, 8, 8, 8, 8, 4, 4, 4, 4, 8, 8, 8, 8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3792,7 +3792,7 @@ mod tests {
         let b = _mm256_set1_epi32(4);
         let r = _mm256_hadd_epi32(a, b);
         let e = _mm256_setr_epi32(4, 4, 8, 8, 4, 4, 8, 8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3804,7 +3804,7 @@ mod tests {
         let r = _mm256_hadds_epi16(a, b);
         let e =
             _mm256_setr_epi16(0x7FFF, 4, 4, 4, 8, 8, 8, 8, 4, 4, 4, 4, 8, 8, 8, 8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3813,7 +3813,7 @@ mod tests {
         let b = _mm256_set1_epi16(4);
         let r = _mm256_hsub_epi16(a, b);
         let e = _mm256_set1_epi16(0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3822,7 +3822,7 @@ mod tests {
         let b = _mm256_set1_epi32(4);
         let r = _mm256_hsub_epi32(a, b);
         let e = _mm256_set1_epi32(0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3833,7 +3833,7 @@ mod tests {
         let b = _mm256_set1_epi16(4);
         let r = _mm256_hsubs_epi16(a, b);
         let e = _mm256_insert_epi16(_mm256_set1_epi16(0), 0x7FFF, 0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3842,7 +3842,7 @@ mod tests {
         let b = _mm256_set1_epi16(4);
         let r = _mm256_madd_epi16(a, b);
         let e = _mm256_set1_epi32(16);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3851,7 +3851,7 @@ mod tests {
         let b = _mm_setr_epi64x(7, 8);
         let r = _mm256_inserti128_si256(a, b, 0b01);
         let e = _mm256_setr_epi64x(1, 2, 7, 8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3860,7 +3860,7 @@ mod tests {
         let b = _mm256_set1_epi8(4);
         let r = _mm256_maddubs_epi16(a, b);
         let e = _mm256_set1_epi16(16);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3880,7 +3880,7 @@ mod tests {
         let mask = _mm256_setr_epi32(-1, 0, 0, -1, 0, -1, -1, 0);
         let r = _mm256_maskload_epi32(a, mask);
         let e = _mm256_setr_epi32(1, 0, 0, 4, 0, 6, 7, 0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3900,7 +3900,7 @@ mod tests {
         let mask = _mm256_setr_epi64x(0, -1, -1, 0);
         let r = _mm256_maskload_epi64(a, mask);
         let e = _mm256_setr_epi64x(0, 2, 3, 0);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -3948,7 +3948,7 @@ mod tests {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_max_epi16(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -3956,7 +3956,7 @@ mod tests {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_max_epi32(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -3964,7 +3964,7 @@ mod tests {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_max_epi8(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -3972,7 +3972,7 @@ mod tests {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_max_epu16(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -3980,7 +3980,7 @@ mod tests {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_max_epu32(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -3988,7 +3988,7 @@ mod tests {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_max_epu8(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -3996,7 +3996,7 @@ mod tests {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_min_epi16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -4004,7 +4004,7 @@ mod tests {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_min_epi32(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -4012,7 +4012,7 @@ mod tests {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_min_epi8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -4020,7 +4020,7 @@ mod tests {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_min_epu16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -4028,7 +4028,7 @@ mod tests {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_min_epu32(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -4036,7 +4036,7 @@ mod tests {
         let a = _mm256_set1_epi8(2);
         let b = _mm256_set1_epi8(4);
         let r = _mm256_min_epu8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -4053,7 +4053,7 @@ mod tests {
         let b = _mm256_set1_epi8(4);
         let r = _mm256_mpsadbw_epu8(a, b, 0);
         let e = _mm256_set1_epi16(8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4062,7 +4062,7 @@ mod tests {
         let b = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_mul_epi32(a, b);
         let e = _mm256_setr_epi64x(0, 0, 10, 14);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4071,7 +4071,7 @@ mod tests {
         let b = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_mul_epu32(a, b);
         let e = _mm256_setr_epi64x(0, 0, 10, 14);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4080,7 +4080,7 @@ mod tests {
         let b = _mm256_set1_epi16(6535);
         let r = _mm256_mulhi_epi16(a, b);
         let e = _mm256_set1_epi16(651);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4089,7 +4089,7 @@ mod tests {
         let b = _mm256_set1_epi16(6535);
         let r = _mm256_mulhi_epu16(a, b);
         let e = _mm256_set1_epi16(651);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4098,7 +4098,7 @@ mod tests {
         let b = _mm256_set1_epi16(4);
         let r = _mm256_mullo_epi16(a, b);
         let e = _mm256_set1_epi16(8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4107,7 +4107,7 @@ mod tests {
         let b = _mm256_set1_epi32(4);
         let r = _mm256_mullo_epi32(a, b);
         let e = _mm256_set1_epi32(8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4116,7 +4116,7 @@ mod tests {
         let b = _mm256_set1_epi16(4);
         let r = _mm256_mullo_epi16(a, b);
         let e = _mm256_set1_epi16(8);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4124,7 +4124,7 @@ mod tests {
         let a = _mm256_set1_epi8(-1);
         let b = _mm256_set1_epi8(0);
         let r = _mm256_or_si256(a, b);
-        assert_eq!(r, a);
+        assert_eq_m256i(r, a);
     }
 
     #[simd_test = "avx2"]
@@ -4140,7 +4140,7 @@ mod tests {
             4, 4, 4, 4, 4, 4, 4, 4,
         );
 
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4150,7 +4150,7 @@ mod tests {
         let r = _mm256_packs_epi32(a, b);
         let e = _mm256_setr_epi16(2, 2, 2, 2, 4, 4, 4, 4, 2, 2, 2, 2, 4, 4, 4, 4);
 
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4166,7 +4166,7 @@ mod tests {
             4, 4, 4, 4, 4, 4, 4, 4,
         );
 
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4176,7 +4176,7 @@ mod tests {
         let r = _mm256_packus_epi32(a, b);
         let e = _mm256_setr_epi16(2, 2, 2, 2, 4, 4, 4, 4, 2, 2, 2, 2, 4, 4, 4, 4);
 
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4185,7 +4185,7 @@ mod tests {
         let b = _mm256_set1_epi8(4);
         let r = _mm256_sad_epu8(a, b);
         let e = _mm256_set1_epi64x(16);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4201,7 +4201,7 @@ mod tests {
             4, 5, 6, 7, 88, 66, 66, 55,
         );
         let r = _mm256_shufflehi_epi16(a, 0b00_01_01_11);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4217,7 +4217,7 @@ mod tests {
             88, 66, 66, 55, 4, 5, 6, 7,
         );
         let r = _mm256_shufflelo_epi16(a, 0b00_01_01_11);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4226,7 +4226,7 @@ mod tests {
         let b = _mm256_set1_epi16(-1);
         let r = _mm256_sign_epi16(a, b);
         let e = _mm256_set1_epi16(-2);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4235,7 +4235,7 @@ mod tests {
         let b = _mm256_set1_epi32(-1);
         let r = _mm256_sign_epi32(a, b);
         let e = _mm256_set1_epi32(-2);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4244,7 +4244,7 @@ mod tests {
         let b = _mm256_set1_epi8(-1);
         let r = _mm256_sign_epi8(a, b);
         let e = _mm256_set1_epi8(-2);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4252,7 +4252,7 @@ mod tests {
         let a = _mm256_set1_epi16(0xFF);
         let b = _mm_insert_epi16(_mm_set1_epi16(0), 4, 0);
         let r = _mm256_sll_epi16(a, b);
-        assert_eq!(r, _mm256_set1_epi16(0xFF0));
+        assert_eq_m256i(r, _mm256_set1_epi16(0xFF0));
     }
 
     #[simd_test = "avx2"]
@@ -4260,7 +4260,7 @@ mod tests {
         let a = _mm256_set1_epi32(0xFFFF);
         let b = _mm_insert_epi32(_mm_set1_epi32(0), 4, 0);
         let r = _mm256_sll_epi32(a, b);
-        assert_eq!(r, _mm256_set1_epi32(0xFFFF0));
+        assert_eq_m256i(r, _mm256_set1_epi32(0xFFFF0));
     }
 
     #[simd_test = "avx2"]
@@ -4268,12 +4268,12 @@ mod tests {
         let a = _mm256_set1_epi64x(0xFFFFFFFF);
         let b = _mm_insert_epi64(_mm_set1_epi64x(0), 4, 0);
         let r = _mm256_sll_epi64(a, b);
-        assert_eq!(r, _mm256_set1_epi64x(0xFFFFFFFF0));
+        assert_eq_m256i(r, _mm256_set1_epi64x(0xFFFFFFFF0));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_slli_epi16() {
-        assert_eq!(
+        assert_eq_m256i(
             _mm256_slli_epi16(_mm256_set1_epi16(0xFF), 4),
             _mm256_set1_epi16(0xFF0)
         );
@@ -4281,7 +4281,7 @@ mod tests {
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_slli_epi32() {
-        assert_eq!(
+        assert_eq_m256i(
             _mm256_slli_epi32(_mm256_set1_epi32(0xFFFF), 4),
             _mm256_set1_epi32(0xFFFF0)
         );
@@ -4289,7 +4289,7 @@ mod tests {
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_slli_epi64() {
-        assert_eq!(
+        assert_eq_m256i(
             _mm256_slli_epi64(_mm256_set1_epi64x(0xFFFFFFFF), 4),
             _mm256_set1_epi64x(0xFFFFFFFF0)
         );
@@ -4299,7 +4299,7 @@ mod tests {
     unsafe fn test_mm256_slli_si256() {
         let a = _mm256_set1_epi64x(0xFFFFFFFF);
         let r = _mm256_slli_si256(a, 3);
-        assert_eq!(r, _mm256_set1_epi64x(0xFFFFFFFF000000));
+        assert_eq_m256i(r, _mm256_set1_epi64x(0xFFFFFFFF000000));
     }
 
     #[simd_test = "avx2"]
@@ -4317,7 +4317,7 @@ mod tests {
         let b = _mm256_set1_epi32(1);
         let r = _mm256_sllv_epi32(a, b);
         let e = _mm256_set1_epi32(4);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4335,7 +4335,7 @@ mod tests {
         let b = _mm256_set1_epi64x(1);
         let r = _mm256_sllv_epi64(a, b);
         let e = _mm256_set1_epi64x(4);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4343,7 +4343,7 @@ mod tests {
         let a = _mm256_set1_epi16(-1);
         let b = _mm_setr_epi16(1, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm256_sra_epi16(a, b);
-        assert_eq!(r, _mm256_set1_epi16(-1));
+        assert_eq_m256i(r, _mm256_set1_epi16(-1));
     }
 
     #[simd_test = "avx2"]
@@ -4351,12 +4351,12 @@ mod tests {
         let a = _mm256_set1_epi32(-1);
         let b = _mm_insert_epi32(_mm_set1_epi32(0), 1, 0);
         let r = _mm256_sra_epi32(a, b);
-        assert_eq!(r, _mm256_set1_epi32(-1));
+        assert_eq_m256i(r, _mm256_set1_epi32(-1));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_srai_epi16() {
-        assert_eq!(
+        assert_eq_m256i(
             _mm256_srai_epi16(_mm256_set1_epi16(-1), 1),
             _mm256_set1_epi16(-1)
         );
@@ -4364,7 +4364,7 @@ mod tests {
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_srai_epi32() {
-        assert_eq!(
+        assert_eq_m256i(
             _mm256_srai_epi32(_mm256_set1_epi32(-1), 1),
             _mm256_set1_epi32(-1)
         );
@@ -4385,7 +4385,7 @@ mod tests {
         let count = _mm256_set1_epi32(1);
         let r = _mm256_srav_epi32(a, count);
         let e = _mm256_set1_epi32(2);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4405,7 +4405,7 @@ mod tests {
             20, 21, 22, 23, 24, 25, 26, 27,
             28, 29, 30, 31, 32, 0, 0, 0,
         );
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4413,7 +4413,7 @@ mod tests {
         let a = _mm256_set1_epi16(0xFF);
         let b = _mm_insert_epi16(_mm_set1_epi16(0), 4, 0);
         let r = _mm256_srl_epi16(a, b);
-        assert_eq!(r, _mm256_set1_epi16(0xF));
+        assert_eq_m256i(r, _mm256_set1_epi16(0xF));
     }
 
     #[simd_test = "avx2"]
@@ -4421,7 +4421,7 @@ mod tests {
         let a = _mm256_set1_epi32(0xFFFF);
         let b = _mm_insert_epi32(_mm_set1_epi32(0), 4, 0);
         let r = _mm256_srl_epi32(a, b);
-        assert_eq!(r, _mm256_set1_epi32(0xFFF));
+        assert_eq_m256i(r, _mm256_set1_epi32(0xFFF));
     }
 
     #[simd_test = "avx2"]
@@ -4429,12 +4429,12 @@ mod tests {
         let a = _mm256_set1_epi64x(0xFFFFFFFF);
         let b = _mm_setr_epi64x(4, 0);
         let r = _mm256_srl_epi64(a, b);
-        assert_eq!(r, _mm256_set1_epi64x(0xFFFFFFF));
+        assert_eq_m256i(r, _mm256_set1_epi64x(0xFFFFFFF));
     }
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_srli_epi16() {
-        assert_eq!(
+        assert_eq_m256i(
             _mm256_srli_epi16(_mm256_set1_epi16(0xFF), 4),
             _mm256_set1_epi16(0xF)
         );
@@ -4442,7 +4442,7 @@ mod tests {
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_srli_epi32() {
-        assert_eq!(
+        assert_eq_m256i(
             _mm256_srli_epi32(_mm256_set1_epi32(0xFFFF), 4),
             _mm256_set1_epi32(0xFFF)
         );
@@ -4450,7 +4450,7 @@ mod tests {
 
     #[simd_test = "avx2"]
     unsafe fn test_mm256_srli_epi64() {
-        assert_eq!(
+        assert_eq_m256i(
             _mm256_srli_epi64(_mm256_set1_epi64x(0xFFFFFFFF), 4),
             _mm256_set1_epi64x(0xFFFFFFF)
         );
@@ -4471,7 +4471,7 @@ mod tests {
         let count = _mm256_set1_epi32(1);
         let r = _mm256_srlv_epi32(a, count);
         let e = _mm256_set1_epi32(1);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4489,7 +4489,7 @@ mod tests {
         let count = _mm256_set1_epi64x(1);
         let r = _mm256_srlv_epi64(a, count);
         let e = _mm256_set1_epi64x(1);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4497,7 +4497,7 @@ mod tests {
         let a = _mm256_set1_epi16(4);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_sub_epi16(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4505,7 +4505,7 @@ mod tests {
         let a = _mm256_set1_epi32(4);
         let b = _mm256_set1_epi32(2);
         let r = _mm256_sub_epi32(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4513,7 +4513,7 @@ mod tests {
         let a = _mm256_set1_epi64x(4);
         let b = _mm256_set1_epi64x(2);
         let r = _mm256_sub_epi64(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4521,7 +4521,7 @@ mod tests {
         let a = _mm256_set1_epi8(4);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_sub_epi8(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4529,7 +4529,7 @@ mod tests {
         let a = _mm256_set1_epi16(4);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_subs_epi16(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4537,7 +4537,7 @@ mod tests {
         let a = _mm256_set1_epi8(4);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_subs_epi8(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4545,7 +4545,7 @@ mod tests {
         let a = _mm256_set1_epi16(4);
         let b = _mm256_set1_epi16(2);
         let r = _mm256_subs_epu16(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4553,7 +4553,7 @@ mod tests {
         let a = _mm256_set1_epi8(4);
         let b = _mm256_set1_epi8(2);
         let r = _mm256_subs_epu8(a, b);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4561,7 +4561,7 @@ mod tests {
         let a = _mm256_set1_epi8(5);
         let b = _mm256_set1_epi8(3);
         let r = _mm256_xor_si256(a, b);
-        assert_eq!(r, _mm256_set1_epi8(6));
+        assert_eq_m256i(r, _mm256_set1_epi8(6));
     }
 
     #[simd_test = "avx2"]
@@ -4581,7 +4581,7 @@ mod tests {
             -25, -26, -27, -28, -29, -30, -31, -32,
         );
         let r = _mm256_alignr_epi8(a, b, 33);
-        assert_eq!(r, _mm256_set1_epi8(0));
+        assert_eq_m256i(r, _mm256_set1_epi8(0));
 
         let r = _mm256_alignr_epi8(a, b, 17);
         #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -4591,7 +4591,7 @@ mod tests {
             18, 19, 20, 21, 22, 23, 24, 25,
             26, 27, 28, 29, 30, 31, 32, 0,
         );
-        assert_eq!(r, expected);
+        assert_eq_m256i(r, expected);
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let expected = _mm256_setr_epi8(
@@ -4601,7 +4601,7 @@ mod tests {
             9, 10, 11, 12, 13, 14, 15, 16,
         );
         let r = _mm256_alignr_epi8(a, b, 16);
-        assert_eq!(r, expected);
+        assert_eq_m256i(r, expected);
 
         let r = _mm256_alignr_epi8(a, b, 15);
         #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -4611,10 +4611,10 @@ mod tests {
             -32, 1, 2, 3, 4, 5, 6, 7,
             8, 9, 10, 11, 12, 13, 14, 15,
         );
-        assert_eq!(r, expected);
+        assert_eq_m256i(r, expected);
 
         let r = _mm256_alignr_epi8(a, b, 0);
-        assert_eq!(r, b);
+        assert_eq_m256i(r, b);
     }
 
     #[simd_test = "avx2"]
@@ -4641,7 +4641,7 @@ mod tests {
             29, 22, 22, 27, 21, 18, 25, 17,
         );
         let r = _mm256_shuffle_epi8(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m256i(r, expected);
     }
 
     #[simd_test = "avx2"]
@@ -4650,7 +4650,7 @@ mod tests {
         let b = _mm256_setr_epi32(5, 0, 5, 1, 7, 6, 3, 4);
         let expected = _mm256_setr_epi32(600, 100, 600, 200, 800, 700, 400, 500);
         let r = _mm256_permutevar8x32_epi32(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m256i(r, expected);
     }
 
     #[simd_test = "avx2"]
@@ -4658,7 +4658,7 @@ mod tests {
         let a = _mm256_setr_epi64x(100, 200, 300, 400);
         let expected = _mm256_setr_epi64x(400, 100, 200, 100);
         let r = _mm256_permute4x64_epi64(a, 0b00010011);
-        assert_eq!(r, expected);
+        assert_eq_m256i(r, expected);
     }
 
     #[simd_test = "avx2"]
@@ -4667,7 +4667,7 @@ mod tests {
         let b = _mm256_setr_epi64x(300, 400, 700, 800);
         let r = _mm256_permute2x128_si256(a, b, 0b00_01_00_11);
         let e = _mm256_setr_epi64x(700, 800, 500, 600);
-        assert_eq!(r, e);
+        assert_eq_m256i(r, e);
     }
 
     #[simd_test = "avx2"]
@@ -4731,7 +4731,7 @@ mod tests {
             _mm256_setr_epi32(0, 16, 32, 48, 1, 2, 3, 4),
             4,
         );
-        assert_eq!(r, _mm256_setr_epi32(0, 16, 32, 48, 1, 2, 3, 4));
+        assert_eq_m256i(r, _mm256_setr_epi32(0, 16, 32, 48, 1, 2, 3, 4));
     }
 
     #[simd_test = "avx2"]
@@ -4748,7 +4748,7 @@ mod tests {
             _mm256_setr_epi32(-1, -1, -1, 0, 0, 0, 0, 0),
             4,
         );
-        assert_eq!(r, _mm256_setr_epi32(0, 16, 64, 256, 256, 256, 256, 256));
+        assert_eq_m256i(r, _mm256_setr_epi32(0, 16, 64, 256, 256, 256, 256, 256));
     }
 
     #[simd_test = "avx2"]
@@ -4867,7 +4867,7 @@ mod tests {
             _mm_setr_epi32(0, 16, 32, 48),
             8,
         );
-        assert_eq!(r, _mm256_setr_epi64x(0, 16, 32, 48));
+        assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 32, 48));
     }
 
     #[simd_test = "avx2"]
@@ -4884,7 +4884,7 @@ mod tests {
             _mm256_setr_epi64x(-1, -1, -1, 0),
             8,
         );
-        assert_eq!(r, _mm256_setr_epi64x(0, 16, 64, 256));
+        assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 64, 256));
     }
 
     #[simd_test = "avx2"]
@@ -5124,7 +5124,7 @@ mod tests {
             _mm256_setr_epi64x(0, 16, 32, 48),
             8,
         );
-        assert_eq!(r, _mm256_setr_epi64x(0, 16, 32, 48));
+        assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 32, 48));
     }
 
     #[simd_test = "avx2"]
@@ -5141,7 +5141,7 @@ mod tests {
             _mm256_setr_epi64x(-1, -1, -1, 0),
             8,
         );
-        assert_eq!(r, _mm256_setr_epi64x(0, 16, 64, 256));
+        assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 64, 256));
     }
 
     #[simd_test = "avx2"]

--- a/coresimd/src/x86/i586/sse.rs
+++ b/coresimd/src/x86/i586/sse.rs
@@ -3188,6 +3188,6 @@ mod tests {
         let mut mem =
             ::std::boxed::Box::<__m64>::new(transmute(i8x8::splat(1)));
         _mm_stream_pi(&mut *mem as *mut _ as *mut _, a);
-        assert_eq!(a, *mem);
+        assert_eq_m64(a, *mem);
     }
 }

--- a/coresimd/src/x86/i586/sse2.rs
+++ b/coresimd/src/x86/i586/sse2.rs
@@ -2369,7 +2369,7 @@ mod tests {
         let e = _mm_setr_epi8(
             16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2377,7 +2377,7 @@ mod tests {
         let a = _mm_set1_epi8(0x7F);
         let b = _mm_set1_epi8(1);
         let r = _mm_add_epi8(a, b);
-        assert_eq!(r, _mm_set1_epi8(-128));
+        assert_eq_m128i(r, _mm_set1_epi8(-128));
     }
 
     #[simd_test = "sse2"]
@@ -2386,7 +2386,7 @@ mod tests {
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_add_epi16(a, b);
         let e = _mm_setr_epi16(8, 10, 12, 14, 16, 18, 20, 22);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2395,7 +2395,7 @@ mod tests {
         let b = _mm_setr_epi32(4, 5, 6, 7);
         let r = _mm_add_epi32(a, b);
         let e = _mm_setr_epi32(4, 6, 8, 10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2404,7 +2404,7 @@ mod tests {
         let b = _mm_setr_epi64x(2, 3);
         let r = _mm_add_epi64(a, b);
         let e = _mm_setr_epi64x(2, 4);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2420,7 +2420,7 @@ mod tests {
         let e = _mm_setr_epi8(
             16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2428,7 +2428,7 @@ mod tests {
         let a = _mm_set1_epi8(0x7F);
         let b = _mm_set1_epi8(1);
         let r = _mm_adds_epi8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2436,7 +2436,7 @@ mod tests {
         let a = _mm_set1_epi8(-0x80);
         let b = _mm_set1_epi8(-1);
         let r = _mm_adds_epi8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2445,7 +2445,7 @@ mod tests {
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_adds_epi16(a, b);
         let e = _mm_setr_epi16(8, 10, 12, 14, 16, 18, 20, 22);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2453,7 +2453,7 @@ mod tests {
         let a = _mm_set1_epi16(0x7FFF);
         let b = _mm_set1_epi16(1);
         let r = _mm_adds_epi16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2461,7 +2461,7 @@ mod tests {
         let a = _mm_set1_epi16(-0x8000);
         let b = _mm_set1_epi16(-1);
         let r = _mm_adds_epi16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2477,7 +2477,7 @@ mod tests {
         let e = _mm_setr_epi8(
             16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2485,7 +2485,7 @@ mod tests {
         let a = _mm_set1_epi8(!0);
         let b = _mm_set1_epi8(1);
         let r = _mm_adds_epu8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2494,7 +2494,7 @@ mod tests {
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_adds_epu16(a, b);
         let e = _mm_setr_epi16(8, 10, 12, 14, 16, 18, 20, 22);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2502,21 +2502,21 @@ mod tests {
         let a = _mm_set1_epi16(!0);
         let b = _mm_set1_epi16(1);
         let r = _mm_adds_epu16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_avg_epu8() {
         let (a, b) = (_mm_set1_epi8(3), _mm_set1_epi8(9));
         let r = _mm_avg_epu8(a, b);
-        assert_eq!(r, _mm_set1_epi8(6));
+        assert_eq_m128i(r, _mm_set1_epi8(6));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_avg_epu16() {
         let (a, b) = (_mm_set1_epi16(3), _mm_set1_epi16(9));
         let r = _mm_avg_epu16(a, b);
-        assert_eq!(r, _mm_set1_epi16(6));
+        assert_eq_m128i(r, _mm_set1_epi16(6));
     }
 
     #[simd_test = "sse2"]
@@ -2525,7 +2525,7 @@ mod tests {
         let b = _mm_setr_epi16(9, 10, 11, 12, 13, 14, 15, 16);
         let r = _mm_madd_epi16(a, b);
         let e = _mm_setr_epi32(29, 81, 149, 233);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2533,7 +2533,7 @@ mod tests {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(-1);
         let r = _mm_max_epi16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2541,7 +2541,7 @@ mod tests {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(!0);
         let r = _mm_max_epu8(a, b);
-        assert_eq!(r, b);
+        assert_eq_m128i(r, b);
     }
 
     #[simd_test = "sse2"]
@@ -2549,7 +2549,7 @@ mod tests {
         let a = _mm_set1_epi16(1);
         let b = _mm_set1_epi16(-1);
         let r = _mm_min_epi16(a, b);
-        assert_eq!(r, b);
+        assert_eq_m128i(r, b);
     }
 
     #[simd_test = "sse2"]
@@ -2557,28 +2557,28 @@ mod tests {
         let a = _mm_set1_epi8(1);
         let b = _mm_set1_epi8(!0);
         let r = _mm_min_epu8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_mulhi_epi16() {
         let (a, b) = (_mm_set1_epi16(1000), _mm_set1_epi16(-1001));
         let r = _mm_mulhi_epi16(a, b);
-        assert_eq!(r, _mm_set1_epi16(-16));
+        assert_eq_m128i(r, _mm_set1_epi16(-16));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_mulhi_epu16() {
         let (a, b) = (_mm_set1_epi16(1000), _mm_set1_epi16(1001));
         let r = _mm_mulhi_epu16(a, b);
-        assert_eq!(r, _mm_set1_epi16(15));
+        assert_eq_m128i(r, _mm_set1_epi16(15));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_mullo_epi16() {
         let (a, b) = (_mm_set1_epi16(1000), _mm_set1_epi16(-1001));
         let r = _mm_mullo_epi16(a, b);
-        assert_eq!(r, _mm_set1_epi16(-17960));
+        assert_eq_m128i(r, _mm_set1_epi16(-17960));
     }
 
     #[simd_test = "sse2"]
@@ -2587,7 +2587,7 @@ mod tests {
         let b = _mm_setr_epi64x(1_000_000_000, 1 << 35);
         let r = _mm_mul_epu32(a, b);
         let e = _mm_setr_epi64x(1_000_000_000 * 1_000_000_000, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -2602,42 +2602,42 @@ mod tests {
         let b = _mm_setr_epi8(0, 0, 0, 0, 2, 1, 2, 1, 1, 1, 1, 1, 1, 2, 1, 2);
         let r = _mm_sad_epu8(a, b);
         let e = _mm_setr_epi64x(1020, 614);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_sub_epi8() {
         let (a, b) = (_mm_set1_epi8(5), _mm_set1_epi8(6));
         let r = _mm_sub_epi8(a, b);
-        assert_eq!(r, _mm_set1_epi8(-1));
+        assert_eq_m128i(r, _mm_set1_epi8(-1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_sub_epi16() {
         let (a, b) = (_mm_set1_epi16(5), _mm_set1_epi16(6));
         let r = _mm_sub_epi16(a, b);
-        assert_eq!(r, _mm_set1_epi16(-1));
+        assert_eq_m128i(r, _mm_set1_epi16(-1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_sub_epi32() {
         let (a, b) = (_mm_set1_epi32(5), _mm_set1_epi32(6));
         let r = _mm_sub_epi32(a, b);
-        assert_eq!(r, _mm_set1_epi32(-1));
+        assert_eq_m128i(r, _mm_set1_epi32(-1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_sub_epi64() {
         let (a, b) = (_mm_set1_epi64x(5), _mm_set1_epi64x(6));
         let r = _mm_sub_epi64(a, b);
-        assert_eq!(r, _mm_set1_epi64x(-1));
+        assert_eq_m128i(r, _mm_set1_epi64x(-1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_subs_epi8() {
         let (a, b) = (_mm_set1_epi8(5), _mm_set1_epi8(2));
         let r = _mm_subs_epi8(a, b);
-        assert_eq!(r, _mm_set1_epi8(3));
+        assert_eq_m128i(r, _mm_set1_epi8(3));
     }
 
     #[simd_test = "sse2"]
@@ -2645,7 +2645,7 @@ mod tests {
         let a = _mm_set1_epi8(0x7F);
         let b = _mm_set1_epi8(-1);
         let r = _mm_subs_epi8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2653,14 +2653,14 @@ mod tests {
         let a = _mm_set1_epi8(-0x80);
         let b = _mm_set1_epi8(1);
         let r = _mm_subs_epi8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_subs_epi16() {
         let (a, b) = (_mm_set1_epi16(5), _mm_set1_epi16(2));
         let r = _mm_subs_epi16(a, b);
-        assert_eq!(r, _mm_set1_epi16(3));
+        assert_eq_m128i(r, _mm_set1_epi16(3));
     }
 
     #[simd_test = "sse2"]
@@ -2668,7 +2668,7 @@ mod tests {
         let a = _mm_set1_epi16(0x7FFF);
         let b = _mm_set1_epi16(-1);
         let r = _mm_subs_epi16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2676,14 +2676,14 @@ mod tests {
         let a = _mm_set1_epi16(-0x8000);
         let b = _mm_set1_epi16(1);
         let r = _mm_subs_epi16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_subs_epu8() {
         let (a, b) = (_mm_set1_epi8(5), _mm_set1_epi8(2));
         let r = _mm_subs_epu8(a, b);
-        assert_eq!(r, _mm_set1_epi8(3));
+        assert_eq_m128i(r, _mm_set1_epi8(3));
     }
 
     #[simd_test = "sse2"]
@@ -2691,14 +2691,14 @@ mod tests {
         let a = _mm_set1_epi8(0);
         let b = _mm_set1_epi8(1);
         let r = _mm_subs_epu8(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_subs_epu16() {
         let (a, b) = (_mm_set1_epi16(5), _mm_set1_epi16(2));
         let r = _mm_subs_epu16(a, b);
-        assert_eq!(r, _mm_set1_epi16(3));
+        assert_eq_m128i(r, _mm_set1_epi16(3));
     }
 
     #[simd_test = "sse2"]
@@ -2706,7 +2706,7 @@ mod tests {
         let a = _mm_set1_epi16(0);
         let b = _mm_set1_epi16(1);
         let r = _mm_subs_epu16(a, b);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -2718,7 +2718,7 @@ mod tests {
         let r = _mm_slli_si128(a, 1);
         let e =
             _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = _mm_setr_epi8(
@@ -2726,28 +2726,28 @@ mod tests {
         );
         let r = _mm_slli_si128(a, 15);
         let e = _mm_setr_epi8(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
         );
         let r = _mm_slli_si128(a, 16);
-        assert_eq!(r, _mm_set1_epi8(0));
+        assert_eq_m128i(r, _mm_set1_epi8(0));
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
         );
         let r = _mm_slli_si128(a, -1);
-        assert_eq!(_mm_set1_epi8(0), r);
+        assert_eq_m128i(_mm_set1_epi8(0), r);
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
         );
         let r = _mm_slli_si128(a, -0x80000000);
-        assert_eq!(r, _mm_set1_epi8(0));
+        assert_eq_m128i(r, _mm_set1_epi8(0));
     }
 
     #[simd_test = "sse2"]
@@ -2763,22 +2763,22 @@ mod tests {
             0xFFF0 as u16 as i16, 0xFFF0 as u16 as i16, 0x0FF0, 0x00F0,
             0, 0, 0, 0,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_sll_epi16() {
         let a = _mm_setr_epi16(0xFF, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_sll_epi16(a, _mm_setr_epi16(4, 0, 0, 0, 0, 0, 0, 0));
-        assert_eq!(r, _mm_setr_epi16(0xFF0, 0, 0, 0, 0, 0, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi16(0xFF0, 0, 0, 0, 0, 0, 0, 0));
         let r = _mm_sll_epi16(a, _mm_setr_epi16(0, 0, 0, 0, 4, 0, 0, 0));
-        assert_eq!(r, _mm_setr_epi16(0xFF, 0, 0, 0, 0, 0, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi16(0xFF, 0, 0, 0, 0, 0, 0, 0));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_slli_epi32() {
         let r = _mm_slli_epi32(_mm_set1_epi32(0xFFFF), 4);
-        assert_eq!(r, _mm_set1_epi32(0xFFFF0));
+        assert_eq_m128i(r, _mm_set1_epi32(0xFFFF0));
     }
 
     #[simd_test = "sse2"]
@@ -2786,13 +2786,13 @@ mod tests {
         let a = _mm_set1_epi32(0xFFFF);
         let b = _mm_setr_epi32(4, 0, 0, 0);
         let r = _mm_sll_epi32(a, b);
-        assert_eq!(r, _mm_set1_epi32(0xFFFF0));
+        assert_eq_m128i(r, _mm_set1_epi32(0xFFFF0));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_slli_epi64() {
         let r = _mm_slli_epi64(_mm_set1_epi64x(0xFFFFFFFF), 4);
-        assert_eq!(r, _mm_set1_epi64x(0xFFFFFFFF0));
+        assert_eq_m128i(r, _mm_set1_epi64x(0xFFFFFFFF0));
     }
 
     #[simd_test = "sse2"]
@@ -2800,13 +2800,13 @@ mod tests {
         let a = _mm_set1_epi64x(0xFFFFFFFF);
         let b = _mm_setr_epi64x(4, 0);
         let r = _mm_sll_epi64(a, b);
-        assert_eq!(r, _mm_set1_epi64x(0xFFFFFFFF0));
+        assert_eq_m128i(r, _mm_set1_epi64x(0xFFFFFFFF0));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_srai_epi16() {
         let r = _mm_srai_epi16(_mm_set1_epi16(-1), 1);
-        assert_eq!(r, _mm_set1_epi16(-1));
+        assert_eq_m128i(r, _mm_set1_epi16(-1));
     }
 
     #[simd_test = "sse2"]
@@ -2814,13 +2814,13 @@ mod tests {
         let a = _mm_set1_epi16(-1);
         let b = _mm_setr_epi16(1, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_sra_epi16(a, b);
-        assert_eq!(r, _mm_set1_epi16(-1));
+        assert_eq_m128i(r, _mm_set1_epi16(-1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_srai_epi32() {
         let r = _mm_srai_epi32(_mm_set1_epi32(-1), 1);
-        assert_eq!(r, _mm_set1_epi32(-1));
+        assert_eq_m128i(r, _mm_set1_epi32(-1));
     }
 
     #[simd_test = "sse2"]
@@ -2828,7 +2828,7 @@ mod tests {
         let a = _mm_set1_epi32(-1);
         let b = _mm_setr_epi32(1, 0, 0, 0);
         let r = _mm_sra_epi32(a, b);
-        assert_eq!(r, _mm_set1_epi32(-1));
+        assert_eq_m128i(r, _mm_set1_epi32(-1));
     }
 
     #[simd_test = "sse2"]
@@ -2842,7 +2842,7 @@ mod tests {
         let e = _mm_setr_epi8(
             2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = _mm_setr_epi8(
@@ -2850,28 +2850,28 @@ mod tests {
         );
         let r = _mm_srli_si128(a, 15);
         let e = _mm_setr_epi8(16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
         );
         let r = _mm_srli_si128(a, 16);
-        assert_eq!(r, _mm_set1_epi8(0));
+        assert_eq_m128i(r, _mm_set1_epi8(0));
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
         );
         let r = _mm_srli_si128(a, -1);
-        assert_eq!(r, _mm_set1_epi8(0));
+        assert_eq_m128i(r, _mm_set1_epi8(0));
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let a = _mm_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
         );
         let r = _mm_srli_si128(a, -0x80000000);
-        assert_eq!(r, _mm_set1_epi8(0));
+        assert_eq_m128i(r, _mm_set1_epi8(0));
     }
 
     #[simd_test = "sse2"]
@@ -2885,22 +2885,22 @@ mod tests {
         let e = _mm_setr_epi16(
             0xFFF as u16 as i16, 0xFF as u16 as i16, 0xF, 0, 0, 0, 0, 0,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_srl_epi16() {
         let a = _mm_setr_epi16(0xFF, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_srl_epi16(a, _mm_setr_epi16(4, 0, 0, 0, 0, 0, 0, 0));
-        assert_eq!(r, _mm_setr_epi16(0xF, 0, 0, 0, 0, 0, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi16(0xF, 0, 0, 0, 0, 0, 0, 0));
         let r = _mm_srl_epi16(a, _mm_setr_epi16(0, 0, 0, 0, 4, 0, 0, 0));
-        assert_eq!(r, _mm_setr_epi16(0xFF, 0, 0, 0, 0, 0, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi16(0xFF, 0, 0, 0, 0, 0, 0, 0));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_srli_epi32() {
         let r = _mm_srli_epi32(_mm_set1_epi32(0xFFFF), 4);
-        assert_eq!(r, _mm_set1_epi32(0xFFF));
+        assert_eq_m128i(r, _mm_set1_epi32(0xFFF));
     }
 
     #[simd_test = "sse2"]
@@ -2908,13 +2908,13 @@ mod tests {
         let a = _mm_set1_epi32(0xFFFF);
         let b = _mm_setr_epi32(4, 0, 0, 0);
         let r = _mm_srl_epi32(a, b);
-        assert_eq!(r, _mm_set1_epi32(0xFFF));
+        assert_eq_m128i(r, _mm_set1_epi32(0xFFF));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_srli_epi64() {
         let r = _mm_srli_epi64(_mm_set1_epi64x(0xFFFFFFFF), 4);
-        assert_eq!(r, _mm_set1_epi64x(0xFFFFFFF));
+        assert_eq_m128i(r, _mm_set1_epi64x(0xFFFFFFF));
     }
 
     #[simd_test = "sse2"]
@@ -2922,7 +2922,7 @@ mod tests {
         let a = _mm_set1_epi64x(0xFFFFFFFF);
         let b = _mm_setr_epi64x(4, 0);
         let r = _mm_srl_epi64(a, b);
-        assert_eq!(r, _mm_set1_epi64x(0xFFFFFFF));
+        assert_eq_m128i(r, _mm_set1_epi64x(0xFFFFFFF));
     }
 
     #[simd_test = "sse2"]
@@ -2930,7 +2930,7 @@ mod tests {
         let a = _mm_set1_epi8(5);
         let b = _mm_set1_epi8(3);
         let r = _mm_and_si128(a, b);
-        assert_eq!(r, _mm_set1_epi8(1));
+        assert_eq_m128i(r, _mm_set1_epi8(1));
     }
 
     #[simd_test = "sse2"]
@@ -2938,7 +2938,7 @@ mod tests {
         let a = _mm_set1_epi8(5);
         let b = _mm_set1_epi8(3);
         let r = _mm_andnot_si128(a, b);
-        assert_eq!(r, _mm_set1_epi8(2));
+        assert_eq_m128i(r, _mm_set1_epi8(2));
     }
 
     #[simd_test = "sse2"]
@@ -2946,7 +2946,7 @@ mod tests {
         let a = _mm_set1_epi8(5);
         let b = _mm_set1_epi8(3);
         let r = _mm_or_si128(a, b);
-        assert_eq!(r, _mm_set1_epi8(7));
+        assert_eq_m128i(r, _mm_set1_epi8(7));
     }
 
     #[simd_test = "sse2"]
@@ -2954,7 +2954,7 @@ mod tests {
         let a = _mm_set1_epi8(5);
         let b = _mm_set1_epi8(3);
         let r = _mm_xor_si128(a, b);
-        assert_eq!(r, _mm_set1_epi8(6));
+        assert_eq_m128i(r, _mm_set1_epi8(6));
     }
 
     #[simd_test = "sse2"]
@@ -2965,7 +2965,7 @@ mod tests {
             _mm_setr_epi8(15, 14, 2, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_cmpeq_epi8(a, b);
         #[cfg_attr(rustfmt, rustfmt_skip)]
-        assert_eq!(
+        assert_eq_m128i(
             r,
             _mm_setr_epi8(
                 0, 0, 0xFFu8 as i8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -2978,7 +2978,7 @@ mod tests {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_epi16(7, 6, 2, 4, 3, 2, 1, 0);
         let r = _mm_cmpeq_epi16(a, b);
-        assert_eq!(r, _mm_setr_epi16(0, 0, !0, 0, 0, 0, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi16(0, 0, !0, 0, 0, 0, 0, 0));
     }
 
     #[simd_test = "sse2"]
@@ -2986,7 +2986,7 @@ mod tests {
         let a = _mm_setr_epi32(0, 1, 2, 3);
         let b = _mm_setr_epi32(3, 2, 2, 0);
         let r = _mm_cmpeq_epi32(a, b);
-        assert_eq!(r, _mm_setr_epi32(0, 0, !0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(0, 0, !0, 0));
     }
 
     #[simd_test = "sse2"]
@@ -2995,7 +2995,7 @@ mod tests {
         let b = _mm_set1_epi8(0);
         let r = _mm_cmpgt_epi8(a, b);
         let e = _mm_set_epi8(!0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3004,7 +3004,7 @@ mod tests {
         let b = _mm_set1_epi16(0);
         let r = _mm_cmpgt_epi16(a, b);
         let e = _mm_set_epi16(!0, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3012,7 +3012,7 @@ mod tests {
         let a = _mm_set_epi32(5, 0, 0, 0);
         let b = _mm_set1_epi32(0);
         let r = _mm_cmpgt_epi32(a, b);
-        assert_eq!(r, _mm_set_epi32(!0, 0, 0, 0));
+        assert_eq_m128i(r, _mm_set_epi32(!0, 0, 0, 0));
     }
 
     #[simd_test = "sse2"]
@@ -3021,7 +3021,7 @@ mod tests {
         let b = _mm_set_epi8(5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_cmplt_epi8(a, b);
         let e = _mm_set_epi8(!0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3030,7 +3030,7 @@ mod tests {
         let b = _mm_set_epi16(5, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_cmplt_epi16(a, b);
         let e = _mm_set_epi16(!0, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3038,7 +3038,7 @@ mod tests {
         let a = _mm_set1_epi32(0);
         let b = _mm_set_epi32(5, 0, 0, 0);
         let r = _mm_cmplt_epi32(a, b);
-        assert_eq!(r, _mm_set_epi32(!0, 0, 0, 0));
+        assert_eq_m128i(r, _mm_set_epi32(!0, 0, 0, 0));
     }
 
     #[simd_test = "sse2"]
@@ -3066,13 +3066,13 @@ mod tests {
     unsafe fn test_mm_cvtps_epi32() {
         let a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_cvtps_epi32(a);
-        assert_eq!(r, _mm_setr_epi32(1, 2, 3, 4));
+        assert_eq_m128i(r, _mm_setr_epi32(1, 2, 3, 4));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_cvtsi32_si128() {
         let r = _mm_cvtsi32_si128(5);
-        assert_eq!(r, _mm_setr_epi32(5, 0, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(5, 0, 0, 0));
     }
 
     #[simd_test = "sse2"]
@@ -3084,19 +3084,19 @@ mod tests {
     #[simd_test = "sse2"]
     unsafe fn test_mm_set_epi64x() {
         let r = _mm_set_epi64x(0, 1);
-        assert_eq!(r, _mm_setr_epi64x(1, 0));
+        assert_eq_m128i(r, _mm_setr_epi64x(1, 0));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_set_epi32() {
         let r = _mm_set_epi32(0, 1, 2, 3);
-        assert_eq!(r, _mm_setr_epi32(3, 2, 1, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(3, 2, 1, 0));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_set_epi16() {
         let r = _mm_set_epi16(0, 1, 2, 3, 4, 5, 6, 7);
-        assert_eq!(r, _mm_setr_epi16(7, 6, 5, 4, 3, 2, 1, 0));
+        assert_eq_m128i(r, _mm_setr_epi16(7, 6, 5, 4, 3, 2, 1, 0));
     }
 
     #[simd_test = "sse2"]
@@ -3107,43 +3107,43 @@ mod tests {
         );
         let e =
             _mm_setr_epi8(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_set1_epi64x() {
         let r = _mm_set1_epi64x(1);
-        assert_eq!(r, _mm_set1_epi64x(1));
+        assert_eq_m128i(r, _mm_set1_epi64x(1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_set1_epi32() {
         let r = _mm_set1_epi32(1);
-        assert_eq!(r, _mm_set1_epi32(1));
+        assert_eq_m128i(r, _mm_set1_epi32(1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_set1_epi16() {
         let r = _mm_set1_epi16(1);
-        assert_eq!(r, _mm_set1_epi16(1));
+        assert_eq_m128i(r, _mm_set1_epi16(1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_set1_epi8() {
         let r = _mm_set1_epi8(1);
-        assert_eq!(r, _mm_set1_epi8(1));
+        assert_eq_m128i(r, _mm_set1_epi8(1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_setr_epi32() {
         let r = _mm_setr_epi32(0, 1, 2, 3);
-        assert_eq!(r, _mm_setr_epi32(0, 1, 2, 3));
+        assert_eq_m128i(r, _mm_setr_epi32(0, 1, 2, 3));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_setr_epi16() {
         let r = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
-        assert_eq!(r, _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7));
+        assert_eq_m128i(r, _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7));
     }
 
     #[simd_test = "sse2"]
@@ -3154,34 +3154,34 @@ mod tests {
         );
         let e =
             _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_setzero_si128() {
         let r = _mm_setzero_si128();
-        assert_eq!(r, _mm_set1_epi64x(0));
+        assert_eq_m128i(r, _mm_set1_epi64x(0));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_loadl_epi64() {
         let a = _mm_setr_epi64x(6, 5);
         let r = _mm_loadl_epi64(&a as *const _);
-        assert_eq!(r, _mm_setr_epi64x(6, 0));
+        assert_eq_m128i(r, _mm_setr_epi64x(6, 0));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_load_si128() {
         let a = _mm_set_epi64x(5, 6);
         let r = _mm_load_si128(&a as *const _ as *const _);
-        assert_eq!(a, r);
+        assert_eq_m128i(a, r);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_loadu_si128() {
         let a = _mm_set_epi64x(5, 6);
         let r = _mm_loadu_si128(&a as *const _ as *const _);
-        assert_eq!(a, r);
+        assert_eq_m128i(a, r);
     }
 
     #[simd_test = "sse2"]
@@ -3191,7 +3191,7 @@ mod tests {
         let mut r = _mm_set1_epi8(0);
         _mm_maskmoveu_si128(a, mask, &mut r as *mut _ as *mut i8);
         let e = _mm_set_epi8(0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3202,7 +3202,7 @@ mod tests {
             &mut r as *mut _ as *mut __m128i,
             a,
         );
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -3213,7 +3213,7 @@ mod tests {
             &mut r as *mut _ as *mut __m128i,
             a,
         );
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -3224,7 +3224,7 @@ mod tests {
             &mut r as *mut _ as *mut __m128i,
             a,
         );
-        assert_eq!(r, _mm_setr_epi64x(2, 0));
+        assert_eq_m128i(r, _mm_setr_epi64x(2, 0));
     }
 
     #[simd_test = "sse2"]
@@ -3232,7 +3232,7 @@ mod tests {
         let a = _mm_setr_epi32(1, 2, 3, 4);
         let mut r = _mm_undefined_si128();
         _mm_stream_si128(&mut r as *mut _, a);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
     }
 
     #[simd_test = "sse2"]
@@ -3247,7 +3247,7 @@ mod tests {
     unsafe fn test_mm_move_epi64() {
         let a = _mm_setr_epi64x(5, 6);
         let r = _mm_move_epi64(a);
-        assert_eq!(r, _mm_setr_epi64x(5, 0));
+        assert_eq_m128i(r, _mm_setr_epi64x(5, 0));
     }
 
     #[simd_test = "sse2"]
@@ -3256,7 +3256,7 @@ mod tests {
         let b = _mm_setr_epi16(0, 0, 0, 0, 0, 0, -0x81, 0x80);
         let r = _mm_packs_epi16(a, b);
         #[cfg_attr(rustfmt, rustfmt_skip)]
-        assert_eq!(
+        assert_eq_m128i(
             r,
             _mm_setr_epi8(
                 0x7F, -0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0x80, 0x7F
@@ -3269,7 +3269,7 @@ mod tests {
         let a = _mm_setr_epi32(0x8000, -0x8001, 0, 0);
         let b = _mm_setr_epi32(0, 0, -0x8001, 0x8000);
         let r = _mm_packs_epi32(a, b);
-        assert_eq!(
+        assert_eq_m128i(
             r,
             _mm_setr_epi16(0x7FFF, -0x8000, 0, 0, 0, 0, -0x8000, 0x7FFF)
         );
@@ -3280,7 +3280,7 @@ mod tests {
         let a = _mm_setr_epi16(0x100, -1, 0, 0, 0, 0, 0, 0);
         let b = _mm_setr_epi16(0, 0, 0, 0, 0, 0, -1, 0x100);
         let r = _mm_packus_epi16(a, b);
-        assert_eq!(
+        assert_eq_m128i(
             r,
             _mm_setr_epi8(!0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, !0)
         );
@@ -3300,7 +3300,7 @@ mod tests {
         let a = _mm_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7);
         let r = _mm_insert_epi16(a, 9, 0);
         let e = _mm_setr_epi16(9, 1, 2, 3, 4, 5, 6, 7);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3321,7 +3321,7 @@ mod tests {
         let a = _mm_setr_epi32(5, 10, 15, 20);
         let r = _mm_shuffle_epi32(a, 0b00_01_01_11);
         let e = _mm_setr_epi32(20, 10, 10, 5);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3329,7 +3329,7 @@ mod tests {
         let a = _mm_setr_epi16(1, 2, 3, 4, 5, 10, 15, 20);
         let r = _mm_shufflehi_epi16(a, 0b00_01_01_11);
         let e = _mm_setr_epi16(1, 2, 3, 4, 20, 10, 10, 5);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3337,7 +3337,7 @@ mod tests {
         let a = _mm_setr_epi16(5, 10, 15, 20, 1, 2, 3, 4);
         let r = _mm_shufflelo_epi16(a, 0b00_01_01_11);
         let e = _mm_setr_epi16(20, 10, 10, 5, 1, 2, 3, 4);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3353,7 +3353,7 @@ mod tests {
         let e = _mm_setr_epi8(
             8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3362,7 +3362,7 @@ mod tests {
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_unpackhi_epi16(a, b);
         let e = _mm_setr_epi16(4, 12, 5, 13, 6, 14, 7, 15);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3371,7 +3371,7 @@ mod tests {
         let b = _mm_setr_epi32(4, 5, 6, 7);
         let r = _mm_unpackhi_epi32(a, b);
         let e = _mm_setr_epi32(2, 6, 3, 7);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3380,7 +3380,7 @@ mod tests {
         let b = _mm_setr_epi64x(2, 3);
         let r = _mm_unpackhi_epi64(a, b);
         let e = _mm_setr_epi64x(1, 3);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3394,7 +3394,7 @@ mod tests {
         let r = _mm_unpacklo_epi8(a, b);
         let e =
             _mm_setr_epi8(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3403,7 +3403,7 @@ mod tests {
         let b = _mm_setr_epi16(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_unpacklo_epi16(a, b);
         let e = _mm_setr_epi16(0, 8, 1, 9, 2, 10, 3, 11);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3412,7 +3412,7 @@ mod tests {
         let b = _mm_setr_epi32(4, 5, 6, 7);
         let r = _mm_unpacklo_epi32(a, b);
         let e = _mm_setr_epi32(0, 4, 1, 5);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3421,7 +3421,7 @@ mod tests {
         let b = _mm_setr_epi64x(2, 3);
         let r = _mm_unpacklo_epi64(a, b);
         let e = _mm_setr_epi64x(0, 2);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3575,7 +3575,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpeq_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3583,7 +3583,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmplt_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3591,7 +3591,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmple_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3599,7 +3599,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(5.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpgt_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3607,7 +3607,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpge_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3615,7 +3615,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpord_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3623,7 +3623,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpunord_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3631,7 +3631,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpneq_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3639,7 +3639,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpnlt_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3647,7 +3647,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpnle_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3655,7 +3655,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(5.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpngt_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3663,7 +3663,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, transmute(2.0f64));
         let r = transmute::<_, __m128i>(_mm_cmpnge_sd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3671,7 +3671,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, 0);
         let r = transmute::<_, __m128i>(_mm_cmpeq_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3679,7 +3679,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, !0);
         let r = transmute::<_, __m128i>(_mm_cmplt_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3687,7 +3687,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, !0);
         let r = transmute::<_, __m128i>(_mm_cmple_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3695,7 +3695,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, 0);
         let r = transmute::<_, __m128i>(_mm_cmpgt_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3703,7 +3703,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(!0, 0);
         let r = transmute::<_, __m128i>(_mm_cmpge_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3711,7 +3711,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(0, !0);
         let r = transmute::<_, __m128i>(_mm_cmpord_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3719,7 +3719,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, 0);
         let r = transmute::<_, __m128i>(_mm_cmpunord_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3727,7 +3727,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(!0, !0);
         let r = transmute::<_, __m128i>(_mm_cmpneq_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3735,7 +3735,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(5.0, 3.0));
         let e = _mm_setr_epi64x(0, 0);
         let r = transmute::<_, __m128i>(_mm_cmpnlt_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3743,7 +3743,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, 0);
         let r = transmute::<_, __m128i>(_mm_cmpnle_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3751,7 +3751,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(5.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, !0);
         let r = transmute::<_, __m128i>(_mm_cmpngt_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -3759,7 +3759,7 @@ mod tests {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
         let e = _mm_setr_epi64x(0, !0);
         let r = transmute::<_, __m128i>(_mm_cmpnge_pd(a, b));
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse2"]
@@ -4068,22 +4068,22 @@ mod tests {
     #[simd_test = "sse2"]
     unsafe fn test_mm_cvtpd_epi32() {
         let r = _mm_cvtpd_epi32(_mm_setr_pd(-1.0, 5.0));
-        assert_eq!(r, _mm_setr_epi32(-1, 5, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(-1, 5, 0, 0));
 
         let r = _mm_cvtpd_epi32(_mm_setr_pd(-1.0, -5.0));
-        assert_eq!(r, _mm_setr_epi32(-1, -5, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(-1, -5, 0, 0));
 
         let r = _mm_cvtpd_epi32(_mm_setr_pd(f64::MAX, f64::MIN));
-        assert_eq!(r, _mm_setr_epi32(i32::MIN, i32::MIN, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(i32::MIN, i32::MIN, 0, 0));
 
         let r = _mm_cvtpd_epi32(_mm_setr_pd(
             f64::INFINITY,
             f64::NEG_INFINITY,
         ));
-        assert_eq!(r, _mm_setr_epi32(i32::MIN, i32::MIN, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(i32::MIN, i32::MIN, 0, 0));
 
         let r = _mm_cvtpd_epi32(_mm_setr_pd(f64::NAN, f64::NAN));
-        assert_eq!(r, _mm_setr_epi32(i32::MIN, i32::MIN, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(i32::MIN, i32::MIN, 0, 0));
     }
 
     #[simd_test = "sse2"]
@@ -4149,11 +4149,11 @@ mod tests {
     unsafe fn test_mm_cvttpd_epi32() {
         let a = _mm_setr_pd(-1.1, 2.2);
         let r = _mm_cvttpd_epi32(a);
-        assert_eq!(r, _mm_setr_epi32(-1, 2, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(-1, 2, 0, 0));
 
         let a = _mm_setr_pd(f64::NEG_INFINITY, f64::NAN);
         let r = _mm_cvttpd_epi32(a);
-        assert_eq!(r, _mm_setr_epi32(i32::MIN, i32::MIN, 0, 0));
+        assert_eq_m128i(r, _mm_setr_epi32(i32::MIN, i32::MIN, 0, 0));
     }
 
     #[simd_test = "sse2"]
@@ -4171,12 +4171,12 @@ mod tests {
     unsafe fn test_mm_cvttps_epi32() {
         let a = _mm_setr_ps(-1.1, 2.2, -3.3, 6.6);
         let r = _mm_cvttps_epi32(a);
-        assert_eq!(r, _mm_setr_epi32(-1, 2, -3, 6));
+        assert_eq_m128i(r, _mm_setr_epi32(-1, 2, -3, 6));
 
         let a =
             _mm_setr_ps(f32::NEG_INFINITY, f32::INFINITY, f32::MIN, f32::MAX);
         let r = _mm_cvttps_epi32(a);
-        assert_eq!(r, _mm_setr_epi32(i32::MIN, i32::MIN, i32::MIN, i32::MIN));
+        assert_eq_m128i(r, _mm_setr_epi32(i32::MIN, i32::MIN, i32::MIN, i32::MIN));
     }
 
     #[simd_test = "sse2"]
@@ -4276,7 +4276,7 @@ mod tests {
         let a = _mm_set1_pd(0.);
         let expected = _mm_set1_epi64x(0);
         let r = _mm_castpd_si128(a);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "sse2"]
@@ -4292,7 +4292,7 @@ mod tests {
         let a = _mm_set1_ps(0.);
         let expected = _mm_set1_epi32(0);
         let r = _mm_castps_si128(a);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "sse2"]

--- a/coresimd/src/x86/i586/sse3.rs
+++ b/coresimd/src/x86/i586/sse3.rs
@@ -189,7 +189,7 @@ mod tests {
             13, 14, 15, 16,
         );
         let r = _mm_lddqu_si128(&a);
-        assert_eq!(a, r);
+        assert_eq_m128i(a, r);
     }
 
     #[simd_test = "sse3"]

--- a/coresimd/src/x86/i586/sse41.rs
+++ b/coresimd/src/x86/i586/sse41.rs
@@ -815,7 +815,7 @@ mod tests {
         let e = _mm_setr_epi8(
             0, 17, 2, 19, 4, 21, 6, 23, 8, 25, 10, 27, 12, 29, 14, 31,
         );
-        assert_eq!(_mm_blendv_epi8(a, b, mask), e);
+        assert_eq_m128i(_mm_blendv_epi8(a, b, mask), e);
     }
 
     #[simd_test = "sse4.1"]
@@ -862,7 +862,7 @@ mod tests {
         let b = _mm_set1_epi16(1);
         let r = _mm_blend_epi16(a, b, 0b1010_1100);
         let e = _mm_setr_epi16(0, 0, 1, 1, 0, 1, 0, 1);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -907,9 +907,9 @@ mod tests {
         let a = _mm_set1_epi8(0);
         let e = _mm_setr_epi8(0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         let r = _mm_insert_epi8(a, 32, 1);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let r = _mm_insert_epi8(a, 32, 17);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -917,9 +917,9 @@ mod tests {
         let a = _mm_set1_epi32(0);
         let e = _mm_setr_epi32(0, 32, 0, 0);
         let r = _mm_insert_epi32(a, 32, 1);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let r = _mm_insert_epi32(a, 32, 5);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -940,7 +940,7 @@ mod tests {
             2, 4, 6, 8, 10, 12, 14, 16,
             18, 20, 22, 24, 26, 28, 30, 32,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -949,7 +949,7 @@ mod tests {
         let b = _mm_setr_epi16(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm_max_epu16(a, b);
         let e = _mm_setr_epi16(2, 4, 6, 8, 10, 12, 14, 16);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -958,7 +958,7 @@ mod tests {
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_max_epi32(a, b);
         let e = _mm_setr_epi32(2, 4, 6, 8);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -967,7 +967,7 @@ mod tests {
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_max_epu32(a, b);
         let e = _mm_setr_epi32(2, 4, 6, 8);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -988,7 +988,7 @@ mod tests {
             1, 3, 5, 7, 9, 11, 13, 15,
             17, 19, 21, 23, 25, 27, 29, 31,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1009,7 +1009,7 @@ mod tests {
             1, -4, -6, 7, -10, -12, 13, -16,
             17, 19, 21, 23, 25, 27, 29, 31,
         );
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1018,7 +1018,7 @@ mod tests {
         let b = _mm_setr_epi16(2, 3, 6, 7, 10, 11, 14, 15);
         let r = _mm_min_epu16(a, b);
         let e = _mm_setr_epi16(1, 3, 5, 7, 9, 11, 13, 15);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1027,7 +1027,7 @@ mod tests {
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_min_epi32(a, b);
         let e = _mm_setr_epi32(1, 3, 5, 7);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1036,7 +1036,7 @@ mod tests {
         let b = _mm_setr_epi32(-2, 3, -6, 8);
         let r = _mm_min_epi32(a, b);
         let e = _mm_setr_epi32(-2, 3, -6, -7);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1045,7 +1045,7 @@ mod tests {
         let b = _mm_setr_epi32(2, 3, 6, 7);
         let r = _mm_min_epu32(a, b);
         let e = _mm_setr_epi32(1, 3, 5, 7);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1054,7 +1054,7 @@ mod tests {
         let b = _mm_setr_epi32(-1, -2, -3, -4);
         let r = _mm_packus_epi32(a, b);
         let e = _mm_setr_epi16(1, 2, 3, 4, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1063,7 +1063,7 @@ mod tests {
         let b = _mm_setr_epi64x(0, 0);
         let r = _mm_cmpeq_epi64(a, b);
         let e = _mm_setr_epi64x(-1, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1071,11 +1071,11 @@ mod tests {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepi8_epi16(a);
         let e = _mm_set1_epi16(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let a = _mm_set1_epi8(-10);
         let r = _mm_cvtepi8_epi16(a);
         let e = _mm_set1_epi16(-10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1083,11 +1083,11 @@ mod tests {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepi8_epi32(a);
         let e = _mm_set1_epi32(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let a = _mm_set1_epi8(-10);
         let r = _mm_cvtepi8_epi32(a);
         let e = _mm_set1_epi32(-10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1095,11 +1095,11 @@ mod tests {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepi8_epi64(a);
         let e = _mm_set1_epi64x(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let a = _mm_set1_epi8(-10);
         let r = _mm_cvtepi8_epi64(a);
         let e = _mm_set1_epi64x(-10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1107,11 +1107,11 @@ mod tests {
         let a = _mm_set1_epi16(10);
         let r = _mm_cvtepi16_epi32(a);
         let e = _mm_set1_epi32(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let a = _mm_set1_epi16(-10);
         let r = _mm_cvtepi16_epi32(a);
         let e = _mm_set1_epi32(-10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1119,11 +1119,11 @@ mod tests {
         let a = _mm_set1_epi16(10);
         let r = _mm_cvtepi16_epi64(a);
         let e = _mm_set1_epi64x(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let a = _mm_set1_epi16(-10);
         let r = _mm_cvtepi16_epi64(a);
         let e = _mm_set1_epi64x(-10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1131,11 +1131,11 @@ mod tests {
         let a = _mm_set1_epi32(10);
         let r = _mm_cvtepi32_epi64(a);
         let e = _mm_set1_epi64x(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let a = _mm_set1_epi32(-10);
         let r = _mm_cvtepi32_epi64(a);
         let e = _mm_set1_epi64x(-10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1143,7 +1143,7 @@ mod tests {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepu8_epi16(a);
         let e = _mm_set1_epi16(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1151,7 +1151,7 @@ mod tests {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepu8_epi32(a);
         let e = _mm_set1_epi32(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1159,7 +1159,7 @@ mod tests {
         let a = _mm_set1_epi8(10);
         let r = _mm_cvtepu8_epi64(a);
         let e = _mm_set1_epi64x(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1167,7 +1167,7 @@ mod tests {
         let a = _mm_set1_epi16(10);
         let r = _mm_cvtepu16_epi32(a);
         let e = _mm_set1_epi32(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1175,7 +1175,7 @@ mod tests {
         let a = _mm_set1_epi16(10);
         let r = _mm_cvtepu16_epi64(a);
         let e = _mm_set1_epi64x(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1183,7 +1183,7 @@ mod tests {
         let a = _mm_set1_epi32(10);
         let r = _mm_cvtepu32_epi64(a);
         let e = _mm_set1_epi64x(10);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1315,7 +1315,7 @@ mod tests {
         let a = _mm_setr_epi16(23, 18, 44, 97, 50, 13, 67, 66);
         let r = _mm_minpos_epu16(a);
         let e = _mm_setr_epi16(13, 5, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1323,7 +1323,7 @@ mod tests {
         let a = _mm_setr_epi16(0, 18, 44, 97, 50, 13, 67, 66);
         let r = _mm_minpos_epu16(a);
         let e = _mm_setr_epi16(0, 0, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1333,7 +1333,7 @@ mod tests {
             let b = _mm_setr_epi32(1, 2, 3, 4);
             let r = _mm_mul_epi32(a, b);
             let e = _mm_setr_epi64x(1, 3);
-            assert_eq!(r, e);
+            assert_eq_m128i(r, e);
         }
         {
             let a = _mm_setr_epi32(
@@ -1350,7 +1350,7 @@ mod tests {
             );
             let r = _mm_mul_epi32(a, b);
             let e = _mm_setr_epi64x(-300, 823043843622);
-            assert_eq!(r, e);
+            assert_eq_m128i(r, e);
         }
     }
 
@@ -1361,7 +1361,7 @@ mod tests {
             let b = _mm_setr_epi32(1, 2, 3, 4);
             let r = _mm_mullo_epi32(a, b);
             let e = _mm_setr_epi32(1, 2, 3, 4);
-            assert_eq!(r, e);
+            assert_eq_m128i(r, e);
         }
         {
             let a = _mm_setr_epi32(15, -2, 1234567, 99999);
@@ -1371,7 +1371,7 @@ mod tests {
             // as a sign bit:
             // 1234567 * 666666 = -1589877210
             let e = _mm_setr_epi32(-300, 512, -1589877210, -1409865409);
-            assert_eq!(r, e);
+            assert_eq_m128i(r, e);
         }
     }
 
@@ -1380,7 +1380,7 @@ mod tests {
         let a = _mm_setr_epi16(8, 7, 6, 5, 4, 1, 2, 3);
         let r = _mm_minpos_epu16(a);
         let e = _mm_setr_epi16(1, 5, 0, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4.1"]
@@ -1390,22 +1390,22 @@ mod tests {
 
         let r = _mm_mpsadbw_epu8(a, a, 0b000);
         let e = _mm_setr_epi16(0, 4, 8, 12, 16, 20, 24, 28);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         let r = _mm_mpsadbw_epu8(a, a, 0b001);
         let e = _mm_setr_epi16(16, 12, 8, 4, 0, 4, 8, 12);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         let r = _mm_mpsadbw_epu8(a, a, 0b100);
         let e = _mm_setr_epi16(16, 20, 24, 28, 32, 36, 40, 44);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         let r = _mm_mpsadbw_epu8(a, a, 0b101);
         let e = _mm_setr_epi16(0, 4, 8, 12, 16, 20, 24, 28);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
 
         let r = _mm_mpsadbw_epu8(a, a, 0b111);
         let e = _mm_setr_epi16(32, 28, 24, 20, 16, 12, 8, 4);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 }

--- a/coresimd/src/x86/i586/sse42.rs
+++ b/coresimd/src/x86/i586/sse42.rs
@@ -640,7 +640,7 @@ mod tests {
             0x00, !0, !0, !0, !0, !0, !0, 0x00,
             !0, !0, !0, !0, 0x00, !0, !0, !0,
         );
-        assert_eq!(i, res);
+        assert_eq_m128i(i, res);
     }
 
     #[simd_test = "sse4.2"]
@@ -715,7 +715,7 @@ mod tests {
             !0, !0, !0, !0, !0, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
         );
-        assert_eq!(i, r);
+        assert_eq_m128i(i, r);
     }
 
     #[simd_test = "sse4.2"]

--- a/coresimd/src/x86/i586/ssse3.rs
+++ b/coresimd/src/x86/i586/ssse3.rs
@@ -296,19 +296,19 @@ mod tests {
     #[simd_test = "ssse3"]
     unsafe fn test_mm_abs_epi8() {
         let r = _mm_abs_epi8(_mm_set1_epi8(-5));
-        assert_eq!(r, _mm_set1_epi8(5));
+        assert_eq_m128i(r, _mm_set1_epi8(5));
     }
 
     #[simd_test = "ssse3"]
     unsafe fn test_mm_abs_epi16() {
         let r = _mm_abs_epi16(_mm_set1_epi16(-5));
-        assert_eq!(r, _mm_set1_epi16(5));
+        assert_eq_m128i(r, _mm_set1_epi16(5));
     }
 
     #[simd_test = "ssse3"]
     unsafe fn test_mm_abs_epi32() {
         let r = _mm_abs_epi32(_mm_set1_epi32(-5));
-        assert_eq!(r, _mm_set1_epi32(5));
+        assert_eq_m128i(r, _mm_set1_epi32(5));
     }
 
     #[simd_test = "ssse3"]
@@ -320,7 +320,7 @@ mod tests {
         let expected =
             _mm_setr_epi8(5, 0, 5, 4, 9, 13, 7, 4, 13, 6, 6, 11, 5, 2, 9, 1);
         let r = _mm_shuffle_epi8(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -330,23 +330,23 @@ mod tests {
         let b =
             _mm_setr_epi8(4, 63, 4, 3, 24, 12, 6, 19, 12, 5, 5, 10, 4, 1, 8, 0);
         let r = _mm_alignr_epi8(a, b, 33);
-        assert_eq!(r, _mm_set1_epi8(0));
+        assert_eq_m128i(r, _mm_set1_epi8(0));
 
         let r = _mm_alignr_epi8(a, b, 17);
         let expected =
             _mm_setr_epi8(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
 
         let r = _mm_alignr_epi8(a, b, 16);
-        assert_eq!(r, a);
+        assert_eq_m128i(r, a);
 
         let r = _mm_alignr_epi8(a, b, 15);
         let expected =
             _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
 
         let r = _mm_alignr_epi8(a, b, 0);
-        assert_eq!(r, b);
+        assert_eq_m128i(r, b);
     }
 
     #[simd_test = "ssse3"]
@@ -355,7 +355,7 @@ mod tests {
         let b = _mm_setr_epi16(4, 128, 4, 3, 24, 12, 6, 19);
         let expected = _mm_setr_epi16(3, 7, 11, 15, 132, 7, 36, 25);
         let r = _mm_hadd_epi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -364,7 +364,7 @@ mod tests {
         let b = _mm_setr_epi16(4, 128, 4, 3, 32767, 1, -32768, -1);
         let expected = _mm_setr_epi16(3, 7, 11, 15, 132, 7, 32767, -32768);
         let r = _mm_hadds_epi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -373,7 +373,7 @@ mod tests {
         let b = _mm_setr_epi32(4, 128, 4, 3);
         let expected = _mm_setr_epi32(3, 7, 132, 7);
         let r = _mm_hadd_epi32(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -382,7 +382,7 @@ mod tests {
         let b = _mm_setr_epi16(4, 128, 4, 3, 24, 12, 6, 19);
         let expected = _mm_setr_epi16(-1, -1, -1, -1, -124, 1, 12, -13);
         let r = _mm_hsub_epi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -391,7 +391,7 @@ mod tests {
         let b = _mm_setr_epi16(4, 128, 4, 3, 32767, -1, -32768, 1);
         let expected = _mm_setr_epi16(-1, -1, -1, -1, -124, 1, 32767, -32768);
         let r = _mm_hsubs_epi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -400,7 +400,7 @@ mod tests {
         let b = _mm_setr_epi32(4, 128, 4, 3);
         let expected = _mm_setr_epi32(-1, -1, -124, 1);
         let r = _mm_hsub_epi32(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -411,7 +411,7 @@ mod tests {
             _mm_setr_epi8(4, 63, 4, 3, 24, 12, 6, 19, 12, 5, 5, 10, 4, 1, 8, 0);
         let expected = _mm_setr_epi16(130, 24, 192, 194, 158, 175, 66, 120);
         let r = _mm_maddubs_epi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -420,7 +420,7 @@ mod tests {
         let b = _mm_setr_epi16(4, 128, 4, 3, 32767, -1, -32768, 1);
         let expected = _mm_setr_epi16(0, 0, 0, 0, 5, 0, -7, 0);
         let r = _mm_mulhrs_epi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -441,7 +441,7 @@ mod tests {
             9, 10, -11, 12, 13, -14, 15, 0,
         );
         let r = _mm_sign_epi8(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -450,7 +450,7 @@ mod tests {
         let b = _mm_setr_epi16(4, 128, 0, 3, 1, -1, -2, 1);
         let expected = _mm_setr_epi16(1, 2, 0, 4, -5, 6, -7, 8);
         let r = _mm_sign_epi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -459,6 +459,6 @@ mod tests {
         let b = _mm_setr_epi32(1, -1, 1, 0);
         let expected = _mm_setr_epi32(-1, -2, 3, 0);
         let r = _mm_sign_epi32(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 }

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -493,7 +493,7 @@ mod tests {
     #[simd_test = "mmx"]
     unsafe fn test_mm_setzero_si64() {
         let r: __m64 = ::std::mem::transmute(0_i64);
-        assert_eq!(r, _mm_setzero_si64());
+        assert_eq_m64(r, _mm_setzero_si64());
     }
 
     #[simd_test = "mmx"]
@@ -501,8 +501,8 @@ mod tests {
         let a = _mm_setr_pi8(-1, -1, 1, 1, -1, 0, 1, 0);
         let b = _mm_setr_pi8(-127, 101, 99, 126, 0, -1, 0, 1);
         let e = _mm_setr_pi8(-128, 100, 100, 127, -1, -1, 1, 1);
-        assert_eq!(e, _mm_add_pi8(a, b));
-        assert_eq!(e, _m_paddb(a, b));
+        assert_eq_m64(e, _mm_add_pi8(a, b));
+        assert_eq_m64(e, _m_paddb(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -515,8 +515,8 @@ mod tests {
             i16::max_value() - 1,
         );
         let e = _mm_setr_pi16(i16::min_value(), 30000, -30000, i16::max_value());
-        assert_eq!(e, _mm_add_pi16(a, b));
-        assert_eq!(e, _m_paddw(a, b));
+        assert_eq_m64(e, _mm_add_pi16(a, b));
+        assert_eq_m64(e, _m_paddw(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -524,8 +524,8 @@ mod tests {
         let a = _mm_setr_pi32(1, -1);
         let b = _mm_setr_pi32(i32::max_value() - 1, i32::min_value() + 1);
         let e = _mm_setr_pi32(i32::max_value(), i32::min_value());
-        assert_eq!(e, _mm_add_pi32(a, b));
-        assert_eq!(e, _m_paddd(a, b));
+        assert_eq_m64(e, _mm_add_pi32(a, b));
+        assert_eq_m64(e, _m_paddd(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -534,8 +534,8 @@ mod tests {
         let b = _mm_setr_pi8(-100, 1, -1, 100, 0, -1, 0, 1);
         let e =
             _mm_setr_pi8(i8::min_value(), 0, 0, i8::max_value(), -1, -1, 1, 1);
-        assert_eq!(e, _mm_adds_pi8(a, b));
-        assert_eq!(e, _m_paddsb(a, b));
+        assert_eq_m64(e, _mm_adds_pi8(a, b));
+        assert_eq_m64(e, _m_paddsb(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -543,8 +543,8 @@ mod tests {
         let a = _mm_setr_pi16(-32000, 32000, 4, 0);
         let b = _mm_setr_pi16(-32000, 32000, -5, 1);
         let e = _mm_setr_pi16(i16::min_value(), i16::max_value(), -1, 1);
-        assert_eq!(e, _mm_adds_pi16(a, b));
-        assert_eq!(e, _m_paddsw(a, b));
+        assert_eq_m64(e, _mm_adds_pi16(a, b));
+        assert_eq_m64(e, _m_paddsw(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -552,8 +552,8 @@ mod tests {
         let a = _mm_setr_pi8(0, 1, 2, 3, 4, 5, 6, 200u8 as i8);
         let b = _mm_setr_pi8(0, 10, 20, 30, 40, 50, 60, 200u8 as i8);
         let e = _mm_setr_pi8(0, 11, 22, 33, 44, 55, 66, u8::max_value() as i8);
-        assert_eq!(e, _mm_adds_pu8(a, b));
-        assert_eq!(e, _m_paddusb(a, b));
+        assert_eq_m64(e, _mm_adds_pu8(a, b));
+        assert_eq_m64(e, _m_paddusb(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -561,8 +561,8 @@ mod tests {
         let a = _mm_setr_pi16(0, 1, 2, 60000u16 as i16);
         let b = _mm_setr_pi16(0, 10, 20, 60000u16 as i16);
         let e = _mm_setr_pi16(0, 11, 22, u16::max_value() as i16);
-        assert_eq!(e, _mm_adds_pu16(a, b));
-        assert_eq!(e, _m_paddusw(a, b));
+        assert_eq_m64(e, _mm_adds_pu16(a, b));
+        assert_eq_m64(e, _m_paddusw(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -570,8 +570,8 @@ mod tests {
         let a = _mm_setr_pi8(0, 0, 1, 1, -1, -1, 0, 0);
         let b = _mm_setr_pi8(-1, 1, -2, 2, 100, -100, -127, 127);
         let e = _mm_setr_pi8(1, -1, 3, -1, -101, 99, 127, -127);
-        assert_eq!(e, _mm_sub_pi8(a, b));
-        assert_eq!(e, _m_psubb(a, b));
+        assert_eq_m64(e, _mm_sub_pi8(a, b));
+        assert_eq_m64(e, _m_psubb(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -579,8 +579,8 @@ mod tests {
         let a = _mm_setr_pi16(-20000, -20000, 20000, 30000);
         let b = _mm_setr_pi16(-10000, 10000, -10000, 30000);
         let e = _mm_setr_pi16(-10000, -30000, 30000, 0);
-        assert_eq!(e, _mm_sub_pi16(a, b));
-        assert_eq!(e, _m_psubw(a, b));
+        assert_eq_m64(e, _mm_sub_pi16(a, b));
+        assert_eq_m64(e, _m_psubw(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -588,8 +588,8 @@ mod tests {
         let a = _mm_setr_pi32(500_000, -500_000);
         let b = _mm_setr_pi32(500_000, 500_000);
         let e = _mm_setr_pi32(0, -1_000_000);
-        assert_eq!(e, _mm_sub_pi32(a, b));
-        assert_eq!(e, _m_psubd(a, b));
+        assert_eq_m64(e, _mm_sub_pi32(a, b));
+        assert_eq_m64(e, _m_psubd(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -606,8 +606,8 @@ mod tests {
             -8,
             8,
         );
-        assert_eq!(e, _mm_subs_pi8(a, b));
-        assert_eq!(e, _m_psubsb(a, b));
+        assert_eq_m64(e, _mm_subs_pi8(a, b));
+        assert_eq_m64(e, _m_psubsb(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -615,8 +615,8 @@ mod tests {
         let a = _mm_setr_pi16(-20000, 20000, 0, 0);
         let b = _mm_setr_pi16(20000, -20000, -1, 1);
         let e = _mm_setr_pi16(i16::min_value(), i16::max_value(), 1, -1);
-        assert_eq!(e, _mm_subs_pi16(a, b));
-        assert_eq!(e, _m_psubsw(a, b));
+        assert_eq_m64(e, _mm_subs_pi16(a, b));
+        assert_eq_m64(e, _m_psubsw(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -624,8 +624,8 @@ mod tests {
         let a = _mm_setr_pi8(50, 10, 20, 30, 40, 60, 70, 80);
         let b = _mm_setr_pi8(60, 20, 30, 40, 30, 20, 10, 0);
         let e = _mm_setr_pi8(0, 0, 0, 0, 10, 40, 60, 80);
-        assert_eq!(e, _mm_subs_pu8(a, b));
-        assert_eq!(e, _m_psubusb(a, b));
+        assert_eq_m64(e, _mm_subs_pu8(a, b));
+        assert_eq_m64(e, _m_psubusb(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -633,8 +633,8 @@ mod tests {
         let a = _mm_setr_pi16(10000, 200, 0, 44444u16 as i16);
         let b = _mm_setr_pi16(20000, 300, 1, 11111);
         let e = _mm_setr_pi16(0, 0, 0, 33333u16 as i16);
-        assert_eq!(e, _mm_subs_pu16(a, b));
-        assert_eq!(e, _m_psubusw(a, b));
+        assert_eq_m64(e, _mm_subs_pu16(a, b));
+        assert_eq_m64(e, _m_psubusw(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -642,7 +642,7 @@ mod tests {
         let a = _mm_setr_pi16(-1, 2, -3, 4);
         let b = _mm_setr_pi16(-5, 6, -7, 8);
         let r = _mm_setr_pi8(-1, 2, -3, 4, -5, 6, -7, 8);
-        assert_eq!(r, _mm_packs_pi16(a, b));
+        assert_eq_m64(r, _mm_packs_pi16(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -650,7 +650,7 @@ mod tests {
         let a = _mm_setr_pi32(-1, 2);
         let b = _mm_setr_pi32(-5, 6);
         let r = _mm_setr_pi16(-1, 2, -5, 6);
-        assert_eq!(r, _mm_packs_pi32(a, b));
+        assert_eq_m64(r, _mm_packs_pi32(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -658,7 +658,7 @@ mod tests {
         let a = _mm_setr_pi8(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_pi8(8, 7, 6, 5, 4, 3, 2, 1);
         let r = _mm_setr_pi8(0, 0, 0, 0, 0, -1, -1, -1);
-        assert_eq!(r, _mm_cmpgt_pi8(a, b));
+        assert_eq_m64(r, _mm_cmpgt_pi8(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -666,7 +666,7 @@ mod tests {
         let a = _mm_setr_pi16(0, 1, 2, 3);
         let b = _mm_setr_pi16(4, 3, 2, 1);
         let r = _mm_setr_pi16(0, 0, 0, -1);
-        assert_eq!(r, _mm_cmpgt_pi16(a, b));
+        assert_eq_m64(r, _mm_cmpgt_pi16(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -676,8 +676,8 @@ mod tests {
         let r0 = _mm_setr_pi32(0, -1);
         let r1 = _mm_setr_pi32(-1, 0);
 
-        assert_eq!(r0, _mm_cmpgt_pi32(a, b));
-        assert_eq!(r1, _mm_cmpgt_pi32(b, a));
+        assert_eq_m64(r0, _mm_cmpgt_pi32(a, b));
+        assert_eq_m64(r1, _mm_cmpgt_pi32(b, a));
     }
 
     #[simd_test = "mmx"]
@@ -686,7 +686,7 @@ mod tests {
         let b = _mm_setr_pi8(1, 2, 5, 6, 9, 10, 13, 14);
         let r = _mm_setr_pi8(8, 9, 11, 10, 12, 13, 15, 14);
 
-        assert_eq!(r, _mm_unpackhi_pi8(a, b));
+        assert_eq_m64(r, _mm_unpackhi_pi8(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -694,7 +694,7 @@ mod tests {
         let a = _mm_setr_pi8(0, 1, 2, 3, 4, 5, 6, 7);
         let b = _mm_setr_pi8(8, 9, 10, 11, 12, 13, 14, 15);
         let r = _mm_setr_pi8(0, 8, 1, 9, 2, 10, 3, 11);
-        assert_eq!(r, _mm_unpacklo_pi8(a, b));
+        assert_eq_m64(r, _mm_unpacklo_pi8(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -702,7 +702,7 @@ mod tests {
         let a = _mm_setr_pi16(0, 1, 2, 3);
         let b = _mm_setr_pi16(4, 5, 6, 7);
         let r = _mm_setr_pi16(2, 6, 3, 7);
-        assert_eq!(r, _mm_unpackhi_pi16(a, b));
+        assert_eq_m64(r, _mm_unpackhi_pi16(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -710,7 +710,7 @@ mod tests {
         let a = _mm_setr_pi16(0, 1, 2, 3);
         let b = _mm_setr_pi16(4, 5, 6, 7);
         let r = _mm_setr_pi16(0, 4, 1, 5);
-        assert_eq!(r, _mm_unpacklo_pi16(a, b));
+        assert_eq_m64(r, _mm_unpacklo_pi16(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -719,7 +719,7 @@ mod tests {
         let b = _mm_setr_pi32(1, 2);
         let r = _mm_setr_pi32(3, 2);
 
-        assert_eq!(r, _mm_unpackhi_pi32(a, b));
+        assert_eq_m64(r, _mm_unpackhi_pi32(a, b));
     }
 
     #[simd_test = "mmx"]
@@ -728,6 +728,6 @@ mod tests {
         let b = _mm_setr_pi32(1, 2);
         let r = _mm_setr_pi32(0, 1);
 
-        assert_eq!(r, _mm_unpacklo_pi32(a, b));
+        assert_eq_m64(r, _mm_unpacklo_pi32(a, b));
     }
 }

--- a/coresimd/src/x86/i686/sse.rs
+++ b/coresimd/src/x86/i686/sse.rs
@@ -455,8 +455,6 @@ pub unsafe fn _mm_cvtps_pi8(a: __m128) -> __m64 {
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
-
     use x86::*;
     use stdsimd_test::simd_test;
 
@@ -466,8 +464,8 @@ mod tests {
         let b = _mm_setr_pi16(5, -2, 7, -4);
         let r = _mm_setr_pi16(5, 6, 7, 8);
 
-        assert_eq!(r, _mm_max_pi16(a, b));
-        assert_eq!(r, _m_pmaxsw(a, b));
+        assert_eq_m64(r, _mm_max_pi16(a, b));
+        assert_eq_m64(r, _m_pmaxsw(a, b));
     }
 
     #[simd_test = "sse"]
@@ -476,8 +474,8 @@ mod tests {
         let b = _mm_setr_pi8(5, 2, 7, 4, 5, 2, 7, 4);
         let r = _mm_setr_pi8(5, 6, 7, 8, 5, 6, 7, 8);
 
-        assert_eq!(r, _mm_max_pu8(a, b));
-        assert_eq!(r, _m_pmaxub(a, b));
+        assert_eq_m64(r, _mm_max_pu8(a, b));
+        assert_eq_m64(r, _m_pmaxub(a, b));
     }
 
     #[simd_test = "sse"]
@@ -486,8 +484,8 @@ mod tests {
         let b = _mm_setr_pi16(5, -2, 7, -4);
         let r = _mm_setr_pi16(-1, -2, -3, -4);
 
-        assert_eq!(r, _mm_min_pi16(a, b));
-        assert_eq!(r, _m_pminsw(a, b));
+        assert_eq_m64(r, _mm_min_pi16(a, b));
+        assert_eq_m64(r, _m_pminsw(a, b));
     }
 
     #[simd_test = "sse"]
@@ -496,42 +494,42 @@ mod tests {
         let b = _mm_setr_pi8(5, 2, 7, 4, 5, 2, 7, 4);
         let r = _mm_setr_pi8(2, 2, 3, 4, 2, 2, 3, 4);
 
-        assert_eq!(r, _mm_min_pu8(a, b));
-        assert_eq!(r, _m_pminub(a, b));
+        assert_eq_m64(r, _mm_min_pu8(a, b));
+        assert_eq_m64(r, _m_pminub(a, b));
     }
 
     #[simd_test = "sse"]
     unsafe fn test_mm_mulhi_pu16() {
         let (a, b) = (_mm_set1_pi16(1000), _mm_set1_pi16(1001));
         let r = _mm_mulhi_pu16(a, b);
-        assert_eq!(r, _mm_set1_pi16(15));
+        assert_eq_m64(r, _mm_set1_pi16(15));
     }
 
     #[simd_test = "sse"]
     unsafe fn test_m_pmulhuw() {
         let (a, b) = (_mm_set1_pi16(1000), _mm_set1_pi16(1001));
         let r = _m_pmulhuw(a, b);
-        assert_eq!(r, _mm_set1_pi16(15));
+        assert_eq_m64(r, _mm_set1_pi16(15));
     }
 
     #[simd_test = "sse"]
     unsafe fn test_mm_avg_pu8() {
         let (a, b) = (_mm_set1_pi8(3), _mm_set1_pi8(9));
         let r = _mm_avg_pu8(a, b);
-        assert_eq!(r, _mm_set1_pi8(6));
+        assert_eq_m64(r, _mm_set1_pi8(6));
 
         let r = _m_pavgb(a, b);
-        assert_eq!(r, _mm_set1_pi8(6));
+        assert_eq_m64(r, _mm_set1_pi8(6));
     }
 
     #[simd_test = "sse"]
     unsafe fn test_mm_avg_pu16() {
         let (a, b) = (_mm_set1_pi16(3), _mm_set1_pi16(9));
         let r = _mm_avg_pu16(a, b);
-        assert_eq!(r, _mm_set1_pi16(6));
+        assert_eq_m64(r, _mm_set1_pi16(6));
 
         let r = _m_pavgw(a, b);
-        assert_eq!(r, _mm_set1_pi16(6));
+        assert_eq_m64(r, _mm_set1_pi16(6));
     }
 
     #[simd_test = "sse"]
@@ -540,10 +538,10 @@ mod tests {
                              1, 2, 3, 4);
         let b = _mm_setr_pi8(0, 0, 0, 0, 2, 1, 2, 1);
         let r = _mm_sad_pu8(a, b);
-        assert_eq!(r, mem::transmute(_mm_setr_pi16(1020, 0, 0, 0)));
+        assert_eq_m64(r, _mm_setr_pi16(1020, 0, 0, 0));
 
         let r = _m_psadbw(a, b);
-        assert_eq!(r, mem::transmute(_mm_setr_pi16(1020, 0, 0, 0)));
+        assert_eq_m64(r, _mm_setr_pi16(1020, 0, 0, 0));
     }
 
     #[simd_test = "sse"]
@@ -610,11 +608,11 @@ mod tests {
             &mut r as *mut _ as *mut i8,
         );
         let e = _mm_setr_pi8(0, 0, 9, 0, 0, 0, 0, 0);
-        assert_eq!(r, e);
+        assert_eq_m64(r, e);
 
         let mut r = _mm_set1_pi8(0);
         _m_maskmovq(a, mask, &mut r as *mut _ as *mut i8);
-        assert_eq!(r, e);
+        assert_eq_m64(r, e);
     }
 
     #[simd_test = "sse"]
@@ -634,13 +632,13 @@ mod tests {
         let a = _mm_setr_pi16(1, 2, 3, 4);
         let r = _mm_insert_pi16(a, 0, 0b0);
         let expected = _mm_setr_pi16(0, 2, 3, 4);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
         let r = _mm_insert_pi16(a, 0, 0b10);
         let expected = _mm_setr_pi16(1, 2, 0, 4);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
 
         let r = _m_pinsrw(a, 0, 0b10);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "sse"]
@@ -658,10 +656,10 @@ mod tests {
         let a = _mm_setr_pi16(1, 2, 3, 4);
         let r = _mm_shuffle_pi16(a, 0b00_01_01_11);
         let expected = _mm_setr_pi16(4, 2, 2, 1);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
 
         let r = _m_pshufw(a, 0b00_01_01_11);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "sse"]
@@ -669,8 +667,8 @@ mod tests {
         let a = _mm_setr_ps(1.0, 2.0, 3.0, 4.0);
         let r = _mm_setr_pi32(1, 2);
 
-        assert_eq!(r, _mm_cvtps_pi32(a));
-        assert_eq!(r, _mm_cvt_ps2pi(a));
+        assert_eq_m64(r, _mm_cvtps_pi32(a));
+        assert_eq_m64(r, _mm_cvt_ps2pi(a));
     }
 
     #[simd_test = "sse"]
@@ -678,21 +676,21 @@ mod tests {
         let a = _mm_setr_ps(7.0, 2.0, 3.0, 4.0);
         let r = _mm_setr_pi32(7, 2);
 
-        assert_eq!(r, _mm_cvttps_pi32(a));
-        assert_eq!(r, _mm_cvtt_ps2pi(a));
+        assert_eq_m64(r, _mm_cvttps_pi32(a));
+        assert_eq_m64(r, _mm_cvtt_ps2pi(a));
     }
 
     #[simd_test = "sse"]
     unsafe fn test_mm_cvtps_pi16() {
         let a = _mm_setr_ps(7.0, 2.0, 3.0, 4.0);
         let r = _mm_setr_pi16(7, 2, 3, 4);
-        assert_eq!(r, _mm_cvtps_pi16(a));
+        assert_eq_m64(r, _mm_cvtps_pi16(a));
     }
 
     #[simd_test = "sse"]
     unsafe fn test_mm_cvtps_pi8() {
         let a = _mm_setr_ps(7.0, 2.0, 3.0, 4.0);
         let r = _mm_setr_pi8(7, 2, 3, 4, 0, 0, 0, 0);
-        assert_eq!(r, _mm_cvtps_pi8(a));
+        assert_eq_m64(r, _mm_cvtps_pi8(a));
     }
 }

--- a/coresimd/src/x86/i686/sse2.rs
+++ b/coresimd/src/x86/i686/sse2.rs
@@ -178,20 +178,20 @@ mod tests {
     unsafe fn test_mm_set_epi64() {
         let r =
             _mm_set_epi64(mem::transmute(1i64), mem::transmute(2i64));
-        assert_eq!(r, _mm_setr_epi64x(2, 1));
+        assert_eq_m128i(r, _mm_setr_epi64x(2, 1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_set1_epi64() {
         let r = _mm_set1_epi64(mem::transmute(1i64));
-        assert_eq!(r, _mm_setr_epi64x(1, 1));
+        assert_eq_m128i(r, _mm_setr_epi64x(1, 1));
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_setr_epi64() {
         let r =
             _mm_setr_epi64(mem::transmute(1i64), mem::transmute(2i64));
-        assert_eq!(r, _mm_setr_epi64x(1, 2));
+        assert_eq_m128i(r, _mm_setr_epi64x(1, 2));
     }
 
     #[simd_test = "sse2"]
@@ -212,7 +212,7 @@ mod tests {
             0,
             0,
         ));
-        assert_eq!(r, _mm_setr_epi64x(5, 0));
+        assert_eq_m128i(r, _mm_setr_epi64x(5, 0));
     }
 
     #[simd_test = "sse2"]

--- a/coresimd/src/x86/i686/sse2.rs
+++ b/coresimd/src/x86/i686/sse2.rs
@@ -154,7 +154,7 @@ mod tests {
         let b = _mm_setr_pi32(3, 4);
         let expected = 3u64;
         let r = _mm_mul_su32(a, b);
-        assert_eq!(r, mem::transmute(expected));
+        assert_eq_m64(r, mem::transmute(expected));
     }
 
     #[simd_test = "sse2"]
@@ -197,7 +197,7 @@ mod tests {
     #[simd_test = "sse2"]
     unsafe fn test_mm_movepi64_pi64() {
         let r = _mm_movepi64_pi64(_mm_setr_epi64x(5, 0));
-        assert_eq!(r, _mm_setr_pi8(5, 0, 0, 0, 0, 0, 0, 0));
+        assert_eq_m64(r, _mm_setr_pi8(5, 0, 0, 0, 0, 0, 0, 0));
     }
 
     #[simd_test = "sse2"]
@@ -219,7 +219,7 @@ mod tests {
     unsafe fn test_mm_cvtpd_pi32() {
         let a = _mm_setr_pd(5., 0.);
         let r = _mm_cvtpd_pi32(a);
-        assert_eq!(r, _mm_setr_pi32(5, 0));
+        assert_eq_m64(r, _mm_setr_pi32(5, 0));
     }
 
     #[simd_test = "sse2"]
@@ -228,10 +228,10 @@ mod tests {
 
         let a = _mm_setr_pd(5., 0.);
         let r = _mm_cvttpd_pi32(a);
-        assert_eq!(r, _mm_setr_pi32(5, 0));
+        assert_eq_m64(r, _mm_setr_pi32(5, 0));
 
         let a = _mm_setr_pd(f64::NEG_INFINITY, f64::NAN);
         let r = _mm_cvttpd_pi32(a);
-        assert_eq!(r, _mm_setr_pi32(i32::MIN, i32::MIN));
+        assert_eq_m64(r, _mm_setr_pi32(i32::MIN, i32::MIN));
     }
 }

--- a/coresimd/src/x86/i686/sse42.rs
+++ b/coresimd/src/x86/i686/sse42.rs
@@ -27,6 +27,6 @@ mod tests {
         let a = _mm_setr_epi64x(0, 0x2a);
         let b = _mm_set1_epi64x(0x00);
         let i = _mm_cmpgt_epi64(a, b);
-        assert_eq!(i, _mm_setr_epi64x(0x00, 0xffffffffffffffffu64 as i64));
+        assert_eq_m128i(i, _mm_setr_epi64x(0x00, 0xffffffffffffffffu64 as i64));
     }
 }

--- a/coresimd/src/x86/i686/sse4a.rs
+++ b/coresimd/src/x86/i686/sse4a.rs
@@ -87,7 +87,7 @@ mod tests {
         let y = _mm_setr_epi64x(v, 0);
         let e = _mm_setr_epi64x(0b0110_i64, 0);
         let r = _mm_extract_si64(x, y);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 
     #[simd_test = "sse4a"]
@@ -104,7 +104,7 @@ mod tests {
         //        ^idx: 2^3 = 8 ^length = 2^2 = 4
         let y = _mm_setr_epi64x(i, v);
         let r = _mm_insert_si64(x, y);
-        assert_eq!(r, expected);
+        assert_eq_m128i(r, expected);
     }
 
     #[repr(align(16))]

--- a/coresimd/src/x86/i686/ssse3.rs
+++ b/coresimd/src/x86/i686/ssse3.rs
@@ -227,19 +227,19 @@ mod tests {
     #[simd_test = "ssse3"]
     unsafe fn test_mm_abs_pi8() {
         let r = _mm_abs_pi8(_mm_set1_pi8(-5));
-        assert_eq!(r, _mm_set1_pi8(5));
+        assert_eq_m64(r, _mm_set1_pi8(5));
     }
 
     #[simd_test = "ssse3"]
     unsafe fn test_mm_abs_pi16() {
         let r = _mm_abs_pi16(_mm_set1_pi16(-5));
-        assert_eq!(r, _mm_set1_pi16(5));
+        assert_eq_m64(r, _mm_set1_pi16(5));
     }
 
     #[simd_test = "ssse3"]
     unsafe fn test_mm_abs_pi32() {
         let r = _mm_abs_pi32(_mm_set1_pi32(-5));
-        assert_eq!(r, _mm_set1_pi32(5));
+        assert_eq_m64(r, _mm_set1_pi32(5));
     }
 
     #[simd_test = "ssse3"]
@@ -248,7 +248,7 @@ mod tests {
         let b = _mm_setr_pi8(4, 128u8 as i8, 4, 3, 24, 12, 6, 19);
         let expected = _mm_setr_pi8(5, 0, 5, 4, 1, 5, 7, 4);
         let r = _mm_shuffle_pi8(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -256,7 +256,7 @@ mod tests {
         let a = _mm_setr_pi32(0x89ABCDEF_u32 as i32, 0x01234567_u32 as i32);
         let b = _mm_setr_pi32(0xBBAA9988_u32 as i32, 0xFFDDEECC_u32 as i32);
         let r = _mm_alignr_pi8(a, b, 4);
-        assert_eq!(r, ::std::mem::transmute(0x89abcdefffddeecc_u64));
+        assert_eq_m64(r, ::std::mem::transmute(0x89abcdefffddeecc_u64));
     }
 
     #[simd_test = "ssse3"]
@@ -265,7 +265,7 @@ mod tests {
         let b = _mm_setr_pi16(4, 128, 4, 3);
         let expected = _mm_setr_pi16(3, 7, 132, 7);
         let r = _mm_hadd_pi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -274,7 +274,7 @@ mod tests {
         let b = _mm_setr_pi32(4, 128);
         let expected = _mm_setr_pi32(3, 132);
         let r = _mm_hadd_pi32(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -283,7 +283,7 @@ mod tests {
         let b = _mm_setr_pi16(32767, 1, -32768, -1);
         let expected = _mm_setr_pi16(3, 7, 32767, -32768);
         let r = _mm_hadds_pi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -292,7 +292,7 @@ mod tests {
         let b = _mm_setr_pi16(4, 128, 4, 3);
         let expected = _mm_setr_pi16(-1, -1, -124, 1);
         let r = _mm_hsub_pi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -301,7 +301,7 @@ mod tests {
         let b = _mm_setr_pi32(4, 128);
         let expected = _mm_setr_pi32(-1, -124);
         let r = _mm_hsub_pi32(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -310,7 +310,7 @@ mod tests {
         let b = _mm_setr_pi16(4, 128, 4, 3);
         let expected = _mm_setr_pi16(-1, -1, -124, 1);
         let r = _mm_hsubs_pi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -319,7 +319,7 @@ mod tests {
         let b = _mm_setr_pi8(4, 63, 4, 3, 24, 12, 6, 19);
         let expected = _mm_setr_pi16(130, 24, 192, 194);
         let r = _mm_maddubs_pi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -328,7 +328,7 @@ mod tests {
         let b = _mm_setr_pi16(4, 32767, -1, -32768);
         let expected = _mm_setr_pi16(0, 2, 0, -4);
         let r = _mm_mulhrs_pi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -337,7 +337,7 @@ mod tests {
         let b = _mm_setr_pi8(4, 64, 0, 3, 1, -1, -2, 1);
         let expected = _mm_setr_pi8(1, 2, 0, 4, -5, 6, -7, 8);
         let r = _mm_sign_pi8(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -346,7 +346,7 @@ mod tests {
         let b = _mm_setr_pi16(1, -1, 1, 0);
         let expected = _mm_setr_pi16(-1, -2, 3, 0);
         let r = _mm_sign_pi16(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 
     #[simd_test = "ssse3"]
@@ -355,6 +355,6 @@ mod tests {
         let b = _mm_setr_pi32(1, 0);
         let expected = _mm_setr_pi32(-1, 0);
         let r = _mm_sign_pi32(a, b);
-        assert_eq!(r, expected);
+        assert_eq_m64(r, expected);
     }
 }

--- a/coresimd/src/x86/mod.rs
+++ b/coresimd/src/x86/mod.rs
@@ -110,7 +110,6 @@ types! {
     /// # if cfg_feature_enabled!("sse2") { unsafe { foo() } }
     /// # }
     /// ```
-    #[derive(PartialEq)]
     pub struct __m128i(i64, i64);
 
     /// 128-bit wide set of four `f32` types, x86-specific

--- a/coresimd/src/x86/mod.rs
+++ b/coresimd/src/x86/mod.rs
@@ -67,7 +67,6 @@ types! {
     /// # if cfg_feature_enabled!("mmx") { unsafe { foo() } }
     /// # }
     /// ```
-    #[derive(PartialEq)]
     pub struct __m64(i64);
 
     /// 128-bit wide integer vector type, x86-specific

--- a/coresimd/src/x86/mod.rs
+++ b/coresimd/src/x86/mod.rs
@@ -222,7 +222,6 @@ types! {
     /// # if cfg_feature_enabled!("avx") { unsafe { foo() } }
     /// # }
     /// ```
-    #[derive(PartialEq)]
     pub struct __m256i(i64, i64, i64, i64);
 
     /// 256-bit wide set of eight `f32` types, x86-specific

--- a/coresimd/src/x86/test.rs
+++ b/coresimd/src/x86/test.rs
@@ -8,7 +8,7 @@ pub unsafe fn assert_eq_m64(a: __m64, b: __m64) {
     assert_eq!(A { a }.b, A { a: b }.b)
 }
 
-#[target_feature(enable = "sse")]
+#[target_feature(enable = "sse2")]
 pub unsafe fn assert_eq_m128i(a: __m128i, b: __m128i) {
     union A { a: __m128i, b: [u64; 2] }
     assert_eq!(A { a }.b, A { a: b }.b)
@@ -46,6 +46,12 @@ pub unsafe fn get_m128(a: __m128, idx: usize) -> f32 {
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_setr_epi64x(a: i64, b: i64) -> __m128i {
     _mm_set_epi64x(b, a)
+}
+
+#[target_feature(enable = "avx")]
+pub unsafe fn assert_eq_m256i(a: __m256i, b: __m256i) {
+    union A { a: __m256i, b: [u64; 4] }
+    assert_eq!(A { a }.b, A { a: b }.b)
 }
 
 #[target_feature(enable = "avx")]

--- a/coresimd/src/x86/test.rs
+++ b/coresimd/src/x86/test.rs
@@ -2,6 +2,12 @@
 
 use x86::*;
 
+#[target_feature(enable = "mmx")]
+pub unsafe fn assert_eq_m64(a: __m64, b: __m64) {
+    union A { a: __m64, b: u64 }
+    assert_eq!(A { a }.b, A { a: b }.b)
+}
+
 #[target_feature(enable = "sse2")]
 pub unsafe fn assert_eq_m128d(a: __m128d, b: __m128d) {
     if _mm_movemask_pd(_mm_cmpeq_pd(a, b)) != 0b11 {

--- a/coresimd/src/x86/test.rs
+++ b/coresimd/src/x86/test.rs
@@ -8,6 +8,12 @@ pub unsafe fn assert_eq_m64(a: __m64, b: __m64) {
     assert_eq!(A { a }.b, A { a: b }.b)
 }
 
+#[target_feature(enable = "sse")]
+pub unsafe fn assert_eq_m128i(a: __m128i, b: __m128i) {
+    union A { a: __m128i, b: [u64; 2] }
+    assert_eq!(A { a }.b, A { a: b }.b)
+}
+
 #[target_feature(enable = "sse2")]
 pub unsafe fn assert_eq_m128d(a: __m128d, b: __m128d) {
     if _mm_movemask_pd(_mm_cmpeq_pd(a, b)) != 0b11 {

--- a/coresimd/src/x86/x86_64/sse2.rs
+++ b/coresimd/src/x86/x86_64/sse2.rs
@@ -160,7 +160,7 @@ mod tests {
     #[simd_test = "sse2"]
     unsafe fn test_mm_cvtsi64_si128() {
         let r = _mm_cvtsi64_si128(5);
-        assert_eq!(r, _mm_setr_epi64x(5, 0));
+        assert_eq_m128i(r, _mm_setr_epi64x(5, 0));
     }
 
     #[simd_test = "sse2"]

--- a/coresimd/src/x86/x86_64/sse41.rs
+++ b/coresimd/src/x86/x86_64/sse41.rs
@@ -46,8 +46,8 @@ mod tests {
         let a = _mm_set1_epi64x(0);
         let e = _mm_setr_epi64x(0, 32);
         let r = _mm_insert_epi64(a, 32, 1);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
         let r = _mm_insert_epi64(a, 32, 3);
-        assert_eq!(r, e);
+        assert_eq_m128i(r, e);
     }
 }


### PR DESCRIPTION
This is mostly just being more conservative with them!