### PR TITLE
Verify intrinsics don't leak to i686

### DIFF
--- a/coresimd/src/lib.rs
+++ b/coresimd/src/lib.rs
@@ -15,7 +15,7 @@
            simd_ffi, target_feature, cfg_target_feature, i128_type, asm,
            const_atomic_usize_new, stmt_expr_attributes, core_intrinsics,
            crate_in_paths)]
-#![cfg_attr(test, feature(proc_macro, test, repr_align, attr_literals))]
+#![cfg_attr(test, feature(proc_macro, test, attr_literals))]
 #![cfg_attr(feature = "cargo-clippy",
             allow(inline_always, too_many_arguments, cast_sign_loss,
                   cast_lossless, cast_possible_wrap,

--- a/coresimd/src/x86/i586/abm.rs
+++ b/coresimd/src/x86/i586/abm.rs
@@ -30,29 +30,11 @@ pub unsafe fn _lzcnt_u32(x: u32) -> u32 {
     x.leading_zeros()
 }
 
-/// Counts the leading most significant zero bits.
-///
-/// When the operand is zero, it returns its size in bits.
-#[inline(always)]
-#[target_feature(enable = "lzcnt")]
-#[cfg_attr(test, assert_instr(lzcnt))]
-pub unsafe fn _lzcnt_u64(x: u64) -> u64 {
-    x.leading_zeros() as u64
-}
-
 /// Counts the bits that are set.
 #[inline(always)]
 #[target_feature(enable = "popcnt")]
 #[cfg_attr(test, assert_instr(popcnt))]
 pub unsafe fn _popcnt32(x: i32) -> i32 {
-    x.count_ones() as i32
-}
-
-/// Counts the bits that are set.
-#[inline(always)]
-#[target_feature(enable = "popcnt")]
-#[cfg_attr(test, assert_instr(popcnt))]
-pub unsafe fn _popcnt64(x: i64) -> i32 {
     x.count_ones() as i32
 }
 
@@ -67,18 +49,8 @@ mod tests {
         assert_eq!(abm::_lzcnt_u32(0b0101_1010), 25);
     }
 
-    #[simd_test = "lzcnt"]
-    unsafe fn _lzcnt_u64() {
-        assert_eq!(abm::_lzcnt_u64(0b0101_1010), 57);
-    }
-
     #[simd_test = "popcnt"]
     unsafe fn _popcnt32() {
         assert_eq!(abm::_popcnt32(0b0101_1010), 4);
-    }
-
-    #[simd_test = "popcnt"]
-    unsafe fn _popcnt64() {
-        assert_eq!(abm::_popcnt64(0b0101_1010), 4);
     }
 }

--- a/coresimd/src/x86/i586/avx.rs
+++ b/coresimd/src/x86/i586/avx.rs
@@ -1245,15 +1245,6 @@ pub unsafe fn _mm256_insert_epi32(a: __m256i, i: i32, index: i32) -> __m256i {
     mem::transmute(simd_insert(a.as_i32x8(), (index as u32) & 7, i))
 }
 
-/// Copy `a` to result, and insert the 64-bit integer `i` into result
-/// at the location specified by `index`.
-#[inline(always)]
-#[target_feature(enable = "avx")]
-// This intrinsic has no corresponding instruction.
-pub unsafe fn _mm256_insert_epi64(a: __m256i, i: i64, index: i32) -> __m256i {
-    mem::transmute(simd_insert(a.as_i64x4(), (index as u32) & 3, i))
-}
-
 /// Load 256-bits (composed of 4 packed double-precision (64-bit)
 /// floating-point elements) from memory into result.
 /// `mem_addr` must be aligned on a 32-byte boundary or a
@@ -3304,14 +3295,6 @@ mod tests {
         let a = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 8);
         let r = _mm256_insert_epi32(a, 0, 7);
         let e = _mm256_setr_epi32(1, 2, 3, 4, 5, 6, 7, 0);
-        assert_eq_m256i(r, e);
-    }
-
-    #[simd_test = "avx"]
-    unsafe fn test_mm256_insert_epi64() {
-        let a = _mm256_setr_epi64x(1, 2, 3, 4);
-        let r = _mm256_insert_epi64(a, 0, 3);
-        let e = _mm256_setr_epi64x(1, 2, 3, 0);
         assert_eq_m256i(r, e);
     }
 

--- a/coresimd/src/x86/i586/avx2.rs
+++ b/coresimd/src/x86/i586/avx2.rs
@@ -2887,15 +2887,6 @@ pub unsafe fn _mm256_extract_epi32(a: __m256i, imm8: i32) -> i32 {
     simd_extract(a.as_i32x8(), imm8)
 }
 
-/// Extract a 64-bit integer from `a`, selected with `imm8`.
-#[inline(always)]
-#[target_feature(enable = "avx2")]
-// This intrinsic has no corresponding instruction.
-pub unsafe fn _mm256_extract_epi64(a: __m256i, imm8: i32) -> i64 {
-    let imm8 = (imm8 & 3) as u32;
-    simd_extract(a.as_i64x4(), imm8)
-}
-
 /// Returns the first element of the input vector of [4 x double].
 #[inline(always)]
 #[target_feature(enable = "avx2")]
@@ -5244,13 +5235,6 @@ mod tests {
         let r2 = _mm256_extract_epi32(a, 11);
         assert_eq!(r1, -1);
         assert_eq!(r2, 3);
-    }
-
-    #[simd_test = "avx2"]
-    unsafe fn test_mm256_extract_epi64() {
-        let a = _mm256_setr_epi64x(0, 1, 2, 3);
-        let r = _mm256_extract_epi64(a, 3);
-        assert_eq!(r, 3);
     }
 
     #[simd_test = "avx2"]

--- a/coresimd/src/x86/i586/bmi.rs
+++ b/coresimd/src/x86/i586/bmi.rs
@@ -21,16 +21,6 @@ pub unsafe fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
     _bextr2_u32(a, (start & 0xff_u32) | ((len & 0xff_u32) << 8_u32))
 }
 
-/// Extracts bits in range [`start`, `start` + `length`) from `a` into
-/// the least significant bits of the result.
-#[inline(always)]
-#[target_feature(enable = "bmi")]
-#[cfg_attr(test, assert_instr(bextr))]
-#[cfg(not(target_arch = "x86"))]
-pub unsafe fn _bextr_u64(a: u64, start: u32, len: u32) -> u64 {
-    _bextr2_u64(a, ((start & 0xff) | ((len & 0xff) << 8)) as u64)
-}
-
 /// Extracts bits of `a` specified by `control` into
 /// the least significant bits of the result.
 ///
@@ -43,32 +33,11 @@ pub unsafe fn _bextr2_u32(a: u32, control: u32) -> u32 {
     x86_bmi_bextr_32(a, control)
 }
 
-/// Extracts bits of `a` specified by `control` into
-/// the least significant bits of the result.
-///
-/// Bits [7,0] of `control` specify the index to the first bit in the range to
-/// be extracted, and bits [15,8] specify the length of the range.
-#[inline(always)]
-#[target_feature(enable = "bmi")]
-#[cfg_attr(test, assert_instr(bextr))]
-#[cfg(not(target_arch = "x86"))]
-pub unsafe fn _bextr2_u64(a: u64, control: u64) -> u64 {
-    x86_bmi_bextr_64(a, control)
-}
-
 /// Bitwise logical `AND` of inverted `a` with `b`.
 #[inline(always)]
 #[target_feature(enable = "bmi")]
 #[cfg_attr(test, assert_instr(andn))]
 pub unsafe fn _andn_u32(a: u32, b: u32) -> u32 {
-    !a & b
-}
-
-/// Bitwise logical `AND` of inverted `a` with `b`.
-#[inline(always)]
-#[target_feature(enable = "bmi")]
-#[cfg_attr(test, assert_instr(andn))]
-pub unsafe fn _andn_u64(a: u64, b: u64) -> u64 {
     !a & b
 }
 
@@ -80,30 +49,12 @@ pub unsafe fn _blsi_u32(x: u32) -> u32 {
     x & x.wrapping_neg()
 }
 
-/// Extract lowest set isolated bit.
-#[inline(always)]
-#[target_feature(enable = "bmi")]
-#[cfg_attr(test, assert_instr(blsi))]
-#[cfg(not(target_arch = "x86"))] // generates lots of instructions
-pub unsafe fn _blsi_u64(x: u64) -> u64 {
-    x & x.wrapping_neg()
-}
-
 /// Get mask up to lowest set bit.
 #[inline(always)]
 #[target_feature(enable = "bmi")]
 #[cfg_attr(test, assert_instr(blsmsk))]
 pub unsafe fn _blsmsk_u32(x: u32) -> u32 {
     x ^ (x.wrapping_sub(1_u32))
-}
-
-/// Get mask up to lowest set bit.
-#[inline(always)]
-#[target_feature(enable = "bmi")]
-#[cfg_attr(test, assert_instr(blsmsk))]
-#[cfg(not(target_arch = "x86"))] // generates lots of instructions
-pub unsafe fn _blsmsk_u64(x: u64) -> u64 {
-    x ^ (x.wrapping_sub(1_u64))
 }
 
 /// Resets the lowest set bit of `x`.
@@ -113,17 +64,6 @@ pub unsafe fn _blsmsk_u64(x: u64) -> u64 {
 #[target_feature(enable = "bmi")]
 #[cfg_attr(test, assert_instr(blsr))]
 pub unsafe fn _blsr_u32(x: u32) -> u32 {
-    x & (x.wrapping_sub(1))
-}
-
-/// Resets the lowest set bit of `x`.
-///
-/// If `x` is sets CF.
-#[inline(always)]
-#[target_feature(enable = "bmi")]
-#[cfg_attr(test, assert_instr(blsr))]
-#[cfg(not(target_arch = "x86"))] // generates lots of instructions
-pub unsafe fn _blsr_u64(x: u64) -> u64 {
     x & (x.wrapping_sub(1))
 }
 
@@ -143,36 +83,13 @@ pub unsafe fn _tzcnt_u32(x: u32) -> u32 {
 #[inline(always)]
 #[target_feature(enable = "bmi")]
 #[cfg_attr(test, assert_instr(tzcnt))]
-pub unsafe fn _tzcnt_u64(x: u64) -> u64 {
-    x.trailing_zeros() as u64
-}
-
-/// Counts the number of trailing least significant zero bits.
-///
-/// When the source operand is 0, it returns its size in bits.
-#[inline(always)]
-#[target_feature(enable = "bmi")]
-#[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _mm_tzcnt_32(x: u32) -> i32 {
     x.trailing_zeros() as i32
 }
 
-/// Counts the number of trailing least significant zero bits.
-///
-/// When the source operand is 0, it returns its size in bits.
-#[inline(always)]
-#[target_feature(enable = "bmi")]
-#[cfg_attr(test, assert_instr(tzcnt))]
-pub unsafe fn _mm_tzcnt_64(x: u64) -> i64 {
-    x.trailing_zeros() as i64
-}
-
-#[allow(dead_code)]
 extern "C" {
     #[link_name = "llvm.x86.bmi.bextr.32"]
     fn x86_bmi_bextr_32(x: u32, y: u32) -> u32;
-    #[link_name = "llvm.x86.bmi.bextr.64"]
-    fn x86_bmi_bextr_64(x: u64, y: u64) -> u64;
 }
 
 #[cfg(test)]
@@ -185,13 +102,6 @@ mod tests {
     unsafe fn _bextr_u32() {
         let r = bmi::_bextr_u32(0b0101_0000u32, 4, 4);
         assert_eq!(r, 0b0000_0101u32);
-    }
-
-    #[simd_test = "bmi"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _bextr_u64() {
-        let r = bmi::_bextr_u64(0b0101_0000u64, 4, 4);
-        assert_eq!(r, 0b0000_0101u64);
     }
 
     #[simd_test = "bmi"]
@@ -218,51 +128,14 @@ mod tests {
     }
 
     #[simd_test = "bmi"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _andn_u64() {
-        assert_eq!(bmi::_andn_u64(0, 0), 0);
-        assert_eq!(bmi::_andn_u64(0, 1), 1);
-        assert_eq!(bmi::_andn_u64(1, 0), 0);
-        assert_eq!(bmi::_andn_u64(1, 1), 0);
-
-        let r = bmi::_andn_u64(0b0000_0000u64, 0b0000_0000u64);
-        assert_eq!(r, 0b0000_0000u64);
-
-        let r = bmi::_andn_u64(0b0000_0000u64, 0b1111_1111u64);
-        assert_eq!(r, 0b1111_1111u64);
-
-        let r = bmi::_andn_u64(0b1111_1111u64, 0b0000_0000u64);
-        assert_eq!(r, 0b0000_0000u64);
-
-        let r = bmi::_andn_u64(0b1111_1111u64, 0b1111_1111u64);
-        assert_eq!(r, 0b0000_0000u64);
-
-        let r = bmi::_andn_u64(0b0100_0000u64, 0b0101_1101u64);
-        assert_eq!(r, 0b0001_1101u64);
-    }
-
-    #[simd_test = "bmi"]
     unsafe fn _blsi_u32() {
         assert_eq!(bmi::_blsi_u32(0b1101_0000u32), 0b0001_0000u32);
-    }
-
-    #[simd_test = "bmi"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _blsi_u64() {
-        assert_eq!(bmi::_blsi_u64(0b1101_0000u64), 0b0001_0000u64);
     }
 
     #[simd_test = "bmi"]
     unsafe fn _blsmsk_u32() {
         let r = bmi::_blsmsk_u32(0b0011_0000u32);
         assert_eq!(r, 0b0001_1111u32);
-    }
-
-    #[simd_test = "bmi"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _blsmsk_u64() {
-        let r = bmi::_blsmsk_u64(0b0011_0000u64);
-        assert_eq!(r, 0b0001_1111u64);
     }
 
     #[simd_test = "bmi"]
@@ -273,25 +146,9 @@ mod tests {
     }
 
     #[simd_test = "bmi"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _blsr_u64() {
-        // TODO: test the behavior when the input is 0
-        let r = bmi::_blsr_u64(0b0011_0000u64);
-        assert_eq!(r, 0b0010_0000u64);
-    }
-
-    #[simd_test = "bmi"]
     unsafe fn _tzcnt_u32() {
         assert_eq!(bmi::_tzcnt_u32(0b0000_0001u32), 0u32);
         assert_eq!(bmi::_tzcnt_u32(0b0000_0000u32), 32u32);
         assert_eq!(bmi::_tzcnt_u32(0b1001_0000u32), 4u32);
-    }
-
-    #[simd_test = "bmi"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _tzcnt_u64() {
-        assert_eq!(bmi::_tzcnt_u64(0b0000_0001u64), 0u64);
-        assert_eq!(bmi::_tzcnt_u64(0b0000_0000u64), 64u64);
-        assert_eq!(bmi::_tzcnt_u64(0b1001_0000u64), 4u64);
     }
 }

--- a/coresimd/src/x86/i586/bmi2.rs
+++ b/coresimd/src/x86/i586/bmi2.rs
@@ -28,35 +28,12 @@ pub unsafe fn _mulx_u32(a: u32, b: u32, hi: &mut u32) -> u32 {
     result as u32
 }
 
-/// Unsigned multiply without affecting flags.
-///
-/// Unsigned multiplication of `a` with `b` returning a pair `(lo, hi)` with
-/// the low half and the high half of the result.
-#[inline(always)]
-#[cfg_attr(test, assert_instr(mulx))]
-#[target_feature(enable = "bmi2")]
-#[cfg(not(target_arch = "x86"))] // calls an intrinsic
-pub unsafe fn _mulx_u64(a: u64, b: u64, hi: &mut u64) -> u64 {
-    let result: u128 = (a as u128) * (b as u128);
-    *hi = (result >> 64) as u64;
-    result as u64
-}
-
 /// Zero higher bits of `a` >= `index`.
 #[inline(always)]
 #[target_feature(enable = "bmi2")]
 #[cfg_attr(test, assert_instr(bzhi))]
 pub unsafe fn _bzhi_u32(a: u32, index: u32) -> u32 {
     x86_bmi2_bzhi_32(a, index)
-}
-
-/// Zero higher bits of `a` >= `index`.
-#[inline(always)]
-#[target_feature(enable = "bmi2")]
-#[cfg_attr(test, assert_instr(bzhi))]
-#[cfg(not(target_arch = "x86"))]
-pub unsafe fn _bzhi_u64(a: u64, index: u32) -> u64 {
-    x86_bmi2_bzhi_64(a, index as u64)
 }
 
 /// Scatter contiguous low order bits of `a` to the result at the positions
@@ -68,16 +45,6 @@ pub unsafe fn _pdep_u32(a: u32, mask: u32) -> u32 {
     x86_bmi2_pdep_32(a, mask)
 }
 
-/// Scatter contiguous low order bits of `a` to the result at the positions
-/// specified by the `mask`.
-#[inline(always)]
-#[target_feature(enable = "bmi2")]
-#[cfg_attr(test, assert_instr(pdep))]
-#[cfg(not(target_arch = "x86"))]
-pub unsafe fn _pdep_u64(a: u64, mask: u64) -> u64 {
-    x86_bmi2_pdep_64(a, mask)
-}
-
 /// Gathers the bits of `x` specified by the `mask` into the contiguous low
 /// order bit positions of the result.
 #[inline(always)]
@@ -87,30 +54,13 @@ pub unsafe fn _pext_u32(a: u32, mask: u32) -> u32 {
     x86_bmi2_pext_32(a, mask)
 }
 
-/// Gathers the bits of `x` specified by the `mask` into the contiguous low
-/// order bit positions of the result.
-#[inline(always)]
-#[target_feature(enable = "bmi2")]
-#[cfg_attr(test, assert_instr(pext))]
-#[cfg(not(target_arch = "x86"))]
-pub unsafe fn _pext_u64(a: u64, mask: u64) -> u64 {
-    x86_bmi2_pext_64(a, mask)
-}
-
-#[allow(dead_code)]
 extern "C" {
     #[link_name = "llvm.x86.bmi.bzhi.32"]
     fn x86_bmi2_bzhi_32(x: u32, y: u32) -> u32;
-    #[link_name = "llvm.x86.bmi.bzhi.64"]
-    fn x86_bmi2_bzhi_64(x: u64, y: u64) -> u64;
     #[link_name = "llvm.x86.bmi.pdep.32"]
     fn x86_bmi2_pdep_32(x: u32, y: u32) -> u32;
-    #[link_name = "llvm.x86.bmi.pdep.64"]
-    fn x86_bmi2_pdep_64(x: u64, y: u64) -> u64;
     #[link_name = "llvm.x86.bmi.pext.32"]
     fn x86_bmi2_pext_32(x: u32, y: u32) -> u32;
-    #[link_name = "llvm.x86.bmi.pext.64"]
-    fn x86_bmi2_pext_64(x: u64, y: u64) -> u64;
 }
 
 #[cfg(test)]
@@ -134,21 +84,6 @@ mod tests {
     }
 
     #[simd_test = "bmi2"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _pext_u64() {
-        let n = 0b1011_1110_1001_0011u64;
-
-        let m0 = 0b0110_0011_1000_0101u64;
-        let s0 = 0b0000_0000_0011_0101u64;
-
-        let m1 = 0b1110_1011_1110_1111u64;
-        let s1 = 0b0001_0111_0100_0011u64;
-
-        assert_eq!(bmi2::_pext_u64(n, m0), s0);
-        assert_eq!(bmi2::_pext_u64(n, m1), s1);
-    }
-
-    #[simd_test = "bmi2"]
     unsafe fn _pdep_u32() {
         let n = 0b1011_1110_1001_0011u32;
 
@@ -163,33 +98,10 @@ mod tests {
     }
 
     #[simd_test = "bmi2"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _pdep_u64() {
-        let n = 0b1011_1110_1001_0011u64;
-
-        let m0 = 0b0110_0011_1000_0101u64;
-        let s0 = 0b0000_0010_0000_0101u64;
-
-        let m1 = 0b1110_1011_1110_1111u64;
-        let s1 = 0b1110_1001_0010_0011u64;
-
-        assert_eq!(bmi2::_pdep_u64(n, m0), s0);
-        assert_eq!(bmi2::_pdep_u64(n, m1), s1);
-    }
-
-    #[simd_test = "bmi2"]
     unsafe fn _bzhi_u32() {
         let n = 0b1111_0010u32;
         let s = 0b0001_0010u32;
         assert_eq!(bmi2::_bzhi_u32(n, 5), s);
-    }
-
-    #[simd_test = "bmi2"]
-    #[cfg(not(target_arch = "x86"))]
-    unsafe fn _bzhi_u64() {
-        let n = 0b1111_0010u64;
-        let s = 0b0001_0010u64;
-        assert_eq!(bmi2::_bzhi_u64(n, 5), s);
     }
 
     #[simd_test = "bmi2"]
@@ -205,25 +117,5 @@ result = 8589934400
         */
         assert_eq!(lo, 0b1111_1111_1111_1111_1111_1111_0100_0000u32);
         assert_eq!(hi, 0b0001u32);
-    }
-
-    #[simd_test = "bmi2"]
-    #[cfg(not(target_arch = "x86"))]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
-    unsafe fn _mulx_u64() {
-        let a: u64 = 9_223_372_036_854_775_800;
-        let b: u64 = 100;
-        let mut hi = 0;
-        let lo = bmi2::_mulx_u64(a, b, &mut hi);
-        /*
-result = 922337203685477580000 =
-0b00110001_1111111111111111_1111111111111111_1111111111111111_1111110011100000
-  ^~hi~~~~ ^~lo~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        */
-        assert_eq!(
-            lo,
-            0b11111111_11111111_11111111_11111111_11111111_11111111_11111100_11100000u64
-        );
-        assert_eq!(hi, 0b00110001u64);
     }
 }

--- a/coresimd/src/x86/x86_64/abm.rs
+++ b/coresimd/src/x86/x86_64/abm.rs
@@ -1,0 +1,37 @@
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Counts the leading most significant zero bits.
+///
+/// When the operand is zero, it returns its size in bits.
+#[inline(always)]
+#[target_feature(enable = "lzcnt")]
+#[cfg_attr(test, assert_instr(lzcnt))]
+pub unsafe fn _lzcnt_u64(x: u64) -> u64 {
+    x.leading_zeros() as u64
+}
+
+/// Counts the bits that are set.
+#[inline(always)]
+#[target_feature(enable = "popcnt")]
+#[cfg_attr(test, assert_instr(popcnt))]
+pub unsafe fn _popcnt64(x: i64) -> i32 {
+    x.count_ones() as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+
+    use x86::*;
+
+    #[simd_test = "lzcnt"]
+    unsafe fn test_lzcnt_u64() {
+        assert_eq!(_lzcnt_u64(0b0101_1010), 57);
+    }
+
+    #[simd_test = "popcnt"]
+    unsafe fn test_popcnt64() {
+        assert_eq!(_popcnt64(0b0101_1010), 4);
+    }
+}

--- a/coresimd/src/x86/x86_64/avx.rs
+++ b/coresimd/src/x86/x86_64/avx.rs
@@ -1,0 +1,28 @@
+use core::mem;
+
+use simd_llvm::*;
+use x86::*;
+
+/// Copy `a` to result, and insert the 64-bit integer `i` into result
+/// at the location specified by `index`.
+#[inline(always)]
+#[target_feature(enable = "avx")]
+// This intrinsic has no corresponding instruction.
+pub unsafe fn _mm256_insert_epi64(a: __m256i, i: i64, index: i32) -> __m256i {
+    mem::transmute(simd_insert(a.as_i64x4(), (index as u32) & 3, i))
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+
+    use x86::*;
+
+    #[simd_test = "avx"]
+    unsafe fn test_mm256_insert_epi64() {
+        let a = _mm256_setr_epi64x(1, 2, 3, 4);
+        let r = _mm256_insert_epi64(a, 0, 3);
+        let e = _mm256_setr_epi64x(1, 2, 3, 0);
+        assert_eq_m256i(r, e);
+    }
+}

--- a/coresimd/src/x86/x86_64/avx2.rs
+++ b/coresimd/src/x86/x86_64/avx2.rs
@@ -1,0 +1,25 @@
+use simd_llvm::*;
+use x86::*;
+
+/// Extract a 64-bit integer from `a`, selected with `imm8`.
+#[inline(always)]
+#[target_feature(enable = "avx2")]
+// This intrinsic has no corresponding instruction.
+pub unsafe fn _mm256_extract_epi64(a: __m256i, imm8: i32) -> i64 {
+    let imm8 = (imm8 & 3) as u32;
+    simd_extract(a.as_i64x4(), imm8)
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+
+    use x86::*;
+
+    #[simd_test = "avx2"]
+    unsafe fn test_mm256_extract_epi64() {
+        let a = _mm256_setr_epi64x(0, 1, 2, 3);
+        let r = _mm256_extract_epi64(a, 3);
+        assert_eq!(r, 3);
+    }
+}

--- a/coresimd/src/x86/x86_64/bmi.rs
+++ b/coresimd/src/x86/x86_64/bmi.rs
@@ -1,0 +1,148 @@
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Extracts bits in range [`start`, `start` + `length`) from `a` into
+/// the least significant bits of the result.
+#[inline(always)]
+#[target_feature(enable = "bmi")]
+#[cfg_attr(test, assert_instr(bextr))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _bextr_u64(a: u64, start: u32, len: u32) -> u64 {
+    _bextr2_u64(a, ((start & 0xff) | ((len & 0xff) << 8)) as u64)
+}
+
+/// Extracts bits of `a` specified by `control` into
+/// the least significant bits of the result.
+///
+/// Bits [7,0] of `control` specify the index to the first bit in the range to
+/// be extracted, and bits [15,8] specify the length of the range.
+#[inline(always)]
+#[target_feature(enable = "bmi")]
+#[cfg_attr(test, assert_instr(bextr))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _bextr2_u64(a: u64, control: u64) -> u64 {
+    x86_bmi_bextr_64(a, control)
+}
+
+/// Bitwise logical `AND` of inverted `a` with `b`.
+#[inline(always)]
+#[target_feature(enable = "bmi")]
+#[cfg_attr(test, assert_instr(andn))]
+pub unsafe fn _andn_u64(a: u64, b: u64) -> u64 {
+    !a & b
+}
+
+/// Extract lowest set isolated bit.
+#[inline(always)]
+#[target_feature(enable = "bmi")]
+#[cfg_attr(test, assert_instr(blsi))]
+#[cfg(not(target_arch = "x86"))] // generates lots of instructions
+pub unsafe fn _blsi_u64(x: u64) -> u64 {
+    x & x.wrapping_neg()
+}
+
+/// Get mask up to lowest set bit.
+#[inline(always)]
+#[target_feature(enable = "bmi")]
+#[cfg_attr(test, assert_instr(blsmsk))]
+#[cfg(not(target_arch = "x86"))] // generates lots of instructions
+pub unsafe fn _blsmsk_u64(x: u64) -> u64 {
+    x ^ (x.wrapping_sub(1_u64))
+}
+
+/// Resets the lowest set bit of `x`.
+///
+/// If `x` is sets CF.
+#[inline(always)]
+#[target_feature(enable = "bmi")]
+#[cfg_attr(test, assert_instr(blsr))]
+#[cfg(not(target_arch = "x86"))] // generates lots of instructions
+pub unsafe fn _blsr_u64(x: u64) -> u64 {
+    x & (x.wrapping_sub(1))
+}
+
+/// Counts the number of trailing least significant zero bits.
+///
+/// When the source operand is 0, it returns its size in bits.
+#[inline(always)]
+#[target_feature(enable = "bmi")]
+#[cfg_attr(test, assert_instr(tzcnt))]
+pub unsafe fn _tzcnt_u64(x: u64) -> u64 {
+    x.trailing_zeros() as u64
+}
+
+/// Counts the number of trailing least significant zero bits.
+///
+/// When the source operand is 0, it returns its size in bits.
+#[inline(always)]
+#[target_feature(enable = "bmi")]
+#[cfg_attr(test, assert_instr(tzcnt))]
+pub unsafe fn _mm_tzcnt_64(x: u64) -> i64 {
+    x.trailing_zeros() as i64
+}
+
+extern "C" {
+    #[link_name = "llvm.x86.bmi.bextr.64"]
+    fn x86_bmi_bextr_64(x: u64, y: u64) -> u64;
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+
+    use x86::*;
+
+    #[simd_test = "bmi"]
+    unsafe fn test_bextr_u64() {
+        let r = _bextr_u64(0b0101_0000u64, 4, 4);
+        assert_eq!(r, 0b0000_0101u64);
+    }
+
+    #[simd_test = "bmi"]
+    unsafe fn test_andn_u64() {
+        assert_eq!(_andn_u64(0, 0), 0);
+        assert_eq!(_andn_u64(0, 1), 1);
+        assert_eq!(_andn_u64(1, 0), 0);
+        assert_eq!(_andn_u64(1, 1), 0);
+
+        let r = _andn_u64(0b0000_0000u64, 0b0000_0000u64);
+        assert_eq!(r, 0b0000_0000u64);
+
+        let r = _andn_u64(0b0000_0000u64, 0b1111_1111u64);
+        assert_eq!(r, 0b1111_1111u64);
+
+        let r = _andn_u64(0b1111_1111u64, 0b0000_0000u64);
+        assert_eq!(r, 0b0000_0000u64);
+
+        let r = _andn_u64(0b1111_1111u64, 0b1111_1111u64);
+        assert_eq!(r, 0b0000_0000u64);
+
+        let r = _andn_u64(0b0100_0000u64, 0b0101_1101u64);
+        assert_eq!(r, 0b0001_1101u64);
+    }
+
+    #[simd_test = "bmi"]
+    unsafe fn test_blsi_u64() {
+        assert_eq!(_blsi_u64(0b1101_0000u64), 0b0001_0000u64);
+    }
+
+    #[simd_test = "bmi"]
+    unsafe fn test_blsmsk_u64() {
+        let r = _blsmsk_u64(0b0011_0000u64);
+        assert_eq!(r, 0b0001_1111u64);
+    }
+
+    #[simd_test = "bmi"]
+    unsafe fn test_blsr_u64() {
+        // TODO: test the behavior when the input is 0
+        let r = _blsr_u64(0b0011_0000u64);
+        assert_eq!(r, 0b0010_0000u64);
+    }
+
+    #[simd_test = "bmi"]
+    unsafe fn test_tzcnt_u64() {
+        assert_eq!(_tzcnt_u64(0b0000_0001u64), 0u64);
+        assert_eq!(_tzcnt_u64(0b0000_0000u64), 64u64);
+        assert_eq!(_tzcnt_u64(0b1001_0000u64), 4u64);
+    }
+}

--- a/coresimd/src/x86/x86_64/bmi2.rs
+++ b/coresimd/src/x86/x86_64/bmi2.rs
@@ -1,0 +1,115 @@
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Unsigned multiply without affecting flags.
+///
+/// Unsigned multiplication of `a` with `b` returning a pair `(lo, hi)` with
+/// the low half and the high half of the result.
+#[inline(always)]
+#[cfg_attr(test, assert_instr(mulx))]
+#[target_feature(enable = "bmi2")]
+#[cfg(not(target_arch = "x86"))] // calls an intrinsic
+pub unsafe fn _mulx_u64(a: u64, b: u64, hi: &mut u64) -> u64 {
+    let result: u128 = (a as u128) * (b as u128);
+    *hi = (result >> 64) as u64;
+    result as u64
+}
+
+/// Zero higher bits of `a` >= `index`.
+#[inline(always)]
+#[target_feature(enable = "bmi2")]
+#[cfg_attr(test, assert_instr(bzhi))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _bzhi_u64(a: u64, index: u32) -> u64 {
+    x86_bmi2_bzhi_64(a, index as u64)
+}
+
+/// Scatter contiguous low order bits of `a` to the result at the positions
+/// specified by the `mask`.
+#[inline(always)]
+#[target_feature(enable = "bmi2")]
+#[cfg_attr(test, assert_instr(pdep))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _pdep_u64(a: u64, mask: u64) -> u64 {
+    x86_bmi2_pdep_64(a, mask)
+}
+
+/// Gathers the bits of `x` specified by the `mask` into the contiguous low
+/// order bit positions of the result.
+#[inline(always)]
+#[target_feature(enable = "bmi2")]
+#[cfg_attr(test, assert_instr(pext))]
+#[cfg(not(target_arch = "x86"))]
+pub unsafe fn _pext_u64(a: u64, mask: u64) -> u64 {
+    x86_bmi2_pext_64(a, mask)
+}
+
+extern "C" {
+    #[link_name = "llvm.x86.bmi.bzhi.64"]
+    fn x86_bmi2_bzhi_64(x: u64, y: u64) -> u64;
+    #[link_name = "llvm.x86.bmi.pdep.64"]
+    fn x86_bmi2_pdep_64(x: u64, y: u64) -> u64;
+    #[link_name = "llvm.x86.bmi.pext.64"]
+    fn x86_bmi2_pext_64(x: u64, y: u64) -> u64;
+}
+
+#[cfg(test)]
+mod tests {
+    use stdsimd_test::simd_test;
+
+    use x86::*;
+
+    #[simd_test = "bmi2"]
+    unsafe fn test_pext_u64() {
+        let n = 0b1011_1110_1001_0011u64;
+
+        let m0 = 0b0110_0011_1000_0101u64;
+        let s0 = 0b0000_0000_0011_0101u64;
+
+        let m1 = 0b1110_1011_1110_1111u64;
+        let s1 = 0b0001_0111_0100_0011u64;
+
+        assert_eq!(_pext_u64(n, m0), s0);
+        assert_eq!(_pext_u64(n, m1), s1);
+    }
+
+    #[simd_test = "bmi2"]
+    unsafe fn test_pdep_u64() {
+        let n = 0b1011_1110_1001_0011u64;
+
+        let m0 = 0b0110_0011_1000_0101u64;
+        let s0 = 0b0000_0010_0000_0101u64;
+
+        let m1 = 0b1110_1011_1110_1111u64;
+        let s1 = 0b1110_1001_0010_0011u64;
+
+        assert_eq!(_pdep_u64(n, m0), s0);
+        assert_eq!(_pdep_u64(n, m1), s1);
+    }
+
+    #[simd_test = "bmi2"]
+    unsafe fn test_bzhi_u64() {
+        let n = 0b1111_0010u64;
+        let s = 0b0001_0010u64;
+        assert_eq!(_bzhi_u64(n, 5), s);
+    }
+
+    #[simd_test = "bmi2"]
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    unsafe fn test_mulx_u64() {
+        let a: u64 = 9_223_372_036_854_775_800;
+        let b: u64 = 100;
+        let mut hi = 0;
+        let lo = _mulx_u64(a, b, &mut hi);
+        /*
+result = 922337203685477580000 =
+0b00110001_1111111111111111_1111111111111111_1111111111111111_1111110011100000
+  ^~hi~~~~ ^~lo~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        */
+        assert_eq!(
+            lo,
+            0b11111111_11111111_11111111_11111111_11111111_11111111_11111100_11100000u64
+        );
+        assert_eq!(hi, 0b00110001u64);
+    }
+}

--- a/coresimd/src/x86/x86_64/mod.rs
+++ b/coresimd/src/x86/x86_64/mod.rs
@@ -19,3 +19,18 @@ pub use self::sse42::*;
 
 mod xsave;
 pub use self::xsave::*;
+
+mod abm;
+pub use self::abm::*;
+
+mod avx;
+pub use self::avx::*;
+
+mod bmi;
+pub use self::bmi::*;
+
+mod bmi2;
+pub use self::bmi2::*;
+
+mod avx2;
+pub use self::avx2::*;


### PR DESCRIPTION
Some intrinsics take `i64` or `u64` arguments which typically means that they're
using 64-bit registers and aren't actually available on x86. This commit adds a
check to stdsimd-verify to assert this and moves around some intrinsics that I
believe should only be available on x86_64.

This commit was checked in many places against gcc/clang/MSVC using godbolt.org
to ensure that we're agreeing with what other compilers are doing.

Closes #304