### PR TITLE
Enable verification of more intrinsics

### DIFF
--- a/coresimd/src/x86/i586/rdtsc.rs
+++ b/coresimd/src/x86/i586/rdtsc.rs
@@ -17,7 +17,7 @@ use stdsimd_test::assert_instr;
 /// high-order 32 bits of each of RAX and RDX are cleared.
 #[inline]
 #[cfg_attr(test, assert_instr(rdtsc))]
-pub unsafe fn _rdtsc() -> u64 {
+pub unsafe fn _rdtsc() -> i64 {
     rdtsc()
 }
 
@@ -37,14 +37,14 @@ pub unsafe fn _rdtsc() -> u64 {
 /// high-order 32 bits of each of RAX, RDX, and RCX are cleared.
 #[inline]
 #[cfg_attr(test, assert_instr(rdtscp))]
-pub unsafe fn _rdtscp(aux: *mut u32) -> u64 {
+pub unsafe fn __rdtscp(aux: *mut u32) -> u64 {
     rdtscp(aux as *mut _)
 }
 
 #[allow(improper_ctypes)]
 extern "C" {
     #[link_name = "llvm.x86.rdtsc"]
-    fn rdtsc() -> u64;
+    fn rdtsc() -> i64;
     #[link_name = "llvm.x86.rdtscp"]
     fn rdtscp(aux: *mut u8) -> u64;
 }
@@ -63,7 +63,7 @@ mod tests {
     #[simd_test = "sse2"]
     unsafe fn _rdtscp() {
         let mut aux = 0;
-        let r = rdtsc::_rdtscp(&mut aux);
+        let r = rdtsc::__rdtscp(&mut aux);
         assert_ne!(r, 0); // The chances of this being 0 are infinitesimal
     }
 }

--- a/coresimd/src/x86/x86_64/bswap.rs
+++ b/coresimd/src/x86/x86_64/bswap.rs
@@ -8,14 +8,14 @@ use stdsimd_test::assert_instr;
 /// Return an integer with the reversed byte order of x
 #[inline]
 #[cfg_attr(test, assert_instr(bswap))]
-pub unsafe fn _bswap(x: i32) -> i32 {
-    bswap_i32(x)
+pub unsafe fn _bswap64(x: i64) -> i64 {
+    bswap_i64(x)
 }
 
 #[allow(improper_ctypes)]
 extern "C" {
-    #[link_name = "llvm.bswap.i32"]
-    fn bswap_i32(x: i32) -> i32;
+    #[link_name = "llvm.bswap.i64"]
+    fn bswap_i64(x: i64) -> i64;
 }
 
 #[cfg(test)]
@@ -23,10 +23,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bswap() {
+    fn test_bswap64() {
         unsafe {
-            assert_eq!(_bswap(0x0EADBE0F), 0x0FBEAD0E);
-            assert_eq!(_bswap(0x00000000), 0x00000000);
+            assert_eq!(_bswap64(0x0EADBEEFFADECA0E), 0x0ECADEFAEFBEAD0E);
+            assert_eq!(_bswap64(0x0000000000000000), 0x0000000000000000);
         }
     }
 }

--- a/coresimd/src/x86/x86_64/mod.rs
+++ b/coresimd/src/x86/x86_64/mod.rs
@@ -34,3 +34,6 @@ pub use self::bmi2::*;
 
 mod avx2;
 pub use self::avx2::*;
+
+mod bswap;
+pub use self::bswap::*;


### PR DESCRIPTION
Looks like intrinsics that weren't listing a target feature were accidentally
omitted from the verification logic, so this commit fixes that!

Along the way I've ended up filing #307 and #308 for detected inconsistencies.