### PR TITLE
Remove known exceptions to Intel's signatures

### DIFF
--- a/coresimd/src/x86/i586/sse2.rs
+++ b/coresimd/src/x86/i586/sse2.rs
@@ -1652,96 +1652,96 @@ pub unsafe fn _mm_cmpnge_pd(a: __m128d, b: __m128d) -> __m128d {
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
-pub unsafe fn _mm_comieq_sd(a: __m128d, b: __m128d) -> bool {
-    comieqsd(a, b) as u8 != 0
+pub unsafe fn _mm_comieq_sd(a: __m128d, b: __m128d) -> i32 {
+    comieqsd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for less-than.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
-pub unsafe fn _mm_comilt_sd(a: __m128d, b: __m128d) -> bool {
-    comiltsd(a, b) as u8 != 0
+pub unsafe fn _mm_comilt_sd(a: __m128d, b: __m128d) -> i32 {
+    comiltsd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for less-than-or-equal.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
-pub unsafe fn _mm_comile_sd(a: __m128d, b: __m128d) -> bool {
-    comilesd(a, b) as u8 != 0
+pub unsafe fn _mm_comile_sd(a: __m128d, b: __m128d) -> i32 {
+    comilesd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for greater-than.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
-pub unsafe fn _mm_comigt_sd(a: __m128d, b: __m128d) -> bool {
-    comigtsd(a, b) as u8 != 0
+pub unsafe fn _mm_comigt_sd(a: __m128d, b: __m128d) -> i32 {
+    comigtsd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for greater-than-or-equal.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
-pub unsafe fn _mm_comige_sd(a: __m128d, b: __m128d) -> bool {
-    comigesd(a, b) as u8 != 0
+pub unsafe fn _mm_comige_sd(a: __m128d, b: __m128d) -> i32 {
+    comigesd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for not-equal.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
-pub unsafe fn _mm_comineq_sd(a: __m128d, b: __m128d) -> bool {
-    comineqsd(a, b) as u8 != 0
+pub unsafe fn _mm_comineq_sd(a: __m128d, b: __m128d) -> i32 {
+    comineqsd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for equality.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
-pub unsafe fn _mm_ucomieq_sd(a: __m128d, b: __m128d) -> bool {
-    ucomieqsd(a, b) as u8 != 0
+pub unsafe fn _mm_ucomieq_sd(a: __m128d, b: __m128d) -> i32 {
+    ucomieqsd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for less-than.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
-pub unsafe fn _mm_ucomilt_sd(a: __m128d, b: __m128d) -> bool {
-    ucomiltsd(a, b) as u8 != 0
+pub unsafe fn _mm_ucomilt_sd(a: __m128d, b: __m128d) -> i32 {
+    ucomiltsd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for less-than-or-equal.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
-pub unsafe fn _mm_ucomile_sd(a: __m128d, b: __m128d) -> bool {
-    ucomilesd(a, b) as u8 != 0
+pub unsafe fn _mm_ucomile_sd(a: __m128d, b: __m128d) -> i32 {
+    ucomilesd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for greater-than.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
-pub unsafe fn _mm_ucomigt_sd(a: __m128d, b: __m128d) -> bool {
-    ucomigtsd(a, b) as u8 != 0
+pub unsafe fn _mm_ucomigt_sd(a: __m128d, b: __m128d) -> i32 {
+    ucomigtsd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for greater-than-or-equal.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
-pub unsafe fn _mm_ucomige_sd(a: __m128d, b: __m128d) -> bool {
-    ucomigesd(a, b) as u8 != 0
+pub unsafe fn _mm_ucomige_sd(a: __m128d, b: __m128d) -> i32 {
+    ucomigesd(a, b)
 }
 
 /// Compare the lower element of `a` and `b` for not-equal.
 #[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
-pub unsafe fn _mm_ucomineq_sd(a: __m128d, b: __m128d) -> bool {
-    ucomineqsd(a, b) as u8 != 0
+pub unsafe fn _mm_ucomineq_sd(a: __m128d, b: __m128d) -> i32 {
+    ucomineqsd(a, b)
 }
 
 /// Convert packed double-precision (64-bit) floating-point elements in "a" to
@@ -3876,79 +3876,79 @@ mod tests {
     #[simd_test = "sse2"]
     unsafe fn test_mm_comieq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(_mm_comieq_sd(a, b));
+        assert!(_mm_comieq_sd(a, b) != 0);
 
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(!_mm_comieq_sd(a, b));
+        assert!(_mm_comieq_sd(a, b) == 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_comilt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(!_mm_comilt_sd(a, b));
+        assert!(_mm_comilt_sd(a, b) == 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_comile_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(_mm_comile_sd(a, b));
+        assert!(_mm_comile_sd(a, b) != 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_comigt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(!_mm_comigt_sd(a, b));
+        assert!(_mm_comigt_sd(a, b) == 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_comige_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(_mm_comige_sd(a, b));
+        assert!(_mm_comige_sd(a, b) != 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_comineq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(!_mm_comineq_sd(a, b));
+        assert!(_mm_comineq_sd(a, b) == 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_ucomieq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(_mm_ucomieq_sd(a, b));
+        assert!(_mm_ucomieq_sd(a, b) != 0);
 
         let (a, b) = (_mm_setr_pd(NAN, 2.0), _mm_setr_pd(NAN, 3.0));
-        assert!(!_mm_ucomieq_sd(a, b));
+        assert!(_mm_ucomieq_sd(a, b) == 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_ucomilt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(!_mm_ucomilt_sd(a, b));
+        assert!(_mm_ucomilt_sd(a, b) == 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_ucomile_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(_mm_ucomile_sd(a, b));
+        assert!(_mm_ucomile_sd(a, b) != 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_ucomigt_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(!_mm_ucomigt_sd(a, b));
+        assert!(_mm_ucomigt_sd(a, b) == 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_ucomige_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(_mm_ucomige_sd(a, b));
+        assert!(_mm_ucomige_sd(a, b) != 0);
     }
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_ucomineq_sd() {
         let (a, b) = (_mm_setr_pd(1.0, 2.0), _mm_setr_pd(1.0, 3.0));
-        assert!(!_mm_ucomineq_sd(a, b));
+        assert!(_mm_ucomineq_sd(a, b) == 0);
     }
 
     #[simd_test = "sse2"]

--- a/coresimd/src/x86/i586/sse41.rs
+++ b/coresimd/src/x86/i586/sse41.rs
@@ -184,8 +184,8 @@ pub unsafe fn _mm_insert_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
 #[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pinsrb, imm8 = 0))]
-pub unsafe fn _mm_insert_epi8(a: __m128i, i: i8, imm8: i32) -> __m128i {
-    mem::transmute(simd_insert(a.as_i8x16(), (imm8 & 0b1111) as u32, i))
+pub unsafe fn _mm_insert_epi8(a: __m128i, i: i32, imm8: i32) -> __m128i {
+    mem::transmute(simd_insert(a.as_i8x16(), (imm8 & 0b1111) as u32, i as i8))
 }
 
 /// Return a copy of `a` with the 32-bit integer from `i` inserted at a

--- a/coresimd/src/x86/i686/sse.rs
+++ b/coresimd/src/x86/i686/sse.rs
@@ -312,9 +312,9 @@ pub unsafe fn _m_maskmovq(a: __m64, mask: __m64, mem_addr: *mut i8) {
 #[inline]
 #[target_feature(enable = "sse,mmx")]
 #[cfg_attr(test, assert_instr(pextrw, imm2 = 0))]
-pub unsafe fn _mm_extract_pi16(a: __m64, imm2: i32) -> i16 {
+pub unsafe fn _mm_extract_pi16(a: __m64, imm2: i32) -> i32 {
     macro_rules! call {
-        ($imm2:expr) => { pextrw(a, $imm2) as i16 }
+        ($imm2:expr) => { pextrw(a, $imm2) as i32 }
     }
     constify_imm2!(imm2, call)
 }
@@ -324,7 +324,7 @@ pub unsafe fn _mm_extract_pi16(a: __m64, imm2: i32) -> i16 {
 #[inline]
 #[target_feature(enable = "sse,mmx")]
 #[cfg_attr(test, assert_instr(pextrw, imm2 = 0))]
-pub unsafe fn _m_pextrw(a: __m64, imm2: i32) -> i16 {
+pub unsafe fn _m_pextrw(a: __m64, imm2: i32) -> i32 {
     _mm_extract_pi16(a, imm2)
 }
 

--- a/stdsimd-verify/tests/x86-intel.rs
+++ b/stdsimd-verify/tests/x86-intel.rs
@@ -407,29 +407,11 @@ fn equate(t: &Type, intel: &str, intrinsic: &str) -> Result<(), String> {
         | (&Type::M256, "__m256")
         | (&Type::Ptr(&Type::M256), "__m256*") => {}
 
-        // These two intrinsics return a 16-bit element but in Intel's
-        // intrinsics they're listed as returning an `int`.
-        (&Type::PrimSigned(16), "int") if intrinsic == "_mm_extract_pi16" => {}
-        (&Type::PrimSigned(16), "int") if intrinsic == "_m_pextrw" => {}
-
-        // This intrinsic takes an `i8` to get inserted into an i8 vector, but
-        // Intel says the argument is i32...
-        (&Type::PrimSigned(8), "int") if intrinsic == "_mm_insert_epi8" => {}
-
         // This is a macro (?) in C which seems to mutate its arguments, but
         // that means that we're taking pointers to arguments in rust
         // as we're not exposing it as a macro.
         (&Type::Ptr(&Type::M128), "__m128")
             if intrinsic == "_MM_TRANSPOSE4_PS" => {}
-
-        // These intrinsics return an `int` in C but they're always either the
-        // bit 1 or 0 so we switch it to returning `bool` in rust
-        (&Type::Bool, "int")
-            if intrinsic.starts_with("_mm_comi")
-                && intrinsic.ends_with("_sd") => {}
-        (&Type::Bool, "int")
-            if intrinsic.starts_with("_mm_ucomi")
-                && intrinsic.ends_with("_sd") => {}
 
         _ => bail!(
             "failed to equate: `{}` and {:?} for {}",


### PR DESCRIPTION
We had a few lingering intrinsics which were getting some special
treatment for having different types than what Intel specified. This
commit removes all these cases and reverts to precisely what upstream
Intel mentions (even if it doesn't make the most sense in some cases)