### PR TITLE
Start adding stability attributes

### DIFF
--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -1,4 +1,5 @@
 /// Platform independent SIMD vector types and operations.
+#[unstable(feature = "stdsimd", issue = "0")]
 pub mod simd {
     pub use coresimd::v128::*;
     pub use coresimd::v256::*;
@@ -7,20 +8,28 @@ pub mod simd {
 }
 
 /// Platform dependent vendor intrinsics.
-pub mod vendor {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    pub use coresimd::x86::*;
+#[unstable(feature = "stdsimd", issue = "0")]
+pub mod arch {
+    #[cfg(target_arch = "x86")]
+    pub mod x86 {
+        pub use coresimd::x86::*;
+    }
 
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    pub use coresimd::arm::*;
+    #[cfg(target_arch = "x86_64")]
+    pub mod x86_64 {
+        pub use coresimd::x86::*;
+    }
+
+    #[cfg(target_arch = "arm")]
+    pub mod arm {
+        pub use coresimd::arm::*;
+    }
 
     #[cfg(target_arch = "aarch64")]
-    pub use coresimd::aarch64::*;
-
-    // FIXME: rust does not expose the nvptx and nvptx64 targets yet
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64",
-                  target_arch = "arm", target_arch = "aarch64")))]
-    pub use coresimd::nvptx::*;
+    pub mod aarch64 {
+        pub use coresimd::arm::*;
+        pub use coresimd::aarch64::*;
+    }
 }
 
 #[macro_use]

--- a/coresimd/x86/i586/avx2.rs
+++ b/coresimd/x86/i586/avx2.rs
@@ -2017,7 +2017,7 @@ pub unsafe fn _mm256_shuffle_epi8(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -2623,7 +2623,7 @@ pub unsafe fn _mm256_subs_epu8(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -2672,7 +2672,7 @@ pub unsafe fn _mm256_unpackhi_epi8(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -2720,7 +2720,7 @@ pub unsafe fn _mm256_unpacklo_epi8(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -2764,7 +2764,7 @@ pub unsafe fn _mm256_unpackhi_epi16(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -2808,7 +2808,7 @@ pub unsafe fn _mm256_unpacklo_epi16(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -2851,7 +2851,7 @@ pub unsafe fn _mm256_unpackhi_epi32(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -2891,7 +2891,7 @@ pub unsafe fn _mm256_unpacklo_epi32(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -2930,7 +2930,7 @@ pub unsafe fn _mm256_unpackhi_epi64(a: __m256i, b: __m256i) -> __m256i {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #

--- a/coresimd/x86/i586/sse.rs
+++ b/coresimd/x86/i586/sse.rs
@@ -867,7 +867,7 @@ pub unsafe fn _mm_movemask_ps(a: __m128) -> i32 {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -921,7 +921,7 @@ pub unsafe fn _mm_loadh_pi(a: __m128, p: *const __m64) -> __m128 {
 ///
 /// ```rust
 /// # #![feature(cfg_target_feature)]
-/// # #![feature(target_feature)]
+/// # #![feature(target_feature, stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #

--- a/coresimd/x86/i586/sse41.rs
+++ b/coresimd/x86/i586/sse41.rs
@@ -551,6 +551,8 @@ pub unsafe fn _mm_ceil_ss(a: __m128, b: __m128) -> __m128 {
 /// Rounding is done according to the rounding parameter, which can be one of:
 ///
 /// ```
+/// #![feature(stdsimd)]
+///
 /// extern crate stdsimd;
 ///
 /// #[cfg(target_arch = "x86")]
@@ -588,6 +590,8 @@ pub unsafe fn _mm_round_pd(a: __m128d, rounding: i32) -> __m128d {
 /// Rounding is done according to the rounding parameter, which can be one of:
 ///
 /// ```
+/// #![feature(stdsimd)]
+///
 /// extern crate stdsimd;
 ///
 /// #[cfg(target_arch = "x86")]
@@ -627,6 +631,8 @@ pub unsafe fn _mm_round_ps(a: __m128, rounding: i32) -> __m128 {
 /// Rounding is done according to the rounding parameter, which can be one of:
 ///
 /// ```
+/// #![feature(stdsimd)]
+///
 /// extern crate stdsimd;
 ///
 /// #[cfg(target_arch = "x86")]
@@ -666,6 +672,8 @@ pub unsafe fn _mm_round_sd(a: __m128d, b: __m128d, rounding: i32) -> __m128d {
 /// Rounding is done according to the rounding parameter, which can be one of:
 ///
 /// ```
+/// #![feature(stdsimd)]
+///
 /// extern crate stdsimd;
 ///
 /// #[cfg(target_arch = "x86")]

--- a/coresimd/x86/i586/sse42.rs
+++ b/coresimd/x86/i586/sse42.rs
@@ -98,6 +98,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// ```
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
+/// # #![feature(stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -141,6 +142,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// ```
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
+/// # #![feature(stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -182,6 +184,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// ```
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
+/// # #![feature(stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -223,6 +226,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// ```
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
+/// # #![feature(stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #
@@ -416,6 +420,7 @@ pub unsafe fn _mm_cmpestrm(
 /// ```
 /// # #![feature(cfg_target_feature)]
 /// # #![feature(target_feature)]
+/// # #![feature(stdsimd)]
 /// #
 /// # #[macro_use] extern crate stdsimd;
 /// #

--- a/coresimd/x86/mod.rs
+++ b/coresimd/x86/mod.rs
@@ -54,7 +54,7 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(cfg_target_feature, target_feature)]
+    /// # #![feature(cfg_target_feature, target_feature, stdsimd)]
     /// # #[macro_use]
     /// # extern crate stdsimd;
     /// # fn main() {
@@ -100,7 +100,7 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(cfg_target_feature, target_feature)]
+    /// # #![feature(cfg_target_feature, target_feature, stdsimd)]
     /// # #[macro_use]
     /// # extern crate stdsimd;
     /// # fn main() {
@@ -139,7 +139,7 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(cfg_target_feature, target_feature)]
+    /// # #![feature(cfg_target_feature, target_feature, stdsimd)]
     /// # #[macro_use]
     /// # extern crate stdsimd;
     /// # fn main() {
@@ -178,7 +178,7 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(cfg_target_feature, target_feature)]
+    /// # #![feature(cfg_target_feature, target_feature, stdsimd)]
     /// # #[macro_use]
     /// # extern crate stdsimd;
     /// # fn main() {
@@ -221,7 +221,7 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(cfg_target_feature, target_feature)]
+    /// # #![feature(cfg_target_feature, target_feature, stdsimd)]
     /// # #[macro_use]
     /// # extern crate stdsimd;
     /// # fn main() {
@@ -260,7 +260,7 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(cfg_target_feature, target_feature)]
+    /// # #![feature(cfg_target_feature, target_feature, stdsimd)]
     /// # #[macro_use]
     /// # extern crate stdsimd;
     /// # fn main() {
@@ -299,7 +299,7 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(cfg_target_feature, target_feature)]
+    /// # #![feature(cfg_target_feature, target_feature, stdsimd)]
     /// # #[macro_use]
     /// # extern crate stdsimd;
     /// # fn main() {

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -14,7 +14,8 @@
 #![feature(const_fn, link_llvm_intrinsics, platform_intrinsics, repr_simd,
            simd_ffi, target_feature, cfg_target_feature, i128_type, asm,
            integer_atomics, stmt_expr_attributes, core_intrinsics,
-           crate_in_paths, no_core, attr_literals, rustc_attrs)]
+           crate_in_paths, no_core, attr_literals, rustc_attrs, stdsimd,
+           staged_api)]
 #![cfg_attr(test, feature(proc_macro, test, attr_literals, abi_vectorcall))]
 #![cfg_attr(feature = "cargo-clippy",
             allow(inline_always, too_many_arguments, cast_sign_loss,
@@ -24,6 +25,7 @@
                   many_single_char_names))]
 #![cfg_attr(test, allow(unused_imports))]
 #![no_core]
+#![unstable(feature = "stdsimd", issue = "0")]
 
 #[cfg_attr(not(test), macro_use)]
 extern crate core as _core;
@@ -41,18 +43,8 @@ extern crate stdsimd;
 #[path = "../../../coresimd/mod.rs"]
 mod coresimd;
 
+pub use coresimd::arch;
 pub use coresimd::simd;
-
-pub mod arch {
-    #[cfg(target_arch = "x86")]
-    pub mod x86 { pub use coresimd::vendor::*; }
-    #[cfg(target_arch = "x86_64")]
-    pub mod x86_64 { pub use coresimd::vendor::*; }
-    #[cfg(target_arch = "arm")]
-    pub mod arm { pub use coresimd::vendor::*; }
-    #[cfg(target_arch = "aarch64")]
-    pub mod aarch64 { pub use coresimd::vendor::*; }
-}
 
 #[allow(unused_imports)]
 use _core::clone;

--- a/crates/coresimd/tests/cpu-detection.rs
+++ b/crates/coresimd/tests/cpu-detection.rs
@@ -1,4 +1,4 @@
-#![feature(cfg_target_feature)]
+#![feature(cfg_target_feature, stdsimd)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![cfg_attr(feature = "cargo-clippy",
             allow(option_unwrap_used, print_stdout, use_debug))]

--- a/crates/stdsimd/src/lib.rs
+++ b/crates/stdsimd/src/lib.rs
@@ -32,7 +32,7 @@
 //! # Example
 //!
 //! ```rust
-//! #![feature(cfg_target_feature, target_feature)]
+//! #![feature(cfg_target_feature, target_feature, stdsimd)]
 //!
 //! #[macro_use]
 //! extern crate stdsimd;
@@ -132,9 +132,10 @@
 //! [simd_soundness_bug]: https://github.com/rust-lang/rust/issues/44367
 //! [target_feature_impr]: https://github.com/rust-lang/rust/issues/44839
 
-#![feature(const_fn, integer_atomics)]
+#![feature(const_fn, integer_atomics, staged_api, stdsimd)]
 #![cfg_attr(target_os = "linux", feature(linkage))]
 #![no_std]
+#![unstable(feature = "stdsimd", issue = "0")]
 
 extern crate std as _std;
 extern crate coresimd;

--- a/crates/stdsimd/tests/cpu-detection.rs
+++ b/crates/stdsimd/tests/cpu-detection.rs
@@ -1,4 +1,4 @@
-#![feature(cfg_target_feature)]
+#![feature(cfg_target_feature, stdsimd)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![cfg_attr(feature = "cargo-clippy",
             allow(option_unwrap_used, use_debug, print_stdout))]

--- a/stdsimd/arch/detect/aarch64.rs
+++ b/stdsimd/arch/detect/aarch64.rs
@@ -5,6 +5,7 @@ use super::cache;
 use super::linux;
 
 #[macro_export]
+#[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_target_feature_detected {
     ("neon") => {
         // FIXME: this should be removed once we rename Aarch64 neon to asimd

--- a/stdsimd/arch/detect/arm.rs
+++ b/stdsimd/arch/detect/arm.rs
@@ -5,6 +5,7 @@ use super::cache;
 use super::linux;
 
 #[macro_export]
+#[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_target_feature_detected {
     ("neon") => {
         $crate::arch::detect::check_for($crate::arch::detect::Feature::neon)

--- a/stdsimd/arch/detect/powerpc64.rs
+++ b/stdsimd/arch/detect/powerpc64.rs
@@ -4,6 +4,7 @@ use super::cache;
 use super::linux;
 
 #[macro_export]
+#[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_target_feature_detected {
     ("altivec") => {
         $crate::arch::detect::check_for($crate::arch::detect::Feature::altivec)

--- a/stdsimd/arch/detect/x86.rs
+++ b/stdsimd/arch/detect/x86.rs
@@ -26,6 +26,7 @@ use coresimd::arch::x86_64::*;
 use super::{bit, cache};
 
 #[macro_export]
+#[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_target_feature_detected {
     ("aes") => {
         $crate::arch::detect::check_for(

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -1,6 +1,8 @@
+#[unstable(feature = "stdsimd", issue = "0")]
 pub mod arch {
     pub use coresimd::arch::*;
     pub mod detect;
 }
 
+#[unstable(feature = "stdsimd", issue = "0")]
 pub use coresimd::simd;


### PR DESCRIPTION
To integrate into the standard library this crate needs *at least* a
stability attribute on the macro itself but this commit also beings by
adding unstable attributes to the exported modules as well. This should
help everything be unstable-by-default and we can start iterating from
there in the standard library.

This commit also does away with the `coresimd::vendor` module internal
implementation detail, instead directly creating the `arch` module to
allow easily documenting it in this crate and having the docs show up in
rust-lang/rust.