### PR TITLE
Beef up documentation of `arch` module

### DIFF
--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -1,4 +1,8 @@
 /// Platform independent SIMD vector types and operations.
+///
+/// This is an **unstable** module for portable SIMD operations. This module has
+/// not yet gone through an RFC and is likely to change, but feedback is always
+/// welcome!
 #[unstable(feature = "stdsimd", issue = "0")]
 pub mod simd {
     pub use coresimd::v128::*;
@@ -8,23 +12,55 @@ pub mod simd {
 }
 
 /// Platform dependent vendor intrinsics.
+///
+/// This documentation is for the version of this module in the `coresimd`
+/// crate, but you probably want to use the [`stdsimd` crate][stdsimd] which
+/// should have more complete documentation.
+///
+/// [stdsimd]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/arch/index.html
+///
+/// Also note that while this module may appear to contains the intrinsics for
+/// only one platform it actually contains intrinsics for multiple platforms
+/// compiled in conditionally. For other platforms of stdsimd see:
+///
+/// * [x86]
+/// * [x86_64]
+/// * [arm]
+/// * [aarch64]
+///
+/// [x86]: https://rust-lang-nursery.github.io/stdsimd/x86/stdsimd/arch/index.html
+/// [x86_64]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/arch/index.html
+/// [arm]: https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/arch/index.html
+/// [aarch64]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/index.html
 #[unstable(feature = "stdsimd", issue = "0")]
 pub mod arch {
+    /// Platform-specific intrinsics for the `x86` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
     #[cfg(target_arch = "x86")]
     pub mod x86 {
         pub use coresimd::x86::*;
     }
 
+    /// Platform-specific intrinsics for the `x86_64` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
     #[cfg(target_arch = "x86_64")]
     pub mod x86_64 {
         pub use coresimd::x86::*;
     }
 
+    /// Platform-specific intrinsics for the `arm` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
     #[cfg(target_arch = "arm")]
     pub mod arm {
         pub use coresimd::arm::*;
     }
 
+    /// Platform-specific intrinsics for the `aarch64` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
     #[cfg(target_arch = "aarch64")]
     pub mod aarch64 {
         pub use coresimd::arm::*;

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -1,12 +1,10 @@
 //! SIMD and vendor intrinsics support library.
 //!
-//! This documentation is only for one particular architecture, you can find
-//! others at:
+//! This documentation is for the `coresimd` crate, but you probably want to use
+//! the [`stdsimd` crate][stdsimd] which should have more complete
+//! documentation.
 //!
-//! * [i686](https://rust-lang-nursery.github.io/stdsimd/i686/stdsimd/)
-//! * [`x86_64`](https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/)
-//! * [arm](https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/)
-//! * [aarch64](https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/)
+//! [stdsimd]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/
 
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![allow(dead_code)]

--- a/crates/stdsimd/src/lib.rs
+++ b/crates/stdsimd/src/lib.rs
@@ -1,136 +1,11 @@
 //! SIMD and vendor intrinsics support library.
 //!
-//! This documentation is only for one particular architecture, you can find
-//! others at:
+//! This crate defines the vendor intrinsics and types primarily used for SIMD
+//! in Rust. The crate here will soon be available in the standard library, but
+//! for now you can also browse the documentation here, primarily in the `arch`
+//! submodule.
 //!
-//! * [i686](https://rust-lang-nursery.github.io/stdsimd/i686/stdsimd/)
-//! * [`x86_64`](https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/)
-//! * [arm](https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/)
-//! * [aarch64](https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/)
-//! * [powerpc](https://rust-lang-nursery.github.io/stdsimd/powerpc/stdsimd/)
-//! * [powerpc64](https://rust-lang-nursery.github.io/stdsimd/powerpc64/stdsimd/)
-//!
-//! # Overview
-//!
-//! The `simd` module exposes *portable vector types*. These types work on all
-//! platforms, but their run-time performance may vary depending on hardware
-//! support.
-//!
-//! The `vendor` module exposes vendor-specific intrinsics that typically
-//! correspond to a single machine instruction. In general, these intrinsics
-//! are not portable: their availability is architecture-dependent, and not all
-//! machines of that architecture might provide the intrinsic.
-//!
-//! Two macros make it possible to write portable code:
-//!
-//! * `cfg!(target_feature = "feature")`: returns `true` if the `feature` is
-//! enabled in all CPUs that the binary will run on (at compile-time)
-//! * `is_target_feature_detected!("feature")`: returns `true` if the `feature` is
-//! enabled in the CPU in which the binary is currently running on (at
-//! run-time, unless the result is known at compile time)
-//!
-//! # Example
-//!
-//! ```rust
-//! #![feature(cfg_target_feature, target_feature, stdsimd)]
-//!
-//! #[macro_use]
-//! extern crate stdsimd;
-//! use stdsimd::simd::i32x4;
-//!
-//! fn main() {
-//!     let a = i32x4::new(1, 2, 3, 4);
-//!     let b = i32x4::splat(10);
-//!     assert_eq!(b, i32x4::new(10, 10, 10, 10));
-//!     let c = a + b;
-//!     assert_eq!(c, i32x4::new(11, 12, 13, 14));
-//!     assert_eq!(sum_portable(b), 40);
-//!     assert_eq!(sum_ct(b), 40);
-//!     assert_eq!(sum_rt(b), 40);
-//! }
-//!
-//! // Sums the elements of the vector.
-//! fn sum_portable(x: i32x4) -> i32 {
-//!     let mut r = 0;
-//!     for i in 0..4 {
-//!         r += x.extract(i);
-//!     }
-//!     r
-//! }
-//!
-//! // Sums the elements of the vector using SSE2 instructions.
-//! // This function is only safe to call if the CPU where the
-//! // binary runs supports SSE2.
-//! #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-//! #[target_feature(enable = "sse2")]
-//! unsafe fn sum_sse2(x: i32x4) -> i32 {
-//!     #[cfg(target_arch = "x86")]
-//!     use stdsimd::arch::x86::*;;
-//!     #[cfg(target_arch = "x86_64")]
-//!     use stdsimd::arch::x86_64::*;;
-//!     use std::mem;
-//!
-//!     let x: __m128i = mem::transmute(x);
-//!     let x = _mm_add_epi32(x, _mm_srli_si128(x, 8));
-//!     let x = _mm_add_epi32(x, _mm_srli_si128(x, 4));
-//!     let ret = _mm_cvtsi128_si32(x);
-//!     mem::transmute(ret)
-//! }
-//!
-//! // Uses the SSE2 version if SSE2 is enabled for all target
-//! // CPUs at compile-time (does not perform any run-time
-//! // feature detection).
-//! fn sum_ct(x: i32x4) -> i32 {
-//!     #[cfg(all(any(target_arch = "x86_64", target_arch = "x86"),
-//!               target_feature = "sse2"))]
-//!     {
-//!         // This function is only available for x86/x86_64 targets,
-//!         // and is only safe to call it if the target supports SSE2
-//!         unsafe { sum_sse2(x) }
-//!     }
-//!     #[cfg(not(all(any(target_arch = "x86_64", target_arch = "x86"),
-//!                   target_feature = "sse2")))]
-//!     {
-//!         sum_portable(x)
-//!     }
-//! }
-//!
-//! // Detects SSE2 at run-time, and uses a SIMD intrinsic if enabled.
-//! fn sum_rt(x: i32x4) -> i32 {
-//!     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-//!     {
-//!         // If SSE2 is not enabled at compile-time, this
-//!         // detects whether SSE2 is available at run-time:
-//!         if is_target_feature_detected!("sse2") {
-//!             return unsafe { sum_sse2(x) };
-//!         }
-//!     }
-//!     sum_portable(x)
-//! }
-//! ```
-//!
-//! # Status
-//!
-//! This crate is intended for eventual inclusion into the standard library,
-//! but some work and experimentation is needed to get there! First and
-//! foremost you can help out by kicking the tires on this crate and seeing if
-//! it works for your use case! Next up you can help us fill out the [vendor
-//! intrinsics][vendor] to ensure that we've got all the SIMD support
-//! necessary.
-//!
-//! The language support and status of SIMD is also still a little up in the
-//! air right now, you may be interested in a few issues along these lines:
-//!
-//! * [Overal tracking issue for SIMD support][simd_tracking_issue]
-//! * [`cfg_target_feature` tracking issue][cfg_target_feature_issue]
-//! * [SIMD types currently not sound][simd_soundness_bug]
-//! * [`#[target_feature]` improvements][target_feature_impr]
-//!
-//! [vendor]: https://github.com/rust-lang-nursery/stdsimd/issues/40
-//! [simd_tracking_issue]: https://github.com/rust-lang/rust/issues/27731
-//! [cfg_target_feature_issue]: https://github.com/rust-lang/rust/issues/29717
-//! [simd_soundness_bug]: https://github.com/rust-lang/rust/issues/44367
-//! [target_feature_impr]: https://github.com/rust-lang/rust/issues/44839
+//! [stdsimd]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/
 
 #![feature(const_fn, integer_atomics, staged_api, stdsimd)]
 #![cfg_attr(target_os = "linux", feature(linkage))]
@@ -152,6 +27,6 @@ mod stdsimd;
 
 pub use stdsimd::*;
 
-pub use _std::prelude;
-pub use _std::fs;
-pub use _std::io;
+use _std::prelude;
+use _std::fs;
+use _std::io;

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -1,6 +1,357 @@
+/// SIMD and vendor intrinsics module.
+///
+/// This module is intended to be the gateway to architecture-specific intrinsic
+/// functions, typically related to SIMD (but not always!). Each architecture
+/// that Rust compiles to may contain a submodule here, which means that this is
+/// not a portable module! If you're writing a portable library take care when
+/// using these APIs!
+///
+/// Under this module you'll find an architecture-named module, such as
+/// `x86_64`. Each `#[cfg(target_arch)]` that Rust can compile to may have a
+/// module entry here, only present on that particular target. For example the
+/// `i686-pc-windows-msvc` target will have an `x86` module here, whereas
+/// `x86_64-pc-windows-msvc` has `x86_64`.
+///
+/// > **Note**: This module is currently unstable. It was designed in
+/// > [RFC 2325][rfc] and is currently [tracked] for stabilization.
+///
+/// [rfc]: https://github.com/rust-lang/rfcs/pull/2325
+/// [tracked]: https://github.com/rust-lang/rust/issues/48556
+///
+/// # Overview
+///
+/// This module exposes vendor-specific intrinsics that typically correspond to
+/// a single machine instruction. These intrinsics are not portable: their
+/// availability is architecture-dependent, and not all machines of that
+/// architecture might provide the intrinsic.
+///
+/// The `arch` module is intended to be a low-level implementation detail for
+/// higher-level APIs. Using it correctly can be quite tricky as you need to
+/// ensure at least a few guarantees are upheld:
+///
+/// * The correct architecture's module is used. For example the `arm` module
+///   isn't available on the `x86_64-unknown-linux-gnu` target. This is
+///   typically done by ensuring that `#[cfg]` is used appropriately when using
+///   this module.
+/// * The CPU the program is currently running on supports the function being
+///   called. For example it is unsafe to call an AVX2 function on a CPU that
+///   doesn't actually support AVX2.
+///
+/// As a result of the latter of these guarantees all intrinsics in this module
+/// are `unsafe` and extra care needs to be taken when calling them!
+///
+/// # CPU Feature Detection
+///
+/// In order to call these APIs in a safe fashion there's a number of mechanisms
+/// available to ensure that the correct CPU feature is available to call an
+/// intrinsic. Let's consider, for example, the `_mm256_add_epi64` intrinsics on
+/// the `x86` and `x86_64` architectures. This function requires the AVX2
+/// feature as [documented by Intel][intel-dox] so to correctly call this
+/// function we need to (a) guarantee we only call it on x86/x86_64 and (b)
+/// ensure that the CPU feature is available
+///
+/// [intel-dox]: https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm256_add_epi64&expand=100
+///
+/// ## Static CPU Feature Detection
+///
+/// The first option available to us is to conditionally compile code via the
+/// `#[cfg]` attribute. CPU features correspond to the `target_feature` cfg
+/// available, and can be used like so:
+///
+/// ```ignore
+/// #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
+///       target_feature = "avx2"))]
+/// fn foo() {
+///     #[cfg(target_arch = "x86")]
+///     use std::arch::x86::_mm256_add_epi64;
+///     #[cfg(target_arch = "x86_64")]
+///     use std::arch::x86_64::_mm256_add_epi64;
+///
+///     unsafe {
+///         _mm256_add_epi64(...);
+///     }
+/// }
+/// ```
+///
+/// Here we're using `#[cfg(target_feature = "avx2")]` to conditionally compile
+/// this function into our module. This means that if the `avx2` feature is
+/// *enabled statically* then we'll use the `_mm256_add_epi64` function at
+/// runtime. The `unsafe` block here can be justified through the usage of
+/// `#[cfg]` to only compile the code in situations where the safety guarantees
+/// are upheld.
+///
+/// Statically enabling a feature is typically done with the `-C target-feature`
+/// or `-C target-cpu` flags to the compiler. For example if your local CPU
+/// supports AVX2 then you can compile the above function with:
+///
+/// ```sh
+/// $ RUSTFLAGS='-C target-cpu=native' cargo build
+/// ```
+///
+/// Or otherwise you can specifically enable just the AVX2 feature:
+///
+/// ```sh
+/// $ RUSTFLAGS='-C target-feature=+avx2' cargo build
+/// ```
+///
+/// Note that when you compile a binary with a particular feature enabled it's
+/// important to ensure that you only run the binary on systems which satisfy
+/// the required feature set.
+///
+/// ## Dynamic CPU Feature Detection
+///
+/// Sometimes statically dispatching isn't quite what you want. Instead you
+/// might want to build a portable binary that runs across a variety of CPUs,
+/// but at runtime it selects the most optimized implementation available. This
+/// allows you to build a "least common denominator" binary which has certain
+/// sections more optimized for different CPUs.
+///
+/// Taking our previous example from before, we're going to compile our binary
+/// *without* AVX2 support, but we'd like to enable it for just one function. We
+/// can do that in a manner like:
+///
+/// ```ignore
+/// fn foo() {
+///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+///     {
+///         if is_target_feature_detected!("avx2") {
+///             return unsafe { foo_avx2() };
+///         }
+///     }
+///
+///     // fallback implementation without using AVX2
+/// }
+///
+/// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+/// #[target_feature(enable = "avx2")]
+/// unsafe fn foo_avx2() {
+///     #[cfg(target_arch = "x86")]
+///     use std::arch::x86::_mm256_add_epi64;
+///     #[cfg(target_arch = "x86_64")]
+///     use std::arch::x86_64::_mm256_add_epi64;
+///
+///     _mm256_add_epi64(...);
+/// }
+/// ```
+///
+/// There's a couple of components in play here, so let's go through them in
+/// detail!
+///
+/// * First up we notice the `is_target_feature_detected!` macro. Provided by
+///   the standard library, this macro will perform necessary runtime detection
+///   to determine whether the CPU the program is running on supports the
+///   specified feature. In this case the macro will expand to a boolean
+///   expression evaluating to whether the local CPU has the AVX2 feature or not.
+///
+///   Note that this macro, like the `arch` module, is platform-specific. The
+///   name of the macro is the same across platforms, but the arguments to the
+///   macro are only the features for the current platform. For example calling
+///   `is_target_feature_detected!("avx2")` on ARM will be a compile time
+///   error. To ensure we don't hit this error a statement level `#[cfg]` is
+///   used to only compile usage of the macro on x86/x86_64.
+///
+/// * Next up we see our AVX2-enabled function, `foo_avx2`. This function is
+///   decorated with the `#[target_feature]` attribute which enables a CPU
+///   feature for just this one function. Using a compiler flag like `-C
+///   target-feature=+avx2` will enable AVX2 for the entire program, but using
+///   an attribute will only enable it for the one function. Usage of the
+///   `#[target_feature]` attribute currently requires the function to also be
+///   `unsafe`, as we see here. This is because the function can only be
+///   correctly called on systems which have the AVX2 (like the intrinsics
+///   themselves).
+///
+/// And with all that we should have a working program! This program will run
+/// across all machines and it'll use the optimized AVX2 implementation on
+/// machines where support is detected.
+///
+/// # Ergnomics
+///
+/// It's important to note that using the `arch` module is not the easiest thing
+/// in the world, so if you're curious to try it out you may want to brace
+/// yourself for some wordiness!
+///
+/// The primary purpose of this module is to enable stable crates on crates.io
+/// to build up much more ergonomic abstractions which end up using SIMD under
+/// the hood. Over time these abstractions may also move into the standard
+/// library itself, but for now this module is tasked with providing the bare
+/// minimum necessary to use vendor intrinsics on stable Rust.
+///
+/// # Other architectures
+///
+/// This documentation is only for one particular architecture, you can find
+/// others at:
+///
+/// * [x86]
+/// * [x86_64]
+/// * [arm]
+/// * [aarch64]
+///
+/// [x86]: https://rust-lang-nursery.github.io/stdsimd/i686/stdsimd/arch/x86/index.html
+/// [x86_64]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/arch/x86_64/index.html
+/// [arm]: https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/arch/arm/index.html
+/// [aarch64]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/aarch64/index.html
+///
+/// # Examples
+///
+/// First let's take a look at not actually using any intrinsics but instead
+/// using LLVM's auto-vectorization to produce optimized vectorized code for
+/// AVX2 and also for the default platform.
+///
+/// ```rust
+/// #![feature(cfg_target_feature, target_feature, stdsimd)]
+///
+/// # #[cfg(not(dox))]
+/// # #[macro_use]
+/// # extern crate stdsimd;
+///
+/// fn main() {
+///     let mut dst = [0];
+///     add_quickly(&[1], &[2], &mut dst);
+///     assert_eq!(dst[0], 3);
+/// }
+///
+/// fn add_quickly(a: &[u8], b: &[u8], c: &mut [u8]) {
+///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+///     {
+///         // Note that this `unsafe` block is safe because we're testing
+///         // that the `avx2` feature is indeed available on our CPU.
+///         if is_target_feature_detected!("avx2") {
+///             return unsafe { add_quickly_avx2(a, b, c) }
+///         }
+///     }
+///
+///     add_quickly_fallback(a, b, c)
+/// }
+///
+/// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+/// #[target_feature(enable = "avx2")]
+/// unsafe fn add_quickly_avx2(a: &[u8], b: &[u8], c: &mut [u8]) {
+///     add_quickly_fallback(a, b, c) // the function below is inlined here
+/// }
+///
+/// fn add_quickly_fallback(a: &[u8], b: &[u8], c: &mut [u8]) {
+///     for ((a, b), c) in a.iter().zip(b).zip(c) {
+///         *c = *a + *b;
+///     }
+/// }
+/// ```
+///
+/// Next up let's take a look at an example of manually using intrinsics. Here
+/// we'll be using SSE4.1 features to implement hex encoding.
+///
+/// ```
+/// #![feature(cfg_target_feature, target_feature, stdsimd)]
+/// # #![no_std]
+/// # #[cfg(not(dox))]
+/// # extern crate std as real_std;
+/// # #[cfg(not(dox))]
+/// # #[macro_use]
+/// # extern crate stdsimd as std;
+///
+/// fn main() {
+///     let mut dst = [0; 32];
+///     hex_encode(b"\x01\x02\x03", &mut dst);
+///     assert_eq!(&dst[..6], b"010203");
+///
+///     let mut src = [0; 16];
+///     for i in 0..16 {
+///         src[i] = (i + 1) as u8;
+///     }
+///     hex_encode(&src, &mut dst);
+///     assert_eq!(&dst, b"0102030405060708090a0b0c0d0e0f10");
+/// }
+///
+/// pub fn hex_encode(src: &[u8], dst: &mut [u8]) {
+///     let len = src.len().checked_mul(2).unwrap();
+///     assert!(dst.len() >= len);
+///
+///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+///     {
+///         if is_target_feature_detected!("sse4.1") {
+///             return unsafe { hex_encode_sse41(src, dst) };
+///         }
+///     }
+///
+///     hex_encode_fallback(src, dst)
+/// }
+///
+/// // translated from https://github.com/Matherunner/bin2hex-sse/blob/master/base16_sse4.cpp
+/// #[target_feature(enable = "sse4.1")]
+/// #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+/// unsafe fn hex_encode_sse41(mut src: &[u8], dst: &mut [u8]) {
+///     #[cfg(target_arch = "x86")]
+///     use std::arch::x86::*;
+///     #[cfg(target_arch = "x86_64")]
+///     use std::arch::x86_64::*;
+///
+///     let ascii_zero = _mm_set1_epi8(b'0' as i8);
+///     let nines = _mm_set1_epi8(9);
+///     let ascii_a = _mm_set1_epi8((b'a' - 9 - 1) as i8);
+///     let and4bits = _mm_set1_epi8(0xf);
+///
+///     let mut i = 0_isize;
+///     while src.len() >= 16 {
+///         let invec = _mm_loadu_si128(src.as_ptr() as *const _);
+///
+///         let masked1 = _mm_and_si128(invec, and4bits);
+///         let masked2 = _mm_and_si128(_mm_srli_epi64(invec, 4), and4bits);
+///
+///         // return 0xff corresponding to the elements > 9, or 0x00 otherwise
+///         let cmpmask1 = _mm_cmpgt_epi8(masked1, nines);
+///         let cmpmask2 = _mm_cmpgt_epi8(masked2, nines);
+///
+///         // add '0' or the offset depending on the masks
+///         let masked1 = _mm_add_epi8(
+///             masked1,
+///             _mm_blendv_epi8(ascii_zero, ascii_a, cmpmask1),
+///         );
+///         let masked2 = _mm_add_epi8(
+///             masked2,
+///             _mm_blendv_epi8(ascii_zero, ascii_a, cmpmask2),
+///         );
+///
+///         // interleave masked1 and masked2 bytes
+///         let res1 = _mm_unpacklo_epi8(masked2, masked1);
+///         let res2 = _mm_unpackhi_epi8(masked2, masked1);
+///
+///         _mm_storeu_si128(dst.as_mut_ptr().offset(i * 2) as *mut _, res1);
+///         _mm_storeu_si128(dst.as_mut_ptr().offset(i * 2 + 16) as *mut _, res2);
+///         src = &src[16..];
+///         i += 16;
+///     }
+///
+///     let i = i as usize;
+///     hex_encode_fallback(src, &mut dst[i * 2..]);
+/// }
+///
+/// fn hex_encode_fallback(src: &[u8], dst: &mut [u8]) {
+///     fn hex(byte: u8) -> u8 {
+///         static TABLE: &[u8] = b"0123456789abcdef";
+///         TABLE[byte as usize]
+///     }
+///
+///     for (byte, slots) in src.iter().zip(dst.chunks_mut(2)) {
+///         slots[0] = hex((*byte >> 4) & 0xf);
+///         slots[1] = hex(*byte & 0xf);
+///     }
+/// }
+/// ```
+
 #[unstable(feature = "stdsimd", issue = "0")]
 pub mod arch {
-    pub use coresimd::arch::*;
+    #[cfg(target_arch = "x86")]
+    pub use coresimd::arch::x86;
+
+    #[cfg(target_arch = "x86_64")]
+    pub use coresimd::arch::x86_64;
+
+    #[cfg(target_arch = "arm")]
+    pub use coresimd::arch::arm;
+
+    #[cfg(target_arch = "aarch64")]
+    pub use coresimd::arch::aarch64;
+
+    #[doc(hidden)] // unstable implementation detail
     pub mod detect;
 }
 


### PR DESCRIPTION
This commit reorganizes some documentation for inclusion into the standard
library, moving the bulk of the docs to the `arch` module and away from the
crate root which won't actually be the end-user interface.