### PR TITLE
Rename `is_target_feature_detected!`

### DIFF
--- a/coresimd/x86/avx2.rs
+++ b/coresimd/x86/avx2.rs
@@ -2127,7 +2127,7 @@ pub unsafe fn _mm256_shuffle_epi8(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 /// let a = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
@@ -2736,7 +2736,7 @@ pub unsafe fn _mm256_subs_epu8(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 /// let a = _mm256_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -2788,7 +2788,7 @@ pub unsafe fn _mm256_unpackhi_epi8(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 /// let a = _mm256_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -2839,7 +2839,7 @@ pub unsafe fn _mm256_unpacklo_epi8(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 /// let a = _mm256_setr_epi16(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -2886,7 +2886,7 @@ pub unsafe fn _mm256_unpackhi_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 ///
@@ -2934,7 +2934,7 @@ pub unsafe fn _mm256_unpacklo_epi16(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 /// let a = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
@@ -2980,7 +2980,7 @@ pub unsafe fn _mm256_unpackhi_epi32(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 /// let a = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
@@ -3023,7 +3023,7 @@ pub unsafe fn _mm256_unpacklo_epi32(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 /// let a = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -3065,7 +3065,7 @@ pub unsafe fn _mm256_unpackhi_epi64(a: __m256i, b: __m256i) -> __m256i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("avx2") {
+/// #     if is_x86_feature_detected!("avx2") {
 /// #         #[target_feature(enable = "avx2")]
 /// #         unsafe fn worker() {
 /// let a = _mm256_setr_epi64x(0, 1, 2, 3);

--- a/coresimd/x86/mod.rs
+++ b/coresimd/x86/mod.rs
@@ -73,7 +73,7 @@ types! {
     /// let all_bytes_one = _mm_set1_pi8(1);
     /// let two_i32 = _mm_set_pi32(1, 2);
     /// # }
-    /// # if is_target_feature_detected!("mmx") { unsafe { foo() } }
+    /// # if is_x86_feature_detected!("mmx") { unsafe { foo() } }
     /// # }
     /// ```
     pub struct __m64(i64);
@@ -123,7 +123,7 @@ types! {
     /// let all_bytes_one = _mm_set1_epi8(1);
     /// let four_i32 = _mm_set_epi32(1, 2, 3, 4);
     /// # }
-    /// # if is_target_feature_detected!("sse2") { unsafe { foo() } }
+    /// # if is_x86_feature_detected!("sse2") { unsafe { foo() } }
     /// # }
     /// ```
     pub struct __m128i(i64, i64);
@@ -166,7 +166,7 @@ types! {
     /// let four_ones = _mm_set1_ps(1.0);
     /// let four_floats = _mm_set_ps(1.0, 2.0, 3.0, 4.0);
     /// # }
-    /// # if is_target_feature_detected!("sse") { unsafe { foo() } }
+    /// # if is_x86_feature_detected!("sse") { unsafe { foo() } }
     /// # }
     /// ```
     pub struct __m128(f32, f32, f32, f32);
@@ -209,7 +209,7 @@ types! {
     /// let two_ones = _mm_set1_pd(1.0);
     /// let two_floats = _mm_set_pd(1.0, 2.0);
     /// # }
-    /// # if is_target_feature_detected!("sse") { unsafe { foo() } }
+    /// # if is_x86_feature_detected!("sse") { unsafe { foo() } }
     /// # }
     /// ```
     pub struct __m128d(f64, f64);
@@ -256,7 +256,7 @@ types! {
     /// let all_bytes_one = _mm256_set1_epi8(1);
     /// let eight_i32 = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
     /// # }
-    /// # if is_target_feature_detected!("avx") { unsafe { foo() } }
+    /// # if is_x86_feature_detected!("avx") { unsafe { foo() } }
     /// # }
     /// ```
     pub struct __m256i(i64, i64, i64, i64);
@@ -299,7 +299,7 @@ types! {
     /// let eight_ones = _mm256_set1_ps(1.0);
     /// let eight_floats = _mm256_set_ps(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
     /// # }
-    /// # if is_target_feature_detected!("sse") { unsafe { foo() } }
+    /// # if is_x86_feature_detected!("sse") { unsafe { foo() } }
     /// # }
     /// ```
     pub struct __m256(f32, f32, f32, f32, f32, f32, f32, f32);
@@ -342,7 +342,7 @@ types! {
     /// let four_ones = _mm256_set1_pd(1.0);
     /// let four_floats = _mm256_set_pd(1.0, 2.0, 3.0, 4.0);
     /// # }
-    /// # if is_target_feature_detected!("avx") { unsafe { foo() } }
+    /// # if is_x86_feature_detected!("avx") { unsafe { foo() } }
     /// # }
     /// ```
     pub struct __m256d(f64, f64, f64, f64);

--- a/coresimd/x86/sse.rs
+++ b/coresimd/x86/sse.rs
@@ -881,7 +881,7 @@ pub unsafe fn _mm_movemask_ps(a: __m128) -> i32 {
 /// #
 /// # // The real main function
 /// # fn main() {
-/// #     if is_target_feature_detected!("sse") {
+/// #     if is_x86_feature_detected!("sse") {
 /// #         #[target_feature(enable = "sse")]
 /// #         unsafe fn worker() {
 /// #
@@ -936,7 +936,7 @@ pub unsafe fn _mm_loadh_pi(a: __m128, p: *const __m64) -> __m128 {
 ///
 /// # // The real main function
 /// # fn main() {
-/// #     if is_target_feature_detected!("sse") {
+/// #     if is_x86_feature_detected!("sse") {
 /// #         #[target_feature(enable = "sse")]
 /// #         unsafe fn worker() {
 /// #

--- a/coresimd/x86/sse42.rs
+++ b/coresimd/x86/sse42.rs
@@ -115,7 +115,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("sse4.2") {
+/// #     if is_x86_feature_detected!("sse4.2") {
 /// #         #[target_feature(enable = "sse4.2")]
 /// #         unsafe fn worker() {
 /// let haystack = b"This is a long string of text data\r\n\tthat extends
@@ -162,7 +162,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("sse4.2") {
+/// #     if is_x86_feature_detected!("sse4.2") {
 /// #         #[target_feature(enable = "sse4.2")]
 /// #         unsafe fn worker() {
 /// // Ensure your input is 16 byte aligned
@@ -208,7 +208,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("sse4.2") {
+/// #     if is_x86_feature_detected!("sse4.2") {
 /// #         #[target_feature(enable = "sse4.2")]
 /// #         unsafe fn worker() {
 /// # let b = b":;<=>?@[\\]^_`abc";
@@ -254,7 +254,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("sse4.2") {
+/// #     if is_x86_feature_detected!("sse4.2") {
 /// #         #[target_feature(enable = "sse4.2")]
 /// #         unsafe fn worker() {
 /// # let mut some_utf16_words = [0u16; 8];
@@ -452,7 +452,7 @@ pub unsafe fn _mm_cmpestrm(
 /// use std::arch::x86_64::*;
 ///
 /// # fn main() {
-/// #     if is_target_feature_detected!("sse4.2") {
+/// #     if is_x86_feature_detected!("sse4.2") {
 /// #         #[target_feature(enable = "sse4.2")]
 /// #         unsafe fn worker() {
 ///

--- a/crates/coresimd/tests/cpu-detection.rs
+++ b/crates/coresimd/tests/cpu-detection.rs
@@ -10,44 +10,44 @@ extern crate stdsimd;
 #[test]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn x86_all() {
-    println!("sse: {:?}", is_target_feature_detected!("sse"));
-    println!("sse2: {:?}", is_target_feature_detected!("sse2"));
-    println!("sse3: {:?}", is_target_feature_detected!("sse3"));
-    println!("ssse3: {:?}", is_target_feature_detected!("ssse3"));
-    println!("sse4.1: {:?}", is_target_feature_detected!("sse4.1"));
-    println!("sse4.2: {:?}", is_target_feature_detected!("sse4.2"));
-    println!("sse4a: {:?}", is_target_feature_detected!("sse4a"));
-    println!("avx: {:?}", is_target_feature_detected!("avx"));
-    println!("avx2: {:?}", is_target_feature_detected!("avx2"));
-    println!("avx512f {:?}", is_target_feature_detected!("avx512f"));
-    println!("avx512cd {:?}", is_target_feature_detected!("avx512cd"));
-    println!("avx512er {:?}", is_target_feature_detected!("avx512er"));
-    println!("avx512pf {:?}", is_target_feature_detected!("avx512pf"));
-    println!("avx512bw {:?}", is_target_feature_detected!("avx512bw"));
-    println!("avx512dq {:?}", is_target_feature_detected!("avx512dq"));
-    println!("avx512vl {:?}", is_target_feature_detected!("avx512vl"));
+    println!("sse: {:?}", is_x86_feature_detected!("sse"));
+    println!("sse2: {:?}", is_x86_feature_detected!("sse2"));
+    println!("sse3: {:?}", is_x86_feature_detected!("sse3"));
+    println!("ssse3: {:?}", is_x86_feature_detected!("ssse3"));
+    println!("sse4.1: {:?}", is_x86_feature_detected!("sse4.1"));
+    println!("sse4.2: {:?}", is_x86_feature_detected!("sse4.2"));
+    println!("sse4a: {:?}", is_x86_feature_detected!("sse4a"));
+    println!("avx: {:?}", is_x86_feature_detected!("avx"));
+    println!("avx2: {:?}", is_x86_feature_detected!("avx2"));
+    println!("avx512f {:?}", is_x86_feature_detected!("avx512f"));
+    println!("avx512cd {:?}", is_x86_feature_detected!("avx512cd"));
+    println!("avx512er {:?}", is_x86_feature_detected!("avx512er"));
+    println!("avx512pf {:?}", is_x86_feature_detected!("avx512pf"));
+    println!("avx512bw {:?}", is_x86_feature_detected!("avx512bw"));
+    println!("avx512dq {:?}", is_x86_feature_detected!("avx512dq"));
+    println!("avx512vl {:?}", is_x86_feature_detected!("avx512vl"));
     println!(
         "avx512_ifma {:?}",
-        is_target_feature_detected!("avx512ifma")
+        is_x86_feature_detected!("avx512ifma")
     );
     println!(
         "avx512_vbmi {:?}",
-        is_target_feature_detected!("avx512vbmi")
+        is_x86_feature_detected!("avx512vbmi")
     );
     println!(
         "avx512_vpopcntdq {:?}",
-        is_target_feature_detected!("avx512vpopcntdq")
+        is_x86_feature_detected!("avx512vpopcntdq")
     );
-    println!("fma: {:?}", is_target_feature_detected!("fma"));
-    println!("abm: {:?}", is_target_feature_detected!("abm"));
-    println!("bmi: {:?}", is_target_feature_detected!("bmi1"));
-    println!("bmi2: {:?}", is_target_feature_detected!("bmi2"));
-    println!("tbm: {:?}", is_target_feature_detected!("tbm"));
-    println!("popcnt: {:?}", is_target_feature_detected!("popcnt"));
-    println!("lzcnt: {:?}", is_target_feature_detected!("lzcnt"));
-    println!("fxsr: {:?}", is_target_feature_detected!("fxsr"));
-    println!("xsave: {:?}", is_target_feature_detected!("xsave"));
-    println!("xsaveopt: {:?}", is_target_feature_detected!("xsaveopt"));
-    println!("xsaves: {:?}", is_target_feature_detected!("xsaves"));
-    println!("xsavec: {:?}", is_target_feature_detected!("xsavec"));
+    println!("fma: {:?}", is_x86_feature_detected!("fma"));
+    println!("abm: {:?}", is_x86_feature_detected!("abm"));
+    println!("bmi: {:?}", is_x86_feature_detected!("bmi1"));
+    println!("bmi2: {:?}", is_x86_feature_detected!("bmi2"));
+    println!("tbm: {:?}", is_x86_feature_detected!("tbm"));
+    println!("popcnt: {:?}", is_x86_feature_detected!("popcnt"));
+    println!("lzcnt: {:?}", is_x86_feature_detected!("lzcnt"));
+    println!("fxsr: {:?}", is_x86_feature_detected!("fxsr"));
+    println!("xsave: {:?}", is_x86_feature_detected!("xsave"));
+    println!("xsaveopt: {:?}", is_x86_feature_detected!("xsaveopt"));
+    println!("xsaves: {:?}", is_x86_feature_detected!("xsaves"));
+    println!("xsavec: {:?}", is_x86_feature_detected!("xsavec"));
 }

--- a/crates/stdsimd/tests/cpu-detection.rs
+++ b/crates/stdsimd/tests/cpu-detection.rs
@@ -12,75 +12,75 @@ extern crate stdsimd;
 #[test]
 #[cfg(all(target_arch = "arm", target_os = "linux"))]
 fn arm_linux() {
-    println!("neon: {}", is_target_feature_detected!("neon"));
-    println!("pmull: {}", is_target_feature_detected!("pmull"));
+    println!("neon: {}", is_arm_feature_detected!("neon"));
+    println!("pmull: {}", is_arm_feature_detected!("pmull"));
 }
 
 #[test]
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 fn aarch64_linux() {
-    println!("fp: {}", is_target_feature_detected!("fp"));
-    println!("fp16: {}", is_target_feature_detected!("fp16"));
-    println!("neon: {}", is_target_feature_detected!("neon"));
-    println!("asimd: {}", is_target_feature_detected!("asimd"));
-    println!("sve: {}", is_target_feature_detected!("sve"));
-    println!("crc: {}", is_target_feature_detected!("crc"));
-    println!("crypto: {}", is_target_feature_detected!("crypto"));
-    println!("lse: {}", is_target_feature_detected!("lse"));
-    println!("rdm: {}", is_target_feature_detected!("rdm"));
-    println!("rcpc: {}", is_target_feature_detected!("rcpc"));
-    println!("dotprod: {}", is_target_feature_detected!("dotprod"));
+    println!("fp: {}", is_aarch64_feature_detected!("fp"));
+    println!("fp16: {}", is_aarch64_feature_detected!("fp16"));
+    println!("neon: {}", is_aarch64_feature_detected!("neon"));
+    println!("asimd: {}", is_aarch64_feature_detected!("asimd"));
+    println!("sve: {}", is_aarch64_feature_detected!("sve"));
+    println!("crc: {}", is_aarch64_feature_detected!("crc"));
+    println!("crypto: {}", is_aarch64_feature_detected!("crypto"));
+    println!("lse: {}", is_aarch64_feature_detected!("lse"));
+    println!("rdm: {}", is_aarch64_feature_detected!("rdm"));
+    println!("rcpc: {}", is_aarch64_feature_detected!("rcpc"));
+    println!("dotprod: {}", is_aarch64_feature_detected!("dotprod"));
 }
 
 #[test]
 #[cfg(all(target_arch = "powerpc64", target_os = "linux"))]
 fn powerpc64_linux() {
-    println!("altivec: {}", is_target_feature_detected!("altivec"));
-    println!("vsx: {}", is_target_feature_detected!("vsx"));
-    println!("power8: {}", is_target_feature_detected!("power8"));
+    println!("altivec: {}", is_powerpc64_feature_detected!("altivec"));
+    println!("vsx: {}", is_powerpc64_feature_detected!("vsx"));
+    println!("power8: {}", is_powerpc64_feature_detected!("power8"));
 }
 
 #[test]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn x86_all() {
-    println!("sse: {:?}", is_target_feature_detected!("sse"));
-    println!("sse2: {:?}", is_target_feature_detected!("sse2"));
-    println!("sse3: {:?}", is_target_feature_detected!("sse3"));
-    println!("ssse3: {:?}", is_target_feature_detected!("ssse3"));
-    println!("sse4.1: {:?}", is_target_feature_detected!("sse4.1"));
-    println!("sse4.2: {:?}", is_target_feature_detected!("sse4.2"));
-    println!("sse4a: {:?}", is_target_feature_detected!("sse4a"));
-    println!("avx: {:?}", is_target_feature_detected!("avx"));
-    println!("avx2: {:?}", is_target_feature_detected!("avx2"));
-    println!("avx512f {:?}", is_target_feature_detected!("avx512f"));
-    println!("avx512cd {:?}", is_target_feature_detected!("avx512cd"));
-    println!("avx512er {:?}", is_target_feature_detected!("avx512er"));
-    println!("avx512pf {:?}", is_target_feature_detected!("avx512pf"));
-    println!("avx512bw {:?}", is_target_feature_detected!("avx512bw"));
-    println!("avx512dq {:?}", is_target_feature_detected!("avx512dq"));
-    println!("avx512vl {:?}", is_target_feature_detected!("avx512vl"));
+    println!("sse: {:?}", is_x86_feature_detected!("sse"));
+    println!("sse2: {:?}", is_x86_feature_detected!("sse2"));
+    println!("sse3: {:?}", is_x86_feature_detected!("sse3"));
+    println!("ssse3: {:?}", is_x86_feature_detected!("ssse3"));
+    println!("sse4.1: {:?}", is_x86_feature_detected!("sse4.1"));
+    println!("sse4.2: {:?}", is_x86_feature_detected!("sse4.2"));
+    println!("sse4a: {:?}", is_x86_feature_detected!("sse4a"));
+    println!("avx: {:?}", is_x86_feature_detected!("avx"));
+    println!("avx2: {:?}", is_x86_feature_detected!("avx2"));
+    println!("avx512f {:?}", is_x86_feature_detected!("avx512f"));
+    println!("avx512cd {:?}", is_x86_feature_detected!("avx512cd"));
+    println!("avx512er {:?}", is_x86_feature_detected!("avx512er"));
+    println!("avx512pf {:?}", is_x86_feature_detected!("avx512pf"));
+    println!("avx512bw {:?}", is_x86_feature_detected!("avx512bw"));
+    println!("avx512dq {:?}", is_x86_feature_detected!("avx512dq"));
+    println!("avx512vl {:?}", is_x86_feature_detected!("avx512vl"));
     println!(
         "avx512_ifma {:?}",
-        is_target_feature_detected!("avx512ifma")
+        is_x86_feature_detected!("avx512ifma")
     );
     println!(
         "avx512_vbmi {:?}",
-        is_target_feature_detected!("avx512vbmi")
+        is_x86_feature_detected!("avx512vbmi")
     );
     println!(
         "avx512_vpopcntdq {:?}",
-        is_target_feature_detected!("avx512vpopcntdq")
+        is_x86_feature_detected!("avx512vpopcntdq")
     );
-    println!("fma: {:?}", is_target_feature_detected!("fma"));
-    println!("abm: {:?}", is_target_feature_detected!("abm"));
-    println!("bmi: {:?}", is_target_feature_detected!("bmi1"));
-    println!("bmi2: {:?}", is_target_feature_detected!("bmi2"));
-    println!("tbm: {:?}", is_target_feature_detected!("tbm"));
-    println!("popcnt: {:?}", is_target_feature_detected!("popcnt"));
-    println!("lzcnt: {:?}", is_target_feature_detected!("lzcnt"));
-    println!("fxsr: {:?}", is_target_feature_detected!("fxsr"));
-    println!("xsave: {:?}", is_target_feature_detected!("xsave"));
-    println!("xsaveopt: {:?}", is_target_feature_detected!("xsaveopt"));
-    println!("xsaves: {:?}", is_target_feature_detected!("xsaves"));
-    println!("xsavec: {:?}", is_target_feature_detected!("xsavec"));
+    println!("fma: {:?}", is_x86_feature_detected!("fma"));
+    println!("abm: {:?}", is_x86_feature_detected!("abm"));
+    println!("bmi: {:?}", is_x86_feature_detected!("bmi1"));
+    println!("bmi2: {:?}", is_x86_feature_detected!("bmi2"));
+    println!("tbm: {:?}", is_x86_feature_detected!("tbm"));
+    println!("popcnt: {:?}", is_x86_feature_detected!("popcnt"));
+    println!("lzcnt: {:?}", is_x86_feature_detected!("lzcnt"));
+    println!("fxsr: {:?}", is_x86_feature_detected!("fxsr"));
+    println!("xsave: {:?}", is_x86_feature_detected!("xsave"));
+    println!("xsaveopt: {:?}", is_x86_feature_detected!("xsaveopt"));
+    println!("xsaves: {:?}", is_x86_feature_detected!("xsaves"));
+    println!("xsavec: {:?}", is_x86_feature_detected!("xsavec"));
 }

--- a/examples/hex.rs
+++ b/examples/hex.rs
@@ -54,10 +54,10 @@ fn hex_encode<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a str, usize> {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        if is_target_feature_detected!("avx2") {
+        if is_x86_feature_detected!("avx2") {
             return unsafe { hex_encode_avx2(src, dst) };
         }
-        if is_target_feature_detected!("sse4.1") {
+        if is_x86_feature_detected!("sse4.1") {
             return unsafe { hex_encode_sse41(src, dst) };
         }
     }
@@ -197,13 +197,13 @@ mod tests {
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         unsafe {
-            if is_target_feature_detected!("avx2") {
+            if is_x86_feature_detected!("avx2") {
                 assert_eq!(
                     hex_encode_avx2(input, &mut tmp()).unwrap(),
                     output
                 );
             }
-            if is_target_feature_detected!("sse4.1") {
+            if is_x86_feature_detected!("sse4.1") {
                 assert_eq!(
                     hex_encode_sse41(input, &mut tmp()).unwrap(),
                     output
@@ -264,7 +264,7 @@ mod tests {
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         fn avx_equals_fallback(input: Vec<u8>) -> bool {
-            if !is_target_feature_detected!("avx2") {
+            if !is_x86_feature_detected!("avx2") {
                 return true
             }
             let mut space1 = vec![0; input.len() * 2];
@@ -276,7 +276,7 @@ mod tests {
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         fn sse41_equals_fallback(input: Vec<u8>) -> bool {
-            if !is_target_feature_detected!("avx2") {
+            if !is_x86_feature_detected!("avx2") {
                 return true
             }
             let mut space1 = vec![0; input.len() * 2];
@@ -343,28 +343,28 @@ mod benches {
 
         #[bench]
         fn small_avx2(b: &mut test::Bencher) {
-            if is_target_feature_detected!("avx2") {
+            if is_x86_feature_detected!("avx2") {
                 doit(b, SMALL_LEN, hex_encode_avx2);
             }
         }
 
         #[bench]
         fn small_sse41(b: &mut test::Bencher) {
-            if is_target_feature_detected!("sse4.1") {
+            if is_x86_feature_detected!("sse4.1") {
                 doit(b, SMALL_LEN, hex_encode_sse41);
             }
         }
 
         #[bench]
         fn large_avx2(b: &mut test::Bencher) {
-            if is_target_feature_detected!("avx2") {
+            if is_x86_feature_detected!("avx2") {
                 doit(b, LARGE_LEN, hex_encode_avx2);
             }
         }
 
         #[bench]
         fn large_sse41(b: &mut test::Bencher) {
-            if is_target_feature_detected!("sse4.1") {
+            if is_x86_feature_detected!("sse4.1") {
                 doit(b, LARGE_LEN, hex_encode_sse41);
             }
         }

--- a/stdsimd/arch/detect/aarch64.rs
+++ b/stdsimd/arch/detect/aarch64.rs
@@ -6,7 +6,7 @@ use super::linux;
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
-macro_rules! is_target_feature_detected {
+macro_rules! is_aarch64_feature_detected {
     ("neon") => {
         // FIXME: this should be removed once we rename Aarch64 neon to asimd
         $crate::arch::detect::check_for($crate::arch::detect::Feature::asimd)

--- a/stdsimd/arch/detect/arm.rs
+++ b/stdsimd/arch/detect/arm.rs
@@ -6,7 +6,7 @@ use super::linux;
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
-macro_rules! is_target_feature_detected {
+macro_rules! is_arm_feature_detected {
     ("neon") => {
         $crate::arch::detect::check_for($crate::arch::detect::Feature::neon)
     };

--- a/stdsimd/arch/detect/powerpc64.rs
+++ b/stdsimd/arch/detect/powerpc64.rs
@@ -5,7 +5,7 @@ use super::linux;
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
-macro_rules! is_target_feature_detected {
+macro_rules! is_powerpc64_feature_detected {
     ("altivec") => {
         $crate::arch::detect::check_for($crate::arch::detect::Feature::altivec)
     };

--- a/stdsimd/arch/detect/x86.rs
+++ b/stdsimd/arch/detect/x86.rs
@@ -27,7 +27,7 @@ use super::{bit, cache};
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
-macro_rules! is_target_feature_detected {
+macro_rules! is_x86_feature_detected {
     ("aes") => {
         $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::aes)  };
@@ -457,7 +457,7 @@ pub fn detect_features() -> cache::Initializer {
         // "missing part" of ABM, so we map both to the same
         // internal feature.
         //
-        // The `is_target_feature_detected!("lzcnt")` macro then
+        // The `is_x86_feature_detected!("lzcnt")` macro then
         // internally maps to Feature::abm.
         enable(extended_proc_info_ecx, 5, Feature::abm);
         if vendor_id == *b"AuthenticAMD" {
@@ -476,98 +476,98 @@ mod tests {
 
     #[test]
     fn dump() {
-        println!("aes: {:?}", is_target_feature_detected!("aes"));
-        println!("pclmulqdq: {:?}", is_target_feature_detected!("pclmulqdq"));
-        println!("rdrand: {:?}", is_target_feature_detected!("rdrand"));
-        println!("rdseed: {:?}", is_target_feature_detected!("rdseed"));
-        println!("tsc: {:?}", is_target_feature_detected!("tsc"));
-        println!("sse: {:?}", is_target_feature_detected!("sse"));
-        println!("sse2: {:?}", is_target_feature_detected!("sse2"));
-        println!("sse3: {:?}", is_target_feature_detected!("sse3"));
-        println!("ssse3: {:?}", is_target_feature_detected!("ssse3"));
-        println!("sse4.1: {:?}", is_target_feature_detected!("sse4.1"));
-        println!("sse4.2: {:?}", is_target_feature_detected!("sse4.2"));
-        println!("sse4a: {:?}", is_target_feature_detected!("sse4a"));
-        println!("avx: {:?}", is_target_feature_detected!("avx"));
-        println!("avx2: {:?}", is_target_feature_detected!("avx2"));
-        println!("avx512f {:?}", is_target_feature_detected!("avx512f"));
-        println!("avx512cd {:?}", is_target_feature_detected!("avx512cd"));
-        println!("avx512er {:?}", is_target_feature_detected!("avx512er"));
-        println!("avx512pf {:?}", is_target_feature_detected!("avx512pf"));
-        println!("avx512bw {:?}", is_target_feature_detected!("avx512bw"));
-        println!("avx512dq {:?}", is_target_feature_detected!("avx512dq"));
-        println!("avx512vl {:?}", is_target_feature_detected!("avx512vl"));
-        println!("avx512_ifma {:?}", is_target_feature_detected!("avx512ifma"));
-        println!("avx512_vbmi {:?}", is_target_feature_detected!("avx512vbmi"));
+        println!("aes: {:?}", is_x86_feature_detected!("aes"));
+        println!("pclmulqdq: {:?}", is_x86_feature_detected!("pclmulqdq"));
+        println!("rdrand: {:?}", is_x86_feature_detected!("rdrand"));
+        println!("rdseed: {:?}", is_x86_feature_detected!("rdseed"));
+        println!("tsc: {:?}", is_x86_feature_detected!("tsc"));
+        println!("sse: {:?}", is_x86_feature_detected!("sse"));
+        println!("sse2: {:?}", is_x86_feature_detected!("sse2"));
+        println!("sse3: {:?}", is_x86_feature_detected!("sse3"));
+        println!("ssse3: {:?}", is_x86_feature_detected!("ssse3"));
+        println!("sse4.1: {:?}", is_x86_feature_detected!("sse4.1"));
+        println!("sse4.2: {:?}", is_x86_feature_detected!("sse4.2"));
+        println!("sse4a: {:?}", is_x86_feature_detected!("sse4a"));
+        println!("avx: {:?}", is_x86_feature_detected!("avx"));
+        println!("avx2: {:?}", is_x86_feature_detected!("avx2"));
+        println!("avx512f {:?}", is_x86_feature_detected!("avx512f"));
+        println!("avx512cd {:?}", is_x86_feature_detected!("avx512cd"));
+        println!("avx512er {:?}", is_x86_feature_detected!("avx512er"));
+        println!("avx512pf {:?}", is_x86_feature_detected!("avx512pf"));
+        println!("avx512bw {:?}", is_x86_feature_detected!("avx512bw"));
+        println!("avx512dq {:?}", is_x86_feature_detected!("avx512dq"));
+        println!("avx512vl {:?}", is_x86_feature_detected!("avx512vl"));
+        println!("avx512_ifma {:?}", is_x86_feature_detected!("avx512ifma"));
+        println!("avx512_vbmi {:?}", is_x86_feature_detected!("avx512vbmi"));
         println!(
             "avx512_vpopcntdq {:?}",
-            is_target_feature_detected!("avx512vpopcntdq")
+            is_x86_feature_detected!("avx512vpopcntdq")
         );
-        println!("fma: {:?}", is_target_feature_detected!("fma"));
-        println!("abm: {:?}", is_target_feature_detected!("abm"));
-        println!("bmi: {:?}", is_target_feature_detected!("bmi1"));
-        println!("bmi2: {:?}", is_target_feature_detected!("bmi2"));
-        println!("tbm: {:?}", is_target_feature_detected!("tbm"));
-        println!("popcnt: {:?}", is_target_feature_detected!("popcnt"));
-        println!("lzcnt: {:?}", is_target_feature_detected!("lzcnt"));
-        println!("fxsr: {:?}", is_target_feature_detected!("fxsr"));
-        println!("xsave: {:?}", is_target_feature_detected!("xsave"));
-        println!("xsaveopt: {:?}", is_target_feature_detected!("xsaveopt"));
-        println!("xsaves: {:?}", is_target_feature_detected!("xsaves"));
-        println!("xsavec: {:?}", is_target_feature_detected!("xsavec"));
+        println!("fma: {:?}", is_x86_feature_detected!("fma"));
+        println!("abm: {:?}", is_x86_feature_detected!("abm"));
+        println!("bmi: {:?}", is_x86_feature_detected!("bmi1"));
+        println!("bmi2: {:?}", is_x86_feature_detected!("bmi2"));
+        println!("tbm: {:?}", is_x86_feature_detected!("tbm"));
+        println!("popcnt: {:?}", is_x86_feature_detected!("popcnt"));
+        println!("lzcnt: {:?}", is_x86_feature_detected!("lzcnt"));
+        println!("fxsr: {:?}", is_x86_feature_detected!("fxsr"));
+        println!("xsave: {:?}", is_x86_feature_detected!("xsave"));
+        println!("xsaveopt: {:?}", is_x86_feature_detected!("xsaveopt"));
+        println!("xsaves: {:?}", is_x86_feature_detected!("xsaves"));
+        println!("xsavec: {:?}", is_x86_feature_detected!("xsavec"));
     }
 
     #[test]
     fn compare_with_cupid() {
         let information = cupid::master().unwrap();
-        assert_eq!(is_target_feature_detected!("aes"), information.aesni());
-        assert_eq!(is_target_feature_detected!("pclmulqdq"), information.pclmulqdq());
-        assert_eq!(is_target_feature_detected!("rdrand"), information.rdrand());
-        assert_eq!(is_target_feature_detected!("rdseed"), information.rdseed());
-        assert_eq!(is_target_feature_detected!("tsc"), information.tsc());
-        assert_eq!(is_target_feature_detected!("sse"), information.sse());
-        assert_eq!(is_target_feature_detected!("sse2"), information.sse2());
-        assert_eq!(is_target_feature_detected!("sse3"), information.sse3());
-        assert_eq!(is_target_feature_detected!("ssse3"), information.ssse3());
-        assert_eq!(is_target_feature_detected!("sse4.1"), information.sse4_1());
-        assert_eq!(is_target_feature_detected!("sse4.2"), information.sse4_2());
-        assert_eq!(is_target_feature_detected!("sse4a"), information.sse4a());
-        assert_eq!(is_target_feature_detected!("avx"), information.avx());
-        assert_eq!(is_target_feature_detected!("avx2"), information.avx2());
-        assert_eq!(is_target_feature_detected!("avx512f"), information.avx512f());
-        assert_eq!(is_target_feature_detected!("avx512cd"), information.avx512cd());
-        assert_eq!(is_target_feature_detected!("avx512er"), information.avx512er());
-        assert_eq!(is_target_feature_detected!("avx512pf"), information.avx512pf());
-        assert_eq!(is_target_feature_detected!("avx512bw"), information.avx512bw());
-        assert_eq!(is_target_feature_detected!("avx512dq"), information.avx512dq());
-        assert_eq!(is_target_feature_detected!("avx512vl"), information.avx512vl());
+        assert_eq!(is_x86_feature_detected!("aes"), information.aesni());
+        assert_eq!(is_x86_feature_detected!("pclmulqdq"), information.pclmulqdq());
+        assert_eq!(is_x86_feature_detected!("rdrand"), information.rdrand());
+        assert_eq!(is_x86_feature_detected!("rdseed"), information.rdseed());
+        assert_eq!(is_x86_feature_detected!("tsc"), information.tsc());
+        assert_eq!(is_x86_feature_detected!("sse"), information.sse());
+        assert_eq!(is_x86_feature_detected!("sse2"), information.sse2());
+        assert_eq!(is_x86_feature_detected!("sse3"), information.sse3());
+        assert_eq!(is_x86_feature_detected!("ssse3"), information.ssse3());
+        assert_eq!(is_x86_feature_detected!("sse4.1"), information.sse4_1());
+        assert_eq!(is_x86_feature_detected!("sse4.2"), information.sse4_2());
+        assert_eq!(is_x86_feature_detected!("sse4a"), information.sse4a());
+        assert_eq!(is_x86_feature_detected!("avx"), information.avx());
+        assert_eq!(is_x86_feature_detected!("avx2"), information.avx2());
+        assert_eq!(is_x86_feature_detected!("avx512f"), information.avx512f());
+        assert_eq!(is_x86_feature_detected!("avx512cd"), information.avx512cd());
+        assert_eq!(is_x86_feature_detected!("avx512er"), information.avx512er());
+        assert_eq!(is_x86_feature_detected!("avx512pf"), information.avx512pf());
+        assert_eq!(is_x86_feature_detected!("avx512bw"), information.avx512bw());
+        assert_eq!(is_x86_feature_detected!("avx512dq"), information.avx512dq());
+        assert_eq!(is_x86_feature_detected!("avx512vl"), information.avx512vl());
         assert_eq!(
-            is_target_feature_detected!("avx512ifma"),
+            is_x86_feature_detected!("avx512ifma"),
             information.avx512_ifma()
         );
         assert_eq!(
-            is_target_feature_detected!("avx512vbmi"),
+            is_x86_feature_detected!("avx512vbmi"),
             information.avx512_vbmi()
         );
         assert_eq!(
-            is_target_feature_detected!("avx512vpopcntdq"),
+            is_x86_feature_detected!("avx512vpopcntdq"),
             information.avx512_vpopcntdq()
         );
-        assert_eq!(is_target_feature_detected!("fma"), information.fma());
-        assert_eq!(is_target_feature_detected!("bmi1"), information.bmi1());
-        assert_eq!(is_target_feature_detected!("bmi2"), information.bmi2());
-        assert_eq!(is_target_feature_detected!("popcnt"), information.popcnt());
-        assert_eq!(is_target_feature_detected!("abm"), information.lzcnt());
-        assert_eq!(is_target_feature_detected!("tbm"), information.tbm());
-        assert_eq!(is_target_feature_detected!("lzcnt"), information.lzcnt());
-        assert_eq!(is_target_feature_detected!("xsave"), information.xsave());
-        assert_eq!(is_target_feature_detected!("xsaveopt"), information.xsaveopt());
+        assert_eq!(is_x86_feature_detected!("fma"), information.fma());
+        assert_eq!(is_x86_feature_detected!("bmi1"), information.bmi1());
+        assert_eq!(is_x86_feature_detected!("bmi2"), information.bmi2());
+        assert_eq!(is_x86_feature_detected!("popcnt"), information.popcnt());
+        assert_eq!(is_x86_feature_detected!("abm"), information.lzcnt());
+        assert_eq!(is_x86_feature_detected!("tbm"), information.tbm());
+        assert_eq!(is_x86_feature_detected!("lzcnt"), information.lzcnt());
+        assert_eq!(is_x86_feature_detected!("xsave"), information.xsave());
+        assert_eq!(is_x86_feature_detected!("xsaveopt"), information.xsaveopt());
         assert_eq!(
-            is_target_feature_detected!("xsavec"),
+            is_x86_feature_detected!("xsavec"),
             information.xsavec_and_xrstor()
         );
         assert_eq!(
-            is_target_feature_detected!("xsaves"),
+            is_x86_feature_detected!("xsaves"),
             information.xsaves_xrstors_and_ia32_xss()
         );
     }

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -116,7 +116,7 @@
 /// fn foo() {
 ///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ///     {
-///         if is_target_feature_detected!("avx2") {
+///         if is_x86_feature_detected!("avx2") {
 ///             return unsafe { foo_avx2() };
 ///         }
 ///     }
@@ -139,7 +139,7 @@
 /// There's a couple of components in play here, so let's go through them in
 /// detail!
 ///
-/// * First up we notice the `is_target_feature_detected!` macro. Provided by
+/// * First up we notice the `is_x86_feature_detected!` macro. Provided by
 ///   the standard library, this macro will perform necessary runtime detection
 ///   to determine whether the CPU the program is running on supports the
 ///   specified feature. In this case the macro will expand to a boolean
@@ -149,7 +149,7 @@
 ///   Note that this macro, like the `arch` module, is platform-specific. The
 ///   name of the macro is the same across platforms, but the arguments to the
 ///   macro are only the features for the current platform. For example calling
-///   `is_target_feature_detected!("avx2")` on ARM will be a compile time
+///   `is_x86_feature_detected!("avx2")` on ARM will be a compile time
 ///   error. To ensure we don't hit this error a statement level `#[cfg]` is
 ///   used to only compile usage of the macro on `x86`/`x86_64`.
 ///
@@ -218,7 +218,7 @@
 ///     {
 ///         // Note that this `unsafe` block is safe because we're testing
 ///         // that the `avx2` feature is indeed available on our CPU.
-///         if is_target_feature_detected!("avx2") {
+///         if is_x86_feature_detected!("avx2") {
 ///             return unsafe { add_quickly_avx2(a, b, c) }
 ///         }
 ///     }
@@ -270,7 +270,7 @@
 ///
 ///     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ///     {
-///         if is_target_feature_detected!("sse4.1") {
+///         if is_x86_feature_detected!("sse4.1") {
 ///             return unsafe { hex_encode_sse41(src, dst) };
 ///         }
 ///     }


### PR DESCRIPTION
This commit renames the `is_target_feature_detected!` macro to have different
names depending on the platform. For example:

* `is_x86_feature_detected!`
* `is_arm_feature_detected!`
* `is_aarch64_feature_detected!`
* `is_powerpc64_feature_detected!`

Each macro already has a platform-specific albeit similar interface. Currently,
though, each macro takes a different set of strings so the hope is that like
with the name of the architecture in the module we can signal the dangers of
using the macro in a platform-agnostic context.

One liberty taken with the macro currently though is to on both the x86 and
x86_64 architectures name the macro `is_x86_feature_detected` rather than also
having an `is_x86_64_feature_detected`. This mirrors, however, how all the
intrinsics are named the same on x86/x86_64.