### PR TITLE
Add `cfg!` clauses to detection macro

### DIFF
--- a/crates/stdsimd/src/lib.rs
+++ b/crates/stdsimd/src/lib.rs
@@ -8,6 +8,7 @@
 //! [stdsimd]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/
 
 #![feature(const_fn, integer_atomics, staged_api, stdsimd)]
+#![feature(cfg_target_feature)]
 #![cfg_attr(feature = "cargo-clippy", allow(shadow_reuse))]
 #![cfg_attr(target_os = "linux", feature(linkage))]
 #![no_std]

--- a/stdsimd/arch/detect/aarch64.rs
+++ b/stdsimd/arch/detect/aarch64.rs
@@ -9,40 +9,52 @@ use super::linux;
 macro_rules! is_aarch64_feature_detected {
     ("neon") => {
         // FIXME: this should be removed once we rename Aarch64 neon to asimd
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::asimd)
+        cfg!(target_feature = "neon") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::asimd)
     };
     ("asimd") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::asimd)
+        cfg!(target_feature = "neon") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::asimd)
     };
     ("pmull") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::pmull)
+        cfg!(target_feature = "pmull") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::pmull)
     };
     ("fp") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::fp)
+        cfg!(target_feature = "fp") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::fp)
     };
     ("fp16") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::fp16)
+        cfg!(target_feature = "fp16") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::fp16)
     };
     ("sve") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::sve)
+        cfg!(target_feature = "sve") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::sve)
     };
     ("crc") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::crc)
+        cfg!(target_feature = "crc") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::crc)
     };
     ("crypto") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::crypto)
+        cfg!(target_feature = "crypto") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::crypto)
     };
     ("lse") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::lse)
+        cfg!(target_feature = "lse") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::lse)
     };
     ("rdm") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::rdm)
+        cfg!(target_feature = "rdm") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::rdm)
     };
     ("rcpc") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::rcpc)
+        cfg!(target_feature = "rcpc") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::rcpc)
     };
     ("dotprod") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::dotprod)
+        cfg!(target_feature = "dotprot") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::dotprod)
     };
     ("ras") => {
         compile_error!("\"ras\" feature cannot be detected at run-time")

--- a/stdsimd/arch/detect/arm.rs
+++ b/stdsimd/arch/detect/arm.rs
@@ -8,10 +8,12 @@ use super::linux;
 #[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_arm_feature_detected {
     ("neon") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::neon)
+        cfg!(target_feature = "neon") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::neon)
     };
     ("pmull") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::pmull)
+        cfg!(target_feature = "pmull") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::pmull)
     };
     ($t:tt) => { compile_error!(concat!("unknown arm target feature: ", $t)) };
 }

--- a/stdsimd/arch/detect/powerpc64.rs
+++ b/stdsimd/arch/detect/powerpc64.rs
@@ -7,13 +7,16 @@ use super::linux;
 #[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_powerpc64_feature_detected {
     ("altivec") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::altivec)
+        cfg!(target_feature = "altivec") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::altivec)
     };
     ("vsx") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::vsx)
+        cfg!(target_feature = "vsx") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::vsx)
     };
     ("power8") => {
-        $crate::arch::detect::check_for($crate::arch::detect::Feature::power8)
+        cfg!(target_feature = "power8") ||
+            $crate::arch::detect::check_for($crate::arch::detect::Feature::power8)
     };
     ($t:tt) => { compile_error!(concat!("unknown arm target feature: ", $t)) };
 }

--- a/stdsimd/arch/detect/x86.rs
+++ b/stdsimd/arch/detect/x86.rs
@@ -29,144 +29,144 @@ use super::{bit, cache};
 #[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_x86_feature_detected {
     ("aes") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "aes") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::aes)  };
     ("pclmulqdq") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "pclmulqdq") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::pclmulqdq)  };
     ("rdrand") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "rdrand") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::rdrand)  };
     ("rdseed") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "rdseed") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::rdseed)  };
     ("tsc") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "tsc") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::tsc)  };
     ("mmx") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "mmx") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::mmx)  };
     ("sse") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "sse") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::sse)  };
     ("sse2") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "sse2") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::sse2)
     };
     ("sse3") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "sse3") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::sse3)
     };
     ("ssse3") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "ssse3") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::ssse3)
     };
     ("sse4.1") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "sse4.1") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::sse4_1)
     };
     ("sse4.2") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "sse4.2") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::sse4_2)
     };
     ("sse4a") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "sse4a") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::sse4a)
     };
     ("avx") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx)
     };
     ("avx2") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx2") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx2)
     };
     ("avx512f") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512f") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512f)
     };
     ("avx512cd") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512cd") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512cd)
     };
     ("avx512er") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512er") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512er)
     };
     ("avx512pf") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512pf") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512pf)
     };
     ("avx512bw") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512bw") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512bw)
     };
     ("avx512dq") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512dq") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512dq)
     };
     ("avx512vl") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_Feature = "avx512vl") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512vl)
     };
     ("avx512ifma") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512ifma") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512_ifma)
     };
     ("avx512vbmi") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512vbmi") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512_vbmi)
     };
     ("avx512vpopcntdq") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "avx512vpopcntdq") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::avx512_vpopcntdq)
     };
     ("fma") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "fma") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::fma)
     };
     ("bmi1") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "bmi1") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::bmi)
     };
     ("bmi2") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "bmi2") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::bmi2)
     };
     ("abm") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "abm") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::abm)
     };
     ("lzcnt") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "lzcnt") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::abm)
     };
     ("tbm") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "tbm") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::tbm)
     };
     ("popcnt") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "popcnt") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::popcnt)
     };
     ("fxsr") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "fxsr") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::fxsr)
     };
     ("xsave") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "xsave") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::xsave)
     };
     ("xsaveopt") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "xsaveopt") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::xsaveopt)
     };
     ("xsaves") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "xsaves") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::xsaves)
     };
     ("xsavec") => {
-        $crate::arch::detect::check_for(
+        cfg!(target_feature = "xsavec") || $crate::arch::detect::check_for(
             $crate::arch::detect::Feature::xsavec)
     };
     ($t:tt) => {


### PR DESCRIPTION
This way if the feature is statically detected then it'll be expanded to `true`

Closes #349