### PR TITLE
Add initial wasm memory grow/current intrinsics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,19 @@ matrix:
       script: ci/dox.sh
     - script: cargo test --manifest-path crates/stdsimd-verify/Cargo.toml
       install: true
+    - env: TARGET=wasm32-unknown-unknown
+      before_script:
+        - git clone --recursive https://github.com/WebAssembly/wabt
+        - (cd wabt && make -j4)
+        - export PATH=$PATH:$PWD/wabt/bin
+      script:
+        - cargo build --target wasm32-unknown-unknown -p stdsimd
+        - cargo build --target wasm32-unknown-unknown -p stdsimd --release
+        - cargo rustc --target wasm32-unknown-unknown -p stdsimd --release --example wasm -- -C lto
+        - wasm2wat target/wasm32-unknown-unknown/release/examples/wasm.wasm -o wasm.wat
+        - cat wasm.wat
+        - grep current_memory wasm.wat
+        - grep grow_memory wasm.wat
     - env: RUSTFMT=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
       before_script:
       - rustup component add rustfmt-preview

--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -69,6 +69,14 @@ pub mod arch {
         pub use coresimd::arm::*;
         pub use coresimd::aarch64::*;
     }
+
+    /// Platform-specific intrinsics for the `wasm32` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
+    #[cfg(target_arch = "wasm32")]
+    pub mod wasm32 {
+        pub use coresimd::wasm32::*;
+    }
 }
 
 mod simd_llvm;
@@ -82,5 +90,7 @@ mod x86_64;
 mod arm;
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
+#[cfg(target_arch = "wasm32")]
+mod wasm32;
 
 mod nvptx;

--- a/coresimd/wasm32.rs
+++ b/coresimd/wasm32.rs
@@ -1,0 +1,30 @@
+extern "C" {
+    #[link_name = "llvm.wasm.grow.memory.i32"]
+    fn llvm_grow_memory(pages: i32) -> i32;
+    #[link_name = "llvm.wasm.current.memory.i32"]
+    fn llvm_current_memory() -> i32;
+}
+
+/// Corresponding intrinsic to wasm's [`current_memory` instruction][instr]
+///
+/// This function, when called, will return the current memory size in units of
+/// pages.
+///
+/// [instr]: https://github.com/WebAssembly/design/blob/master/Semantics.md#resizing
+#[inline]
+pub unsafe fn current_memory() -> i32 {
+    llvm_current_memory()
+}
+
+/// Corresponding intrinsic to wasm's [`grow_memory` instruction][instr]
+///
+/// This function, when called, will attempt to grow the default linear memory
+/// by the specified number of pages. If memory is successfully grown then the
+/// previous size of memory, in pages, is returned. If memory cannot be grown
+/// then -1 is returned.
+///
+/// [instr]: https://github.com/WebAssembly/design/blob/master/Semantics.md#resizing
+#[inline]
+pub unsafe fn grow_memory(delta: i32) -> i32 {
+    llvm_grow_memory(delta)
+}

--- a/crates/stdsimd/Cargo.toml
+++ b/crates/stdsimd/Cargo.toml
@@ -43,3 +43,8 @@ path = "../../examples/hex.rs"
 [[example]]
 name = "nbody"
 path = "../../examples/nbody.rs"
+
+[[example]]
+name = "wasm"
+crate-type = ["cdylib"]
+path = "../../examples/wasm.rs"

--- a/examples/wasm.rs
+++ b/examples/wasm.rs
@@ -1,0 +1,47 @@
+//! A simple slab allocator for pages in wasm
+
+#![feature(stdsimd)]
+#![cfg(target_arch = "wasm32")]
+
+extern crate stdsimd;
+
+use std::ptr;
+
+use stdsimd::arch::wasm32::*;
+
+static mut HEAD: *mut *mut u8 = 0 as _;
+
+#[no_mangle]
+pub unsafe extern "C" fn page_alloc() -> *mut u8 {
+    if !HEAD.is_null() {
+        let next = *HEAD;
+        let ret = HEAD;
+        HEAD = next as *mut _;
+        return ret as *mut u8;
+    }
+
+    let ret = grow_memory(1);
+
+    // if we failed to allocate a page then return null
+    if ret == -1 {
+        return ptr::null_mut();
+    }
+
+    ((ret as u32) * page_size()) as *mut u8
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn page_free(page: *mut u8) {
+    let page = page as *mut *mut u8;
+    *page = HEAD as *mut u8;
+    HEAD = page;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn memory_used() -> usize {
+    (page_size() * (current_memory() as u32)) as usize
+}
+
+fn page_size() -> u32 {
+    64 * 1024
+}

--- a/stdsimd/arch/detect/cache.rs
+++ b/stdsimd/arch/detect/cache.rs
@@ -1,6 +1,8 @@
 //! Caches run-time feature detection so that it only needs to be computed
 //! once.
 
+#![allow(dead_code)] // not used on all platforms
+
 use core::sync::atomic::Ordering;
 
 #[cfg(target_pointer_width = "64")]

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -353,6 +353,9 @@ pub mod arch {
     #[cfg(target_arch = "aarch64")]
     pub use coresimd::arch::aarch64;
 
+    #[cfg(target_arch = "wasm32")]
+    pub use coresimd::arch::wasm32;
+
     #[doc(hidden)] // unstable implementation detail
     pub mod detect;
 }


### PR DESCRIPTION
This exposes access to the `grow_memory` and `current_memory` instructions
provided by wasm in what will hopefully be a stable interface (the stable part
being x86 first in theory).