### PR TITLE
document all arches when part of std

### DIFF
--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -39,7 +39,8 @@ pub mod arch {
     /// Platform-specific intrinsics for the `x86` platform.
     ///
     /// See the [module documentation](../index.html) for more details.
-    #[cfg(target_arch = "x86")]
+    #[cfg(any(target_arch = "x86", dox))]
+    #[doc(cfg(target_arch = "x86"))]
     pub mod x86 {
         pub use coresimd::x86::*;
     }
@@ -47,7 +48,8 @@ pub mod arch {
     /// Platform-specific intrinsics for the `x86_64` platform.
     ///
     /// See the [module documentation](../index.html) for more details.
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", dox))]
+    #[doc(cfg(target_arch = "x86_64"))]
     pub mod x86_64 {
         pub use coresimd::x86::*;
         pub use coresimd::x86_64::*;
@@ -56,7 +58,8 @@ pub mod arch {
     /// Platform-specific intrinsics for the `arm` platform.
     ///
     /// See the [module documentation](../index.html) for more details.
-    #[cfg(target_arch = "arm")]
+    #[cfg(any(target_arch = "arm", dox))]
+    #[doc(cfg(target_arch = "arm"))]
     pub mod arm {
         pub use coresimd::arm::*;
     }
@@ -64,7 +67,8 @@ pub mod arch {
     /// Platform-specific intrinsics for the `aarch64` platform.
     ///
     /// See the [module documentation](../index.html) for more details.
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", dox))]
+    #[doc(cfg(target_arch = "aarch64"))]
     pub mod aarch64 {
         pub use coresimd::arm::*;
         pub use coresimd::aarch64::*;
@@ -81,14 +85,14 @@ pub mod arch {
 
 mod simd_llvm;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", dox))]
 mod x86;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", dox))]
 mod x86_64;
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64", dox))]
 mod arm;
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", dox))]
 mod aarch64;
 #[cfg(target_arch = "wasm32")]
 mod wasm32;

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -13,7 +13,8 @@
            simd_ffi, target_feature, cfg_target_feature, i128_type, asm,
            integer_atomics, stmt_expr_attributes, core_intrinsics,
            crate_in_paths, no_core, attr_literals, rustc_attrs, stdsimd,
-           staged_api, fn_must_use, core_float, core_slice_ext, align_offset)]
+           staged_api, fn_must_use, core_float, core_slice_ext, align_offset,
+           doc_cfg)]
 #![cfg_attr(test,
             feature(proc_macro, test, attr_literals, abi_vectorcall,
                     untagged_unions))]

--- a/crates/stdsimd/src/lib.rs
+++ b/crates/stdsimd/src/lib.rs
@@ -8,7 +8,7 @@
 //! [stdsimd]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/
 
 #![feature(const_fn, integer_atomics, staged_api, stdsimd)]
-#![feature(cfg_target_feature)]
+#![feature(cfg_target_feature, doc_cfg)]
 #![cfg_attr(feature = "cargo-clippy", allow(shadow_reuse))]
 #![cfg_attr(target_os = "linux", feature(linkage))]
 #![no_std]

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -361,8 +361,9 @@ pub mod arch {
 
     /// Platform-specific intrinsics for the `x86` platform.
     ///
-    /// The documentation with the full listing of `x86` intrinsics is available in [libcore], but
-    /// the module is re-exported here in std as well.
+    /// The documentation with the full listing of `x86` intrinsics is
+    /// available in [libcore], but the module is re-exported here in std
+    /// as well.
     ///
     /// [libcore]: ../../../core/arch/x86/index.html
     #[cfg(dox)]
@@ -371,8 +372,9 @@ pub mod arch {
 
     /// Platform-specific intrinsics for the `x86_64` platform.
     ///
-    /// The documentation with the full listing of `x86_64` intrinsics is available in [libcore],
-    /// but the module is re-exported here in std as well.
+    /// The documentation with the full listing of `x86_64` intrinsics is
+    /// available in [libcore], but the module is re-exported here in std
+    /// as well.
     ///
     /// [libcore]: ../../../core/arch/x86_64/index.html
     #[cfg(dox)]
@@ -381,8 +383,9 @@ pub mod arch {
 
     /// Platform-specific intrinsics for the `arm` platform.
     ///
-    /// The documentation with the full listing of `arm` intrinsics is available in [libcore], but
-    /// the module is re-exported here in std as well.
+    /// The documentation with the full listing of `arm` intrinsics is
+    /// available in [libcore], but the module is re-exported here in std
+    /// as well.
     ///
     /// [libcore]: ../../../core/arch/arm/index.html
     #[cfg(dox)]
@@ -391,8 +394,9 @@ pub mod arch {
 
     /// Platform-specific intrinsics for the `aarch64` platform.
     ///
-    /// The documentation with the full listing of `aarch64` intrinsics is available in [libcore],
-    /// but the module is re-exported here in std as well.
+    /// The documentation with the full listing of `aarch64` intrinsics is
+    /// available in [libcore], but the module is re-exported here in std
+    /// as well.
     ///
     /// [libcore]: ../../../core/arch/aarch64/index.html
     #[cfg(dox)]

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -341,16 +341,16 @@
 /// ```
 #[unstable(feature = "stdsimd", issue = "0")]
 pub mod arch {
-    #[cfg(target_arch = "x86")]
+    #[cfg(all(not(dox), target_arch = "x86"))]
     pub use coresimd::arch::x86;
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(not(dox), target_arch = "x86_64"))]
     pub use coresimd::arch::x86_64;
 
-    #[cfg(target_arch = "arm")]
+    #[cfg(all(not(dox), target_arch = "arm"))]
     pub use coresimd::arch::arm;
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(not(dox), target_arch = "aarch64"))]
     pub use coresimd::arch::aarch64;
 
     #[cfg(target_arch = "wasm32")]
@@ -358,6 +358,46 @@ pub mod arch {
 
     #[doc(hidden)] // unstable implementation detail
     pub mod detect;
+
+    /// Platform-specific intrinsics for the `x86` platform.
+    ///
+    /// The documentation with the full listing of `x86` intrinsics is available in [libcore], but
+    /// the module is re-exported here in std as well.
+    ///
+    /// [libcore]: ../../../core/arch/x86/index.html
+    #[cfg(dox)]
+    #[doc(cfg(target_arch = "x86"))]
+    pub mod x86 {}
+
+    /// Platform-specific intrinsics for the `x86_64` platform.
+    ///
+    /// The documentation with the full listing of `x86_64` intrinsics is available in [libcore],
+    /// but the module is re-exported here in std as well.
+    ///
+    /// [libcore]: ../../../core/arch/x86_64/index.html
+    #[cfg(dox)]
+    #[doc(cfg(target_arch = "x86_64"))]
+    pub mod x86_64 {}
+
+    /// Platform-specific intrinsics for the `arm` platform.
+    ///
+    /// The documentation with the full listing of `arm` intrinsics is available in [libcore], but
+    /// the module is re-exported here in std as well.
+    ///
+    /// [libcore]: ../../../core/arch/arm/index.html
+    #[cfg(dox)]
+    #[doc(cfg(target_arch = "arm"))]
+    pub mod arm {}
+
+    /// Platform-specific intrinsics for the `aarch64` platform.
+    ///
+    /// The documentation with the full listing of `aarch64` intrinsics is available in [libcore],
+    /// but the module is re-exported here in std as well.
+    ///
+    /// [libcore]: ../../../core/arch/aarch64/index.html
+    #[cfg(dox)]
+    #[doc(cfg(target_arch = "aarch64"))]
+    pub mod aarch64 {}
 }
 
 #[unstable(feature = "stdsimd", issue = "0")]


### PR DESCRIPTION
This PR adds the `doc_cfg` feature to coresimd and stdsimd to tell rustdoc about which arch is required for each module. It also uses the `#[cfg(dox)]` configuration flag that the rest of libstd uses to ensure that all four major arch modules are included when rustdoc builds the library. This worked great for coresimd, which now proudly shows all the arch intrinsics. However, when trying to re-export these modules in stdsimd, the cfg(dox) trick doesn't work any more, so instead we mask out these modules and link to libcore. Rather than show the full docs for whatever the native arch of the build environment was, i masked out all of them and stubbed them out.

For a preview, i have [a rendering on my server](https://tonberry.quietmisdreavus.net/simd-std/core/arch/index.html). Here's what the modules listing looks like in `std::arch` when this branch is used as part of the std docs:

![every arch? in this part of the docs? localized entirely on my server? may i see it?](https://user-images.githubusercontent.com/5217170/37231560-334085e8-23b1-11e8-9f2a-aa7c3c600ab1.PNG)
