### PR TITLE
Add CI for android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ matrix:
   allow_failures:
     - env: CLIPPY=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
     - env: RUSTFMT=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
-    - env: TARGET=x86_64-linux-android
 
 before_install:
   # FIXME (travis-ci/travis-ci#8920) shouldn't be necessary...

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,16 @@ matrix:
     - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-gnu NO_ADD=1
     - env: TARGET=x86_64-unknown-linux-gnu-emulated NO_ADD=1 STDSIMD_TEST_EVERYTHING=1
+    - env: TARGET=x86_64-linux-android
     - env: TARGET=arm-unknown-linux-gnueabihf
+    - env: TARGET=arm-linux-androideabi
     - env: TARGET=armv7-unknown-linux-gnueabihf
     - env: TARGET=aarch64-unknown-linux-gnu
     - env: TARGET=mips-unknown-linux-gnu NORUN=1
     - env: TARGET=mipsel-unknown-linux-gnu NORUN=1
     - env: TARGET=mips64-unknown-linux-gnuabi64 NORUN=1
     - env: TARGET=mips64el-unknown-linux-gnuabi64 NORUN=1
+    - env: TARGET=aarch64-linux-android
     - env: TARGET=powerpc-unknown-linux-gnu
     - env: TARGET=powerpc64-unknown-linux-gnu
     - env: TARGET=powerpc64le-unknown-linux-gnu
@@ -56,6 +59,7 @@ matrix:
   allow_failures:
     - env: CLIPPY=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
     - env: RUSTFMT=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
+    - env: TARGET=x86_64-linux-android
 
 before_install:
   # FIXME (travis-ci/travis-ci#8920) shouldn't be necessary...

--- a/ci/android-install-ndk.sh
+++ b/ci/android-install-ndk.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+curl -O https://dl.google.com/android/repository/android-ndk-r15b-linux-x86_64.zip
+unzip -q android-ndk-r15b-linux-x86_64.zip
+
+case "$1" in
+  aarch64)
+    arch=arm64
+    ;;
+
+  i686)
+    arch=x86
+    ;;
+
+  *)
+    arch=$1
+    ;;
+esac;
+
+android-ndk-r15b/build/tools/make_standalone_toolchain.py \
+        --unified-headers \
+        --install-dir /android/ndk-$1 \
+        --arch $arch \
+        --api 24
+
+rm -rf ./android-ndk-r15b-linux-x86_64.zip ./android-ndk-r15b

--- a/ci/android-install-sdk.sh
+++ b/ci/android-install-sdk.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+# Prep the SDK and emulator
+#
+# Note that the update process requires that we accept a bunch of licenses, and
+# we can't just pipe `yes` into it for some reason, so we take the same strategy
+# located in https://github.com/appunite/docker by just wrapping it in a script
+# which apparently magically accepts the licenses.
+
+mkdir sdk
+curl https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip -O
+unzip -d sdk sdk-tools-linux-3859397.zip
+
+case "$1" in
+  arm | armv7)
+    abi=armeabi-v7a
+    ;;
+
+  aarch64)
+    abi=arm64-v8a
+    ;;
+
+  i686)
+    abi=x86
+    ;;
+
+  x86_64)
+    abi=x86_64
+    ;;
+
+  *)
+    echo "invalid arch: $1"
+    exit 1
+    ;;
+esac;
+
+# --no_https avoids
+# javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: No trusted certificate found
+echo "yes" | \
+    ./sdk/tools/bin/sdkmanager --no_https \
+        "emulator" \
+        "platform-tools" \
+        "platforms;android-24" \
+        "system-images;android-24;default;$abi"
+
+echo "no" |
+    ./sdk/tools/bin/avdmanager create avd \
+        --name $1 \
+        --package "system-images;android-24;default;$abi"

--- a/ci/android-sysimage.sh
+++ b/ci/android-sysimage.sh
@@ -1,0 +1,52 @@
+# Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -ex
+
+URL=https://dl.google.com/android/repository/sys-img/android
+
+main() {
+    local arch=$1
+    local name=$2
+    local dest=/system
+    local td=$(mktemp -d)
+
+    apt-get install --no-install-recommends e2tools
+
+    pushd $td
+    curl -O $URL/$name
+    unzip -q $name
+
+    local system=$(find . -name system.img)
+    mkdir -p $dest/{bin,lib,lib64}
+
+    # Extract android linker and libraries to /system
+    # This allows android executables to be run directly (or with qemu)
+    if [ $arch = "x86_64" -o $arch = "arm64" ]; then
+        e2cp -p $system:/bin/linker64 $dest/bin/
+        e2cp -p $system:/lib64/libdl.so $dest/lib64/
+        e2cp -p $system:/lib64/libc.so $dest/lib64/
+        e2cp -p $system:/lib64/libm.so $dest/lib64/
+    else
+        e2cp -p $system:/bin/linker $dest/bin/
+        e2cp -p $system:/lib/libdl.so $dest/lib/
+        e2cp -p $system:/lib/libc.so $dest/lib/
+        e2cp -p $system:/lib/libm.so $dest/lib/
+    fi
+
+    # clean up
+    apt-get purge --auto-remove -y e2tools
+
+    popd
+
+    rm -rf $td
+}
+
+main "${@}"

--- a/ci/docker/aarch64-linux-android/Dockerfile
+++ b/ci/docker/aarch64-linux-android/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:16.04
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+  file \
+  make \
+  curl \
+  ca-certificates \
+  python \
+  unzip \
+  expect \
+  openjdk-9-jre \
+  libstdc++6:i386 \
+  libpulse0 \
+  gcc \
+  libc6-dev
+
+WORKDIR /android/
+COPY android* /android/
+
+ENV ANDROID_ARCH=aarch64
+ENV PATH=$PATH:/android/ndk-$ANDROID_ARCH/bin:/android/sdk/tools:/android/sdk/platform-tools
+
+RUN sh /android/android-install-ndk.sh $ANDROID_ARCH
+RUN sh /android/android-install-sdk.sh $ANDROID_ARCH
+RUN mv /root/.android /tmp
+RUN chmod 777 -R /tmp/.android
+RUN chmod 755 /android/sdk/tools/* /android/sdk/emulator/qemu/linux-x86_64/*
+
+ENV PATH=$PATH:/rust/bin \
+    CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-gcc \
+    CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER=/tmp/runtest \
+    OBJDUMP=aarch64-linux-android-objdump \
+    HOME=/tmp
+
+ADD runtest-android.rs /tmp/runtest.rs
+ENTRYPOINT [ \
+  "bash", \
+  "-c", \
+  # set SHELL so android can detect a 64bits system, see
+  # http://stackoverflow.com/a/41789144
+  "SHELL=/bin/dash /android/sdk/emulator/emulator @aarch64 -no-window & \
+   rustc /tmp/runtest.rs -o /tmp/runtest && \
+   exec \"$@\"", \
+  "--" \
+]

--- a/ci/docker/arm-linux-androideabi/Dockerfile
+++ b/ci/docker/arm-linux-androideabi/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:16.04
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+  file \
+  make \
+  curl \
+  ca-certificates \
+  python \
+  unzip \
+  expect \
+  openjdk-9-jre \
+  libstdc++6:i386 \
+  libpulse0 \
+  gcc \
+  libc6-dev
+
+WORKDIR /android/
+COPY android* /android/
+
+ENV ANDROID_ARCH=arm
+ENV PATH=$PATH:/android/ndk-$ANDROID_ARCH/bin:/android/sdk/tools:/android/sdk/platform-tools
+
+RUN sh /android/android-install-ndk.sh $ANDROID_ARCH
+RUN sh /android/android-install-sdk.sh $ANDROID_ARCH
+RUN mv /root/.android /tmp
+RUN chmod 777 -R /tmp/.android
+RUN chmod 755 /android/sdk/tools/* /android/sdk/emulator/qemu/linux-x86_64/*
+
+ENV PATH=$PATH:/rust/bin \
+    CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
+    CARGO_TARGET_ARM_LINUX_ANDROIDEABI_RUNNER=/tmp/runtest \
+    OBJDUMP=arm-linux-androideabi-objdump \
+    HOME=/tmp
+
+ADD runtest-android.rs /tmp/runtest.rs
+ENTRYPOINT [ \
+  "bash", \
+  "-c", \
+  # set SHELL so android can detect a 64bits system, see
+  # http://stackoverflow.com/a/41789144
+  "SHELL=/bin/dash /android/sdk/emulator/emulator @arm -no-window & \
+   rustc /tmp/runtest.rs -o /tmp/runtest && \
+   exec \"$@\"", \
+  "--" \
+]

--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  gcc \
+  libc-dev \
+  python \
+  unzip \
+  file \
+  make
+
+WORKDIR /android/
+ENV ANDROID_ARCH=x86_64
+COPY android-install-ndk.sh /android/
+RUN sh /android/android-install-ndk.sh $ANDROID_ARCH
+
+# We do not run x86_64-linux-android tests on an android emulator.
+# See ci/android-sysimage.sh for informations about how tests are run.
+COPY android-sysimage.sh /android/
+RUN bash /android/android-sysimage.sh x86_64 x86_64-24_r07.zip
+
+ENV PATH=$PATH:/rust/bin:/android/ndk-$ANDROID_ARCH/bin \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
+    CC_x86_64_linux_android=x86_64-linux-android-gcc \
+    CXX_x86_64_linux_android=x86_64-linux-android-g++ \
+    OBJDUMP=x86_64-linux-android-objdump \
+    HOME=/tmp

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -5,7 +5,7 @@ set -ex
 
 run() {
     echo "Building docker container for TARGET=${1}"
-    docker build -t stdsimd ci/docker/$1
+    docker build -t stdsimd -f ci/docker/$1/Dockerfile ci/
     mkdir -p target
     target=$(echo $1 | sed 's/-emulated//')
     echo "Running docker"
@@ -18,6 +18,7 @@ run() {
       --volume `rustc --print sysroot`:/rust:ro \
       --env TARGET=$target \
       --env STDSIMD_TEST_EVERYTHING \
+      --env STDSIMD_ASSERT_INSTR_IGNORE \
       --volume `pwd`:/checkout:ro \
       --volume `pwd`/target:/checkout/target \
       --workdir /checkout \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -38,6 +38,9 @@ case ${TARGET} in
     i686-* | i586-*)
         export RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static"
         ;;
+    *android*)
+        export STDSIMD_DISABLE_ASSERT_INSTR=1
+        ;;
     *)
         ;;
 esac
@@ -46,6 +49,7 @@ echo "RUSTFLAGS=${RUSTFLAGS}"
 echo "FEATURES=${FEATURES}"
 echo "OBJDUMP=${OBJDUMP}"
 echo "STDSIMD_DISABLE_ASSERT_INSTR=${STDSIMD_DISABLE_ASSERT_INSTR}"
+echo "STDSIMD_TEST_EVERYTHING=${STDSIMD_TEST_EVERYTHING}"
 
 cargo_test() {
     cmd="cargo test --target=$TARGET $1"

--- a/ci/runtest-android.rs
+++ b/ci/runtest-android.rs
@@ -1,0 +1,41 @@
+use std::env;
+use std::process::Command;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    assert_eq!(env::args_os().len(), 2);
+    let test = PathBuf::from(env::args_os().nth(1).unwrap());
+    let dst = Path::new("/data/local/tmp").join(test.file_name().unwrap());
+
+    let status = Command::new("adb")
+        .arg("wait-for-device")
+        .status()
+        .expect("failed to run: adb wait-for-device");
+    assert!(status.success());
+
+    let status = Command::new("adb")
+        .arg("push")
+        .arg(&test)
+        .arg(&dst)
+        .status()
+        .expect("failed to run: adb pushr");
+    assert!(status.success());
+
+    let output = Command::new("adb")
+        .arg("shell")
+        .arg(&dst)
+        .output()
+        .expect("failed to run: adb shell");
+    assert!(status.success());
+
+    println!("status: {}\nstdout ---\n{}\nstderr ---\n{}",
+             output.status,
+             String::from_utf8_lossy(&output.stdout),
+             String::from_utf8_lossy(&output.stderr));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines().filter(|l| l.starts_with("test result"));
+    if !lines.all(|l| l.contains("test result: ok") && l.contains("0 failed")) {
+        panic!("failed to find successful test run");
+    }
+}

--- a/crates/stdsimd-test/src/lib.rs
+++ b/crates/stdsimd-test/src/lib.rs
@@ -81,11 +81,14 @@ fn disassemble_myself() -> HashMap<String, Vec<Function>> {
     } else {
         let objdump =
             env::var("OBJDUMP").unwrap_or_else(|_| "objdump".to_string());
-        let output = Command::new(objdump)
+        let output = Command::new(objdump.clone())
             .arg("--disassemble")
             .arg(&me)
             .output()
-            .expect("failed to execute objdump");
+            .expect(&format!(
+                "failed to execute objdump. OBJDUMP={}",
+                objdump
+            ));
         println!(
             "{}\n{}",
             output.status,

--- a/crates/stdsimd/tests/cpu-detection.rs
+++ b/crates/stdsimd/tests/cpu-detection.rs
@@ -19,14 +19,16 @@
 extern crate stdsimd;
 
 #[test]
-#[cfg(all(target_arch = "arm", target_os = "linux"))]
+#[cfg(all(target_arch = "arm",
+          any(target_os = "linux", target_os = "android")))]
 fn arm_linux() {
     println!("neon: {}", is_arm_feature_detected!("neon"));
     println!("pmull: {}", is_arm_feature_detected!("pmull"));
 }
 
 #[test]
-#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[cfg(all(target_arch = "aarch64",
+          any(target_os = "linux", target_os = "android")))]
 fn aarch64_linux() {
     println!("fp: {}", is_aarch64_feature_detected!("fp"));
     println!("fp16: {}", is_aarch64_feature_detected!("fp16"));
@@ -60,6 +62,12 @@ fn powerpc64_linux() {
 #[test]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn x86_all() {
+    println!("aes: {:?}", is_x86_feature_detected!("aes"));
+    println!("pcmulqdq: {:?}", is_x86_feature_detected!("pclmulqdq"));
+    println!("rdrand: {:?}", is_x86_feature_detected!("rdrand"));
+    println!("rdseed: {:?}", is_x86_feature_detected!("rdseed"));
+    println!("tsc: {:?}", is_x86_feature_detected!("tsc"));
+    println!("mmx: {:?}", is_x86_feature_detected!("mmx"));
     println!("sse: {:?}", is_x86_feature_detected!("sse"));
     println!("sse2: {:?}", is_x86_feature_detected!("sse2"));
     println!("sse3: {:?}", is_x86_feature_detected!("sse3"));
@@ -84,12 +92,12 @@ fn x86_all() {
         is_x86_feature_detected!("avx512vpopcntdq")
     );
     println!("fma: {:?}", is_x86_feature_detected!("fma"));
-    println!("abm: {:?}", is_x86_feature_detected!("abm"));
-    println!("bmi: {:?}", is_x86_feature_detected!("bmi1"));
+    println!("bmi1: {:?}", is_x86_feature_detected!("bmi1"));
     println!("bmi2: {:?}", is_x86_feature_detected!("bmi2"));
+    println!("abm: {:?}", is_x86_feature_detected!("abm"));
+    println!("lzcnt: {:?}", is_x86_feature_detected!("lzcnt"));
     println!("tbm: {:?}", is_x86_feature_detected!("tbm"));
     println!("popcnt: {:?}", is_x86_feature_detected!("popcnt"));
-    println!("lzcnt: {:?}", is_x86_feature_detected!("lzcnt"));
     println!("fxsr: {:?}", is_x86_feature_detected!("fxsr"));
     println!("xsave: {:?}", is_x86_feature_detected!("xsave"));
     println!("xsaveopt: {:?}", is_x86_feature_detected!("xsaveopt"));


### PR DESCRIPTION
This PR adds CI for android targets:

* x86_64-linux-android
* arm-linux-androideabi 
* aarch64-linux-android

The `assert_instr` tests are disabled on these via the `STDSIMD_ASSERT_INSTR_IGNORE` environment variable. 

cc @rubdos

---

@alexcrichton  IIUC it is possible to copy the `objdump` binaries of the target into the android emulator, but I did not find a way to pass the emulator any environment variables. One might be able to get those tests to run by hardcoding the paths to `objdump` within the emulator via a `build.rs` script. Since we are already testing these archs in other build bots, I just disabled here this part of the tests.

I've allowed the`x86_64-linux-android` target to fail because of issue: https://github.com/rust-lang-nursery/stdsimd/issues/368

