### PR TITLE
Add std::ops for vector-scalars

### DIFF
--- a/coresimd/ppsv/api/arithmetic_scalar_ops.rs
+++ b/coresimd/ppsv/api/arithmetic_scalar_ops.rs
@@ -1,0 +1,202 @@
+//! Lane-wise arithmetic operations.
+#![allow(unused)]
+
+macro_rules! impl_arithmetic_scalar_ops {
+    ($id:ident, $elem_ty:ident) => {
+        impl ::ops::Add<$elem_ty> for $id {
+            type Output = Self;
+            #[inline]
+            fn add(self, other: $elem_ty) -> Self {
+                self + $id::splat(other)
+            }
+        }
+        impl ::ops::Add<$id> for $elem_ty {
+            type Output = $id;
+            #[inline]
+            fn add(self, other: $id) -> $id {
+                $id::splat(self) + other
+            }
+        }
+
+        impl ::ops::Sub<$elem_ty> for $id {
+            type Output = Self;
+            #[inline]
+            fn sub(self, other: $elem_ty) -> Self {
+                self - $id::splat(other)
+            }
+        }
+        impl ::ops::Sub<$id> for $elem_ty {
+            type Output = $id;
+            #[inline]
+            fn sub(self, other: $id) -> $id {
+                $id::splat(self) - other
+            }
+        }
+
+        impl ::ops::Mul<$elem_ty> for $id {
+            type Output = Self;
+            #[inline]
+            fn mul(self, other: $elem_ty) -> Self {
+                self * $id::splat(other)
+            }
+        }
+        impl ::ops::Mul<$id> for $elem_ty {
+            type Output = $id;
+            #[inline]
+            fn mul(self, other: $id) -> $id {
+                $id::splat(self) * other
+            }
+        }
+
+        impl ::ops::Div<$elem_ty> for $id {
+            type Output = Self;
+            #[inline]
+            fn div(self, other: $elem_ty) -> Self {
+                self / $id::splat(other)
+            }
+        }
+        impl ::ops::Div<$id> for $elem_ty {
+            type Output = $id;
+            #[inline]
+            fn div(self, other: $id) -> $id {
+                $id::splat(self) / other
+            }
+        }
+
+        impl ::ops::Rem<$elem_ty> for $id {
+            type Output = Self;
+            #[inline]
+            fn rem(self, other: $elem_ty) -> Self {
+                self % $id::splat(other)
+            }
+        }
+        impl ::ops::Rem<$id> for $elem_ty {
+            type Output = $id;
+            #[inline]
+            fn rem(self, other: $id) -> $id {
+                $id::splat(self) % other
+            }
+        }
+
+        impl ::ops::AddAssign<$elem_ty> for $id {
+            #[inline]
+            fn add_assign(&mut self, other: $elem_ty) {
+                *self = *self + other;
+            }
+        }
+
+        impl ::ops::SubAssign<$elem_ty> for $id {
+            #[inline]
+            fn sub_assign(&mut self, other: $elem_ty) {
+                *self = *self - other;
+            }
+        }
+
+        impl ::ops::MulAssign<$elem_ty> for $id {
+            #[inline]
+            fn mul_assign(&mut self, other: $elem_ty) {
+                *self = *self * other;
+            }
+        }
+
+        impl ::ops::DivAssign<$elem_ty> for $id {
+            #[inline]
+            fn div_assign(&mut self, other: $elem_ty) {
+                *self = *self / other;
+            }
+        }
+
+        impl ::ops::RemAssign<$elem_ty> for $id {
+            #[inline]
+            fn rem_assign(&mut self, other: $elem_ty) {
+                *self = *self % other;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+macro_rules! test_arithmetic_scalar_ops {
+    ($id:ident, $elem_ty:ident) => {
+        #[test]
+        fn arithmetic_scalar() {
+            use ::coresimd::simd::$id;
+            let zi = 0 as $elem_ty;
+            let oi = 1 as $elem_ty;
+            let ti = 2 as $elem_ty;
+            let fi = 4 as $elem_ty;
+            let z = $id::splat(zi);
+            let o = $id::splat(oi);
+            let t = $id::splat(ti);
+            let f = $id::splat(fi);
+
+            // add
+            assert_eq!(zi + z, z);
+            assert_eq!(z + zi, z);
+            assert_eq!(oi + z, o);
+            assert_eq!(o + zi, o);
+            assert_eq!(ti + z, t);
+            assert_eq!(t + zi, t);
+            assert_eq!(ti + t, f);
+            assert_eq!(t + ti, f);
+            // sub
+            assert_eq!(zi - z, z);
+            assert_eq!(z - zi, z);
+            assert_eq!(oi - z, o);
+            assert_eq!(o - zi, o);
+            assert_eq!(ti - z, t);
+            assert_eq!(t - zi, t);
+            assert_eq!(fi - t, t);
+            assert_eq!(f - ti, t);
+            assert_eq!(f - o - o, t);
+            assert_eq!(f - oi - oi, t);
+            // mul
+            assert_eq!(zi * z, z);
+            assert_eq!(z * zi, z);
+            assert_eq!(zi * o, z);
+            assert_eq!(z * oi, z);
+            assert_eq!(zi * t, z);
+            assert_eq!(z * ti, z);
+            assert_eq!(oi * t, t);
+            assert_eq!(o * ti, t);
+            assert_eq!(ti * t, f);
+            assert_eq!(t * ti, f);
+            // div
+            assert_eq!(zi / o, z);
+            assert_eq!(z / oi, z);
+            assert_eq!(ti / o, t);
+            assert_eq!(t / oi, t);
+            assert_eq!(fi / o, f);
+            assert_eq!(f / oi, f);
+            assert_eq!(ti / t, o);
+            assert_eq!(t / ti, o);
+            assert_eq!(fi / t, t);
+            assert_eq!(f / ti, t);
+            // rem
+            assert_eq!(oi % o, z);
+            assert_eq!(o % oi, z);
+            assert_eq!(fi % t, z);
+            assert_eq!(f % ti, z);
+
+            {
+                let mut v = z;
+                assert_eq!(v, z);
+                v += oi;  // add_assign
+                assert_eq!(v, o);
+                v -= oi; // sub_assign
+                assert_eq!(v, z);
+                v = t;
+                v *= oi; // mul_assign
+                assert_eq!(v, t);
+                v *= ti;
+                assert_eq!(v, f);
+                v /= oi; // div_assign
+                assert_eq!(v, f);
+                v /= ti;
+                assert_eq!(v, t);
+                v %= ti; // rem_assign
+                assert_eq!(v, z);
+            }
+        }
+    };
+}

--- a/coresimd/ppsv/api/bitwise_ops.rs
+++ b/coresimd/ppsv/api/bitwise_ops.rs
@@ -2,15 +2,15 @@
 #![allow(unused)]
 
 macro_rules! impl_bitwise_ops {
-    ($ty:ident, $true_val:expr) => {
-        impl ::ops::Not for $ty {
+    ($id:ident, $true_val:expr) => {
+        impl ::ops::Not for $id {
             type Output = Self;
             #[inline]
             fn not(self) -> Self {
                 Self::splat($true_val) ^ self
             }
         }
-        impl ::ops::BitXor for $ty {
+        impl ::ops::BitXor for $id {
             type Output = Self;
             #[inline]
             fn bitxor(self, other: Self) -> Self {
@@ -18,7 +18,7 @@ macro_rules! impl_bitwise_ops {
                 unsafe { simd_xor(self, other) }
             }
         }
-        impl ::ops::BitAnd for $ty {
+        impl ::ops::BitAnd for $id {
             type Output = Self;
             #[inline]
             fn bitand(self, other: Self) -> Self {
@@ -26,7 +26,7 @@ macro_rules! impl_bitwise_ops {
                 unsafe { simd_and(self, other) }
             }
         }
-        impl ::ops::BitOr for $ty {
+        impl ::ops::BitOr for $id {
             type Output = Self;
             #[inline]
             fn bitor(self, other: Self) -> Self {
@@ -34,19 +34,19 @@ macro_rules! impl_bitwise_ops {
                 unsafe { simd_or(self, other) }
             }
         }
-        impl ::ops::BitAndAssign for $ty {
+        impl ::ops::BitAndAssign for $id {
             #[inline]
             fn bitand_assign(&mut self, other: Self) {
                 *self = *self & other;
             }
         }
-        impl ::ops::BitOrAssign for $ty {
+        impl ::ops::BitOrAssign for $id {
             #[inline]
             fn bitor_assign(&mut self, other: Self) {
                 *self = *self | other;
             }
         }
-        impl ::ops::BitXorAssign for $ty {
+        impl ::ops::BitXorAssign for $id {
             #[inline]
             fn bitxor_assign(&mut self, other: Self) {
                 *self = *self ^ other;

--- a/coresimd/ppsv/api/bitwise_scalar_ops.rs
+++ b/coresimd/ppsv/api/bitwise_scalar_ops.rs
@@ -1,0 +1,217 @@
+//! Lane-wise bitwise operations for integer and boolean vectors.
+#![allow(unused)]
+
+macro_rules! impl_bitwise_scalar_ops {
+    ($id:ident, $elem_ty:ident) => {
+        impl ::ops::BitXor<$elem_ty> for $id {
+            type Output = Self;
+            #[inline]
+            fn bitxor(self, other: $elem_ty) -> Self {
+                self ^ $id::splat(other)
+            }
+        }
+        impl ::ops::BitXor<$id> for $elem_ty {
+            type Output = $id;
+            #[inline]
+            fn bitxor(self, other: $id) -> $id {
+                $id::splat(self) ^ other
+            }
+        }
+
+        impl ::ops::BitAnd<$elem_ty> for $id {
+            type Output = Self;
+            #[inline]
+            fn bitand(self, other: $elem_ty) -> Self {
+                self & $id::splat(other)
+            }
+        }
+        impl ::ops::BitAnd<$id> for $elem_ty {
+            type Output = $id;
+            #[inline]
+            fn bitand(self, other: $id) -> $id {
+                $id::splat(self) & other
+            }
+        }
+
+        impl ::ops::BitOr<$elem_ty> for $id {
+            type Output = Self;
+            #[inline]
+            fn bitor(self, other: $elem_ty) -> Self {
+                self | $id::splat(other)
+            }
+        }
+        impl ::ops::BitOr<$id> for $elem_ty {
+            type Output = $id;
+            #[inline]
+            fn bitor(self, other: $id) -> $id {
+                $id::splat(self) | other
+            }
+        }
+
+        impl ::ops::BitAndAssign<$elem_ty> for $id {
+            #[inline]
+            fn bitand_assign(&mut self, other: $elem_ty) {
+                *self = *self & other;
+            }
+        }
+        impl ::ops::BitOrAssign<$elem_ty> for $id {
+            #[inline]
+            fn bitor_assign(&mut self, other: $elem_ty) {
+                *self = *self | other;
+            }
+        }
+        impl ::ops::BitXorAssign<$elem_ty> for $id {
+            #[inline]
+            fn bitxor_assign(&mut self, other: $elem_ty) {
+                *self = *self ^ other;
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! test_int_bitwise_scalar_ops {
+    ($id:ident, $elem_ty:ident) => {
+        #[test]
+        fn bitwise_scalar_ops() {
+            use ::coresimd::simd::$id;
+            let zi = 0 as $elem_ty;
+            let oi = 1 as $elem_ty;
+            let ti = 2 as $elem_ty;
+            let z = $id::splat(zi);
+            let o = $id::splat(oi);
+            let t = $id::splat(ti);
+
+            // BitAnd:
+            assert_eq!(oi & o, o);
+            assert_eq!(o & oi, o);
+            assert_eq!(oi & z, z);
+            assert_eq!(o & zi, z);
+            assert_eq!(zi & o, z);
+            assert_eq!(z & oi, z);
+            assert_eq!(zi & z, z);
+            assert_eq!(z & zi, z);
+
+            assert_eq!(ti & t, t);
+            assert_eq!(t & ti, t);
+            assert_eq!(ti & o, z);
+            assert_eq!(t & oi, z);
+            assert_eq!(oi & t, z);
+            assert_eq!(o & ti, z);
+
+            // BitOr:
+            assert_eq!(oi | o, o);
+            assert_eq!(o | oi, o);
+            assert_eq!(oi | z, o);
+            assert_eq!(o | zi, o);
+            assert_eq!(zi | o, o);
+            assert_eq!(z | oi, o);
+            assert_eq!(zi | z, z);
+            assert_eq!(z | zi, z);
+
+            assert_eq!(ti | t, t);
+            assert_eq!(t | ti, t);
+            assert_eq!(zi | t, t);
+            assert_eq!(z | ti, t);
+            assert_eq!(ti | z, t);
+            assert_eq!(t | zi, t);
+
+            // BitXOR:
+            assert_eq!(oi ^ o, z);
+            assert_eq!(o ^ oi, z);
+            assert_eq!(zi ^ z, z);
+            assert_eq!(z ^ zi, z);
+            assert_eq!(zi ^ o, o);
+            assert_eq!(z ^ oi, o);
+            assert_eq!(oi ^ z, o);
+            assert_eq!(o ^ zi, o);
+
+            assert_eq!(ti ^ t, z);
+            assert_eq!(t ^ ti, z);
+            assert_eq!(ti ^ z, t);
+            assert_eq!(t ^ zi, t);
+            assert_eq!(zi ^ t, t);
+            assert_eq!(z ^ ti, t);
+
+            {  // AndAssign:
+                let mut v = o;
+                v &= ti;
+                assert_eq!(v, z);
+            }
+            {  // OrAssign:
+                let mut v = z;
+                v |= oi;
+                assert_eq!(v, o);
+            }
+            {  // XORAssign:
+                let mut v = z;
+                v ^= oi;
+                assert_eq!(v, o);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+macro_rules! test_bool_bitwise_scalar_ops {
+    ($id:ident) => {
+        #[test]
+        fn bool_scalar_arithmetic() {
+            use ::coresimd::simd::*;
+
+            let ti = true;
+            let fi = false;
+            let t = $id::splat(ti);
+            let f = $id::splat(fi);
+            assert!(t != f);
+            assert!(!(t == f));
+
+
+            // BitAnd:
+            assert_eq!(ti & f, f);
+            assert_eq!(t & fi, f);
+            assert_eq!(fi & t, f);
+            assert_eq!(f & ti, f);
+            assert_eq!(ti & t, t);
+            assert_eq!(t & ti, t);
+            assert_eq!(fi & f, f);
+            assert_eq!(f & fi, f);
+
+            // BitOr:
+            assert_eq!(ti | f, t);
+            assert_eq!(t | fi, t);
+            assert_eq!(fi | t, t);
+            assert_eq!(f | ti, t);
+            assert_eq!(ti | t, t);
+            assert_eq!(t | ti, t);
+            assert_eq!(fi | f, f);
+            assert_eq!(f | fi, f);
+
+            // BitXOR:
+            assert_eq!(ti ^ f, t);
+            assert_eq!(t ^ fi, t);
+            assert_eq!(fi ^ t, t);
+            assert_eq!(f ^ ti, t);
+            assert_eq!(ti ^ t, f);
+            assert_eq!(t ^ ti, f);
+            assert_eq!(fi ^ f, f);
+            assert_eq!(f ^ fi, f);
+
+            {  // AndAssign:
+                let mut v = f;
+                v &= ti;
+                assert_eq!(v, f);
+            }
+            {  // OrAssign:
+                let mut v = f;
+                v |= ti;
+                assert_eq!(v, t);
+            }
+            {  // XORAssign:
+                let mut v = f;
+                v ^= ti;
+                assert_eq!(v, t);
+            }
+        }
+    }
+}

--- a/coresimd/ppsv/api/scalar_shifts.rs
+++ b/coresimd/ppsv/api/scalar_shifts.rs
@@ -1,0 +1,123 @@
+//! Implements integer shifts.
+#![allow(unused)]
+
+macro_rules! impl_shifts {
+    ($id:ident, $elem_ty:ident, $($by:ident),+) => {
+        $(
+            impl ::ops::Shl<$by> for $id {
+                type Output = Self;
+                #[inline]
+                fn shl(self, other: $by) -> Self {
+                    use coresimd::simd_llvm::simd_shl;
+                    unsafe { simd_shl(self, $id::splat(other as $elem_ty)) }
+                }
+            }
+            impl ::ops::Shr<$by> for $id {
+                type Output = Self;
+                #[inline]
+                fn shr(self, other: $by) -> Self {
+                    use coresimd::simd_llvm::simd_shr;
+                    unsafe { simd_shr(self, $id::splat(other as $elem_ty)) }
+                }
+            }
+
+            impl ::ops::ShlAssign<$by> for $id {
+                #[inline]
+                fn shl_assign(&mut self, other: $by) {
+                    *self = *self << other;
+                }
+            }
+            impl ::ops::ShrAssign<$by> for $id {
+                #[inline]
+                fn shr_assign(&mut self, other: $by) {
+                    *self = *self >> other;
+                }
+            }
+
+        )+
+    }
+}
+
+macro_rules! impl_all_scalar_shifts {
+    ($id:ident, $elem_ty:ident) => {
+        impl_shifts!(
+            $id, $elem_ty,
+            u8, u16, u32, u64, usize,
+            i8, i16, i32, i64, isize);
+
+    }
+}
+
+#[cfg(test)]
+macro_rules! test_shift_ops {
+    ($id:ident, $elem_ty:ident, $($index_ty:ident),+) => {
+        #[test]
+        fn scalar_shift_ops() {
+            use ::coresimd::simd::$id;
+            use ::std::mem;
+            let z = $id::splat(0 as $elem_ty);
+            let o = $id::splat(1 as $elem_ty);
+            let t = $id::splat(2 as $elem_ty);
+            let f = $id::splat(4 as $elem_ty);
+
+            $(
+                {
+                    let zi = 0 as $index_ty;
+                    let oi = 1 as $index_ty;
+                    let ti = 2 as $index_ty;
+                    let maxi = (mem::size_of::<$elem_ty>() * 8 - 1) as $index_ty;
+
+                    // shr
+                    assert_eq!(z >> zi, z);
+                    assert_eq!(z >> oi, z);
+                    assert_eq!(z >> ti, z);
+                    assert_eq!(z >> ti, z);
+
+                    assert_eq!(o >> zi, o);
+                    assert_eq!(t >> zi, t);
+                    assert_eq!(f >> zi, f);
+                    assert_eq!(f >> maxi, z);
+
+                    assert_eq!(o >> oi, z);
+                    assert_eq!(t >> oi, o);
+                    assert_eq!(t >> ti, z);
+                    assert_eq!(f >> oi, t);
+                    assert_eq!(f >> ti, o);
+                    assert_eq!(f >> maxi, z);
+
+                    // shl
+                    assert_eq!(z << zi, z);
+                    assert_eq!(o << zi, o);
+                    assert_eq!(t << zi, t);
+                    assert_eq!(f << zi, f);
+                    assert_eq!(f << maxi, z);
+
+                    assert_eq!(o << oi, t);
+                    assert_eq!(o << ti, f);
+                    assert_eq!(t << oi, f);
+
+                    {  // shr_assign
+                        let mut v = o;
+                        v >>= oi;
+                        assert_eq!(v, z);
+                    }
+                    {  // shl_assign
+                        let mut v = o;
+                        v <<= oi;
+                        assert_eq!(v, t);
+                    }
+                }
+            )+
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! test_all_scalar_shift_ops {
+    ($id:ident, $elem_ty:ident) => {
+        test_shift_ops!(
+            $id, $elem_ty,
+            u8, u16, u32, u64, usize,
+            i8, i16, i32, i64, isize);
+    }
+}

--- a/coresimd/ppsv/api/shifts.rs
+++ b/coresimd/ppsv/api/shifts.rs
@@ -1,56 +1,42 @@
 //! Implements integer shifts.
 #![allow(unused)]
 
-macro_rules! impl_shifts {
-    ($id:ident, $elem_ty:ident, $($by:ident),+) => {
-        $(
-            impl ::ops::Shl<$by> for $id {
-                type Output = Self;
-                #[inline]
-                fn shl(self, other: $by) -> Self {
-                    use coresimd::simd_llvm::simd_shl;
-                    unsafe { simd_shl(self, $id::splat(other as $elem_ty)) }
-                }
-            }
-            impl ::ops::Shr<$by> for $id {
-                type Output = Self;
-                #[inline]
-                fn shr(self, other: $by) -> Self {
-                    use coresimd::simd_llvm::simd_shr;
-                    unsafe { simd_shr(self, $id::splat(other as $elem_ty)) }
-                }
-            }
-
-            impl ::ops::ShlAssign<$by> for $id {
-                #[inline]
-                fn shl_assign(&mut self, other: $by) {
-                    *self = *self << other;
-                }
-            }
-            impl ::ops::ShrAssign<$by> for $id {
-                #[inline]
-                fn shr_assign(&mut self, other: $by) {
-                    *self = *self >> other;
-                }
-            }
-
-        )+
-    }
-}
-
-macro_rules! impl_all_shifts {
+macro_rules! impl_vector_shifts {
     ($id:ident, $elem_ty:ident) => {
-        impl_shifts!(
-            $id, $elem_ty,
-            u8, u16, u32, u64, usize,
-            i8, i16, i32, i64, isize);
-
+        impl ::ops::Shl<$id> for $id {
+            type Output = Self;
+            #[inline]
+            fn shl(self, other: Self) -> Self {
+                use coresimd::simd_llvm::simd_shl;
+                unsafe { simd_shl(self, other) }
+                }
+        }
+        impl ::ops::Shr<$id> for $id {
+            type Output = Self;
+            #[inline]
+            fn shr(self, other: Self) -> Self {
+                use coresimd::simd_llvm::simd_shr;
+                unsafe { simd_shr(self, other) }
+            }
+        }
+        impl ::ops::ShlAssign<$id> for $id {
+            #[inline]
+            fn shl_assign(&mut self, other: Self) {
+                *self = *self << other;
+            }
+        }
+        impl ::ops::ShrAssign<$id> for $id {
+            #[inline]
+            fn shr_assign(&mut self, other: Self) {
+                *self = *self >> other;
+            }
+        }
     }
 }
 
 #[cfg(test)]
-macro_rules! test_shift_ops {
-    ($id:ident, $elem_ty:ident, $($index_ty:ident),+) => {
+macro_rules! test_vector_shift_ops {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn shift_ops() {
             use ::coresimd::simd::$id;
@@ -60,64 +46,47 @@ macro_rules! test_shift_ops {
             let t = $id::splat(2 as $elem_ty);
             let f = $id::splat(4 as $elem_ty);
 
-            $(
-                {
-                    let zi = 0 as $index_ty;
-                    let oi = 1 as $index_ty;
-                    let ti = 2 as $index_ty;
-                    let maxi = (mem::size_of::<$elem_ty>() * 8 - 1) as $index_ty;
+            let max = $id::splat((mem::size_of::<$elem_ty>() * 8 - 1) as $elem_ty);
 
-                    // shr
-                    assert_eq!(z >> zi, z);
-                    assert_eq!(z >> oi, z);
-                    assert_eq!(z >> ti, z);
-                    assert_eq!(z >> ti, z);
+            // shr
+            assert_eq!(z >> z, z);
+            assert_eq!(z >> o, z);
+            assert_eq!(z >> t, z);
+            assert_eq!(z >> t, z);
 
-                    assert_eq!(o >> zi, o);
-                    assert_eq!(t >> zi, t);
-                    assert_eq!(f >> zi, f);
-                    assert_eq!(f >> maxi, z);
+            assert_eq!(o >> z, o);
+            assert_eq!(t >> z, t);
+            assert_eq!(f >> z, f);
+            assert_eq!(f >> max, z);
 
-                    assert_eq!(o >> oi, z);
-                    assert_eq!(t >> oi, o);
-                    assert_eq!(t >> ti, z);
-                    assert_eq!(f >> oi, t);
-                    assert_eq!(f >> ti, o);
-                    assert_eq!(f >> maxi, z);
+            assert_eq!(o >> o, z);
+            assert_eq!(t >> o, o);
+            assert_eq!(t >> t, z);
+            assert_eq!(f >> o, t);
+            assert_eq!(f >> t, o);
+            assert_eq!(f >> max, z);
 
-                    // shl
-                    assert_eq!(z << zi, z);
-                    assert_eq!(o << zi, o);
-                    assert_eq!(t << zi, t);
-                    assert_eq!(f << zi, f);
-                    assert_eq!(f << maxi, z);
+            // shl
+            assert_eq!(z << z, z);
+            assert_eq!(o << z, o);
+            assert_eq!(t << z, t);
+            assert_eq!(f << z, f);
+            assert_eq!(f << max, z);
 
-                    assert_eq!(o << oi, t);
-                    assert_eq!(o << ti, f);
-                    assert_eq!(t << oi, f);
+            assert_eq!(o << o, t);
+            assert_eq!(o << t, f);
+            assert_eq!(t << o, f);
 
-                    {  // shr_assign
-                        let mut v = o;
-                        v >>= oi;
-                        assert_eq!(v, z);
-                    }
-                    {  // shl_assign
-                        let mut v = o;
-                        v <<= oi;
-                        assert_eq!(v, t);
-                    }
-                }
-            )+
+            {  // shr_assign
+                let mut v = o;
+                v >>= o;
+                assert_eq!(v, z);
+            }
+            {  // shl_assign
+                let mut v = o;
+                v <<= o;
+                assert_eq!(v, t);
+            }
         }
     };
-}
-
-#[cfg(test)]
-macro_rules! test_all_shift_ops {
-    ($id:ident, $elem_ty:ident) => {
-        test_shift_ops!(
-            $id, $elem_ty,
-            u8, u16, u32, u64, usize,
-            i8, i16, i32, i64, isize);
-    }
 }


### PR DESCRIPTION
Today some of the traits are implemented for vectors, and some of them are implemented for scalars:

```rust
let u = i32x4::new(1, 2, 3, 4);
let v = u << 1; // OK
let w = 1 << v; // ERROR
let t = v << v; // ERROR
let u= f32x4::new(1., 2., 3., 4.);
let v = u+ u;  // OK
let w = 1_f32 + v; // ERROR
let t = v + 1_f32; // ERROR
```

This PR fixes these errors for all operators. The implementation is compartmentalized so that we don't need to stabilize all of these at once. For example, we can stabilize (vector, vector) -> vector binary ops first, and decide on (vector, scalar) -> vector and (scalar, vector) -> vector later. 

It is important to be comprehensive with the `std::ops` traits because due to trait coherence users cannot implement them themselves on the portable vector types. Having these available on nightly should help with experimentation.
