### PR TITLE
add llvm bug for reductions on aarch64

### DIFF
--- a/coresimd/ppsv/api/arithmetic_reductions.rs
+++ b/coresimd/ppsv/api/arithmetic_reductions.rs
@@ -26,6 +26,7 @@ macro_rules! impl_arithmetic_reductions {
             #[inline]
             pub fn sum(self) -> $elem_ty {
                 // FIXME: broken on AArch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 let mut x = self.extract(0) as $elem_ty;
                 for i in 1..$id::lanes() {
                     x += self.extract(i) as $elem_ty;
@@ -55,6 +56,7 @@ macro_rules! impl_arithmetic_reductions {
             #[inline]
             pub fn product(self) -> $elem_ty {
                 // FIXME: broken on AArch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 let mut x = self.extract(0) as $elem_ty;
                 for i in 1..$id::lanes() {
                     x *= self.extract(i) as $elem_ty;

--- a/coresimd/ppsv/api/bitwise_reductions.rs
+++ b/coresimd/ppsv/api/bitwise_reductions.rs
@@ -18,6 +18,7 @@ macro_rules! impl_bitwise_reductions {
             #[inline]
             pub fn and(self) -> $elem_ty {
                 // FIXME: broken on aarch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 let mut x = self.extract(0) as $elem_ty;
                 for i in 1..$id::lanes() {
                     x &= self.extract(i) as $elem_ty;
@@ -39,6 +40,7 @@ macro_rules! impl_bitwise_reductions {
             #[inline]
             pub fn or(self) -> $elem_ty {
                 // FIXME: broken on aarch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 let mut x = self.extract(0) as $elem_ty;
                 for i in 1..$id::lanes() {
                     x |= self.extract(i) as $elem_ty;
@@ -60,6 +62,7 @@ macro_rules! impl_bitwise_reductions {
             #[inline]
             pub fn xor(self) -> $elem_ty {
                 // FIXME: broken on aarch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 let mut x = self.extract(0) as $elem_ty;
                 for i in 1..$id::lanes() {
                     x ^= self.extract(i) as $elem_ty;
@@ -88,6 +91,7 @@ macro_rules! impl_bool_bitwise_reductions {
             #[inline]
             pub fn and(self) -> $elem_ty {
                 // FIXME: broken on aarch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 let mut x = self.extract(0) as $elem_ty;
                 for i in 1..$id::lanes() {
                     x &= self.extract(i) as $elem_ty;
@@ -110,6 +114,7 @@ macro_rules! impl_bool_bitwise_reductions {
             #[inline]
             pub fn or(self) -> $elem_ty {
                 // FIXME: broken on aarch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 let mut x = self.extract(0) as $elem_ty;
                 for i in 1..$id::lanes() {
                     x |= self.extract(i) as $elem_ty;
@@ -132,6 +137,7 @@ macro_rules! impl_bool_bitwise_reductions {
             #[inline]
             pub fn xor(self) -> $elem_ty {
                 // FIXME: broken on aarch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 let mut x = self.extract(0) as $elem_ty;
                 for i in 1..$id::lanes() {
                     x ^= self.extract(i) as $elem_ty;

--- a/coresimd/ppsv/api/boolean_reductions.rs
+++ b/coresimd/ppsv/api/boolean_reductions.rs
@@ -18,6 +18,7 @@ macro_rules! impl_bool_reductions {
             #[inline]
             pub fn all(self) -> bool {
                 // FIXME: Broken on AArch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 self.and()
             }
 
@@ -35,6 +36,7 @@ macro_rules! impl_bool_reductions {
             #[inline]
             pub fn any(self) -> bool {
                 // FIXME: Broken on AArch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 self.or()
             }
 

--- a/coresimd/ppsv/api/minmax_reductions.rs
+++ b/coresimd/ppsv/api/minmax_reductions.rs
@@ -23,6 +23,7 @@ macro_rules! impl_minmax_reductions {
             #[inline]
             pub fn max(self) -> $elem_ty {
                 // FIXME: broken on AArch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 use ::num::Float;
                 use ::cmp::Ord;
                 let mut x = self.extract(0);
@@ -51,6 +52,7 @@ macro_rules! impl_minmax_reductions {
             #[inline]
             pub fn min(self) -> $elem_ty {
                 // FIXME: broken on AArch64
+                // https://bugs.llvm.org/show_bug.cgi?id=36796
                 use ::num::Float;
                 use ::cmp::Ord;
                 let mut x = self.extract(0);


### PR DESCRIPTION
I came up with a reproducer for the "failed to select reduction" bugs on AArch64. This PR links the LLVM bug in the appropriate places: https://bugs.llvm.org/show_bug.cgi?id=36796