### PR TITLE
Remove clone impls of repr(simd) types (derives Clone instead).

### DIFF
--- a/coresimd/macros.rs
+++ b/coresimd/macros.rs
@@ -7,17 +7,9 @@ macro_rules! types {
         pub struct $name:ident($($fields:tt)*);
     )*) => ($(
         $(#[$doc])*
-            #[derive(Copy, Debug)]
+        #[derive(Copy, Clone, Debug)]
         #[allow(non_camel_case_types)]
         #[repr(simd)]
         pub struct $name($($fields)*);
-
-        #[cfg_attr(feature = "cargo-clippy", allow(expl_impl_clone_on_copy))]
-        impl ::clone::Clone for $name {
-            #[inline] // currently needed for correctness
-            fn clone(&self) -> $name {
-                *self
-            }
-        }
     )*)
 }

--- a/coresimd/ppsv/api/bool_vectors.rs
+++ b/coresimd/ppsv/api/bool_vectors.rs
@@ -4,15 +4,6 @@
 /// Minimal interface: all packed SIMD boolean vector types implement this.
 macro_rules! impl_bool_minimal {
     ($id:ident, $elem_ty:ident, $elem_count:expr, $($elem_name:ident),+) => {
-
-        #[cfg_attr(feature = "cargo-clippy", allow(expl_impl_clone_on_copy))]
-        impl ::clone::Clone for $id {
-            #[inline] // currently needed for correctness
-            fn clone(&self) -> Self {
-                *self
-            }
-        }
-
         impl $id {
             /// Creates a new instance with each vector elements initialized
             /// with the provided values.

--- a/coresimd/ppsv/api/minimal.rs
+++ b/coresimd/ppsv/api/minimal.rs
@@ -4,14 +4,6 @@
 /// Minimal interface: all packed SIMD vector types implement this.
 macro_rules! impl_minimal {
     ($id:ident, $elem_ty:ident, $elem_count:expr, $($elem_name:ident),+) => {
-        #[cfg_attr(feature = "cargo-clippy", allow(expl_impl_clone_on_copy))]
-        impl ::clone::Clone for $id {
-            #[inline] // currently needed for correctness
-            fn clone(&self) -> Self {
-                *self
-            }
-        }
-
         impl $id {
             /// Creates a new instance with each vector elements initialized
             /// with the provided values.

--- a/coresimd/ppsv/api/mod.rs
+++ b/coresimd/ppsv/api/mod.rs
@@ -59,8 +59,8 @@
 macro_rules! define_ty {
     ($id:ident, $($elem_tys:ident),+ | $(#[$doc:meta])*) => {
         $(#[$doc])*
-            #[repr(simd)]
-        #[derive(Copy, Debug, /*FIXME:*/ PartialOrd)]
+        #[repr(simd)]
+        #[derive(Copy, Clone, Debug, /*FIXME:*/ PartialOrd)]
         #[allow(non_camel_case_types)]
         pub struct $id($($elem_tys),*);
     }


### PR DESCRIPTION
Closes #386 .