### PR TITLE
add tests for endian-dependent behavior

### DIFF
--- a/coresimd/mips/msa.rs
+++ b/coresimd/mips/msa.rs
@@ -17,7 +17,8 @@ extern "C" {
 
 /// Vector Add Absolute Values.
 ///
-/// Adds the absolute values of the elements in `a` and `b` into the result vector.
+/// Adds the absolute values of the elements in `a` and `b` into the result
+/// vector.
 #[inline]
 #[target_feature(enable = "msa")]
 #[cfg_attr(test, assert_instr(add_a.b))]

--- a/coresimd/ppsv/api/arithmetic_ops.rs
+++ b/coresimd/ppsv/api/arithmetic_ops.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_arithmetic_ops {
-    ($id:ident) => {
+    ($id: ident) => {
         impl ::ops::Add for $id {
             type Output = Self;
             #[inline]
@@ -82,15 +82,15 @@ macro_rules! impl_arithmetic_ops {
                 *self = *self % other;
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_arithmetic_ops {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn arithmetic() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let z = $id::splat(0 as $elem_ty);
             let o = $id::splat(1 as $elem_ty);
             let t = $id::splat(2 as $elem_ty);
@@ -126,7 +126,7 @@ macro_rules! test_arithmetic_ops {
             {
                 let mut v = z;
                 assert_eq!(v, z);
-                v += o;  // add_assign
+                v += o; // add_assign
                 assert_eq!(v, o);
                 v -= o; // sub_assign
                 assert_eq!(v, z);

--- a/coresimd/ppsv/api/arithmetic_reductions.rs
+++ b/coresimd/ppsv/api/arithmetic_reductions.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_arithmetic_reductions {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl $id {
             /// Lane-wise addition of the vector elements.
             ///
@@ -12,10 +12,8 @@ macro_rules! impl_arithmetic_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn sum(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_add_ordered;
-                unsafe {
-                    simd_reduce_add_ordered(self, 0 as $elem_ty)
-                }
+                use coresimd::simd_llvm::simd_reduce_add_ordered;
+                unsafe { simd_reduce_add_ordered(self, 0 as $elem_ty) }
             }
             /// Lane-wise addition of the vector elements.
             ///
@@ -42,10 +40,8 @@ macro_rules! impl_arithmetic_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn product(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_mul_ordered;
-                unsafe {
-                    simd_reduce_mul_ordered(self, 1 as $elem_ty)
-                }
+                use coresimd::simd_llvm::simd_reduce_mul_ordered;
+                unsafe { simd_reduce_mul_ordered(self, 1 as $elem_ty) }
             }
             /// Lane-wise multiplication of the vector elements.
             ///
@@ -64,15 +60,14 @@ macro_rules! impl_arithmetic_reductions {
                 x
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_arithmetic_reductions {
-    ($id:ident, $elem_ty:ident) => {
-
+    ($id: ident, $elem_ty: ident) => {
         fn alternating(x: usize) -> ::coresimd::simd::$id {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let mut v = $id::splat(1 as $elem_ty);
             for i in 0..$id::lanes() {
                 if i % x == 0 {
@@ -84,17 +79,20 @@ macro_rules! test_arithmetic_reductions {
 
         #[test]
         fn sum() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let v = $id::splat(0 as $elem_ty);
             assert_eq!(v.sum(), 0 as $elem_ty);
             let v = $id::splat(1 as $elem_ty);
             assert_eq!(v.sum(), $id::lanes() as $elem_ty);
             let v = alternating(2);
-            assert_eq!(v.sum(), ($id::lanes() / 2 + $id::lanes()) as $elem_ty);
+            assert_eq!(
+                v.sum(),
+                ($id::lanes() / 2 + $id::lanes()) as $elem_ty
+            );
         }
         #[test]
         fn product() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let v = $id::splat(0 as $elem_ty);
             assert_eq!(v.product(), 0 as $elem_ty);
             let v = $id::splat(1 as $elem_ty);
@@ -106,7 +104,10 @@ macro_rules! test_arithmetic_reductions {
                 _ => 2,
             };
             let v = alternating(f);
-            assert_eq!(v.product(), (2_usize.pow(($id::lanes() / f) as u32) as $elem_ty));
+            assert_eq!(
+                v.product(),
+                (2_usize.pow(($id::lanes() / f) as u32) as $elem_ty)
+            );
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/arithmetic_scalar_ops.rs
+++ b/coresimd/ppsv/api/arithmetic_scalar_ops.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_arithmetic_scalar_ops {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl ::ops::Add<$elem_ty> for $id {
             type Output = Self;
             #[inline]
@@ -112,15 +112,15 @@ macro_rules! impl_arithmetic_scalar_ops {
                 *self = *self % other;
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_arithmetic_scalar_ops {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn arithmetic_scalar() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let zi = 0 as $elem_ty;
             let oi = 1 as $elem_ty;
             let ti = 2 as $elem_ty;
@@ -181,7 +181,7 @@ macro_rules! test_arithmetic_scalar_ops {
             {
                 let mut v = z;
                 assert_eq!(v, z);
-                v += oi;  // add_assign
+                v += oi; // add_assign
                 assert_eq!(v, o);
                 v -= oi; // sub_assign
                 assert_eq!(v, z);

--- a/coresimd/ppsv/api/bitwise_ops.rs
+++ b/coresimd/ppsv/api/bitwise_ops.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_bitwise_ops {
-    ($id:ident, $true_val:expr) => {
+    ($id: ident, $true_val: expr) => {
         impl ::ops::Not for $id {
             type Output = Self;
             #[inline]
@@ -57,10 +57,10 @@ macro_rules! impl_bitwise_ops {
 
 #[cfg(test)]
 macro_rules! test_int_bitwise_ops {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn bitwise_ops() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let z = $id::splat(0 as $elem_ty);
             let o = $id::splat(1 as $elem_ty);
             let t = $id::splat(2 as $elem_ty);
@@ -100,31 +100,34 @@ macro_rules! test_int_bitwise_ops {
             assert_eq!(t ^ z, t);
             assert_eq!(z ^ t, t);
 
-            {  // AndAssign:
+            {
+                // AndAssign:
                 let mut v = o;
                 v &= t;
                 assert_eq!(v, z);
             }
-            {  // OrAssign:
+            {
+                // OrAssign:
                 let mut v = z;
                 v |= o;
                 assert_eq!(v, o);
             }
-            {  // XORAssign:
+            {
+                // XORAssign:
                 let mut v = z;
                 v ^= o;
                 assert_eq!(v, o);
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_bool_bitwise_ops {
-    ($id:ident) => {
+    ($id: ident) => {
         #[test]
         fn bool_arithmetic() {
-            use ::coresimd::simd::*;
+            use coresimd::simd::*;
 
             let t = $id::splat(true);
             let f = $id::splat(false);
@@ -153,21 +156,24 @@ macro_rules! test_bool_bitwise_ops {
             assert_eq!(t ^ t, f);
             assert_eq!(f ^ f, f);
 
-            {  // AndAssign:
+            {
+                // AndAssign:
                 let mut v = f;
                 v &= t;
                 assert_eq!(v, f);
             }
-            {  // OrAssign:
+            {
+                // OrAssign:
                 let mut v = f;
                 v |= t;
                 assert_eq!(v, t);
             }
-            {  // XORAssign:
+            {
+                // XORAssign:
                 let mut v = f;
                 v ^= t;
                 assert_eq!(v, t);
             }
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/bitwise_reductions.rs
+++ b/coresimd/ppsv/api/bitwise_reductions.rs
@@ -2,16 +2,14 @@
 #![allow(unused)]
 
 macro_rules! impl_bitwise_reductions {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl $id {
             /// Lane-wise bitwise `and` of the vector elements.
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn and(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_and;
-                unsafe {
-                    simd_reduce_and(self)
-                }
+                use coresimd::simd_llvm::simd_reduce_and;
+                unsafe { simd_reduce_and(self) }
             }
             /// Lane-wise bitwise `and` of the vector elements.
             #[cfg(target_arch = "aarch64")]
@@ -30,10 +28,8 @@ macro_rules! impl_bitwise_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn or(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_or;
-                unsafe {
-                    simd_reduce_or(self)
-                }
+                use coresimd::simd_llvm::simd_reduce_or;
+                unsafe { simd_reduce_or(self) }
             }
             /// Lane-wise bitwise `or` of the vector elements.
             #[cfg(target_arch = "aarch64")]
@@ -52,10 +48,8 @@ macro_rules! impl_bitwise_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn xor(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_xor;
-                unsafe {
-                    simd_reduce_xor(self)
-                }
+                use coresimd::simd_llvm::simd_reduce_xor;
+                unsafe { simd_reduce_xor(self) }
             }
             /// Lane-wise bitwise `xor` of the vector elements.
             #[cfg(target_arch = "aarch64")]
@@ -70,17 +64,17 @@ macro_rules! impl_bitwise_reductions {
                 x
             }
         }
-    }
+    };
 }
 
 macro_rules! impl_bool_bitwise_reductions {
-    ($id:ident, $elem_ty:ident, $internal_ty:ident) => {
+    ($id: ident, $elem_ty: ident, $internal_ty: ident) => {
         impl $id {
             /// Lane-wise bitwise `and` of the vector elements.
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn and(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_and;
+                use coresimd::simd_llvm::simd_reduce_and;
                 unsafe {
                     let r: $internal_ty = simd_reduce_and(self);
                     r != 0
@@ -103,7 +97,7 @@ macro_rules! impl_bool_bitwise_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn or(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_or;
+                use coresimd::simd_llvm::simd_reduce_or;
                 unsafe {
                     let r: $internal_ty = simd_reduce_or(self);
                     r != 0
@@ -126,7 +120,7 @@ macro_rules! impl_bool_bitwise_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn xor(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_xor;
+                use coresimd::simd_llvm::simd_reduce_xor;
                 unsafe {
                     let r: $internal_ty = simd_reduce_xor(self);
                     r != 0
@@ -145,16 +139,16 @@ macro_rules! impl_bool_bitwise_reductions {
                 x
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_bitwise_reductions {
-    ($id:ident, $true:expr) => {
+    ($id: ident, $true: expr) => {
         #[test]
         fn and() {
             let false_ = !$true;
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let v = $id::splat(false_);
             assert_eq!(v.and(), false_);
             let v = $id::splat($true);
@@ -169,7 +163,7 @@ macro_rules! test_bitwise_reductions {
         #[test]
         fn or() {
             let false_ = !$true;
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let v = $id::splat(false_);
             assert_eq!(v.or(), false_);
             let v = $id::splat($true);
@@ -184,7 +178,7 @@ macro_rules! test_bitwise_reductions {
         #[test]
         fn xor() {
             let false_ = !$true;
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let v = $id::splat(false_);
             assert_eq!(v.xor(), false_);
             let v = $id::splat($true);
@@ -196,5 +190,5 @@ macro_rules! test_bitwise_reductions {
             let v = v.replace(0, false_);
             assert_eq!(v.xor(), $true);
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/bitwise_scalar_ops.rs
+++ b/coresimd/ppsv/api/bitwise_scalar_ops.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_bitwise_scalar_ops {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl ::ops::BitXor<$elem_ty> for $id {
             type Output = Self;
             #[inline]
@@ -71,10 +71,10 @@ macro_rules! impl_bitwise_scalar_ops {
 
 #[cfg(test)]
 macro_rules! test_int_bitwise_scalar_ops {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn bitwise_scalar_ops() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let zi = 0 as $elem_ty;
             let oi = 1 as $elem_ty;
             let ti = 2 as $elem_ty;
@@ -133,31 +133,34 @@ macro_rules! test_int_bitwise_scalar_ops {
             assert_eq!(zi ^ t, t);
             assert_eq!(z ^ ti, t);
 
-            {  // AndAssign:
+            {
+                // AndAssign:
                 let mut v = o;
                 v &= ti;
                 assert_eq!(v, z);
             }
-            {  // OrAssign:
+            {
+                // OrAssign:
                 let mut v = z;
                 v |= oi;
                 assert_eq!(v, o);
             }
-            {  // XORAssign:
+            {
+                // XORAssign:
                 let mut v = z;
                 v ^= oi;
                 assert_eq!(v, o);
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_bool_bitwise_scalar_ops {
-    ($id:ident) => {
+    ($id: ident) => {
         #[test]
         fn bool_scalar_arithmetic() {
-            use ::coresimd::simd::*;
+            use coresimd::simd::*;
 
             let ti = true;
             let fi = false;
@@ -165,7 +168,6 @@ macro_rules! test_bool_bitwise_scalar_ops {
             let f = $id::splat(fi);
             assert!(t != f);
             assert!(!(t == f));
-
 
             // BitAnd:
             assert_eq!(ti & f, f);
@@ -197,21 +199,24 @@ macro_rules! test_bool_bitwise_scalar_ops {
             assert_eq!(fi ^ f, f);
             assert_eq!(f ^ fi, f);
 
-            {  // AndAssign:
+            {
+                // AndAssign:
                 let mut v = f;
                 v &= ti;
                 assert_eq!(v, f);
             }
-            {  // OrAssign:
+            {
+                // OrAssign:
                 let mut v = f;
                 v |= ti;
                 assert_eq!(v, t);
             }
-            {  // XORAssign:
+            {
+                // XORAssign:
                 let mut v = f;
                 v ^= ti;
                 assert_eq!(v, t);
             }
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/bool_vectors.rs
+++ b/coresimd/ppsv/api/bool_vectors.rs
@@ -98,10 +98,10 @@ macro_rules! impl_bool_minimal {
 
 #[cfg(test)]
 macro_rules! test_bool_minimal {
-    ($id:ident, $elem_count:expr) => {
+    ($id: ident, $elem_count: expr) => {
         #[test]
         fn minimal() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             // TODO: test new
 
             // lanes:
@@ -135,16 +135,16 @@ macro_rules! test_bool_minimal {
         #[test]
         #[should_panic]
         fn minimal_extract_panic_on_out_of_bounds() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let vec = $id::splat(false);
             let _ = vec.extract($id::lanes());
         }
         #[test]
         #[should_panic]
         fn minimal_replace_panic_on_out_of_bounds() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let vec = $id::splat(false);
             let _ = vec.replace($id::lanes(), true);
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/boolean_reductions.rs
+++ b/coresimd/ppsv/api/boolean_reductions.rs
@@ -2,16 +2,14 @@
 #![allow(unused)]
 
 macro_rules! impl_bool_reductions {
-    ($id:ident) => {
+    ($id: ident) => {
         impl $id {
             /// Are `all` vector lanes `true`?
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn all(self) -> bool {
-                use ::coresimd::simd_llvm::simd_reduce_all;
-                unsafe {
-                    simd_reduce_all(self)
-                }
+                use coresimd::simd_llvm::simd_reduce_all;
+                unsafe { simd_reduce_all(self) }
             }
             /// Are `all` vector lanes `true`?
             #[cfg(target_arch = "aarch64")]
@@ -26,10 +24,8 @@ macro_rules! impl_bool_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn any(self) -> bool {
-                use ::coresimd::simd_llvm::simd_reduce_any;
-                unsafe {
-                    simd_reduce_any(self)
-                }
+                use coresimd::simd_llvm::simd_reduce_any;
+                unsafe { simd_reduce_any(self) }
             }
             /// Is `any` vector lanes `true`?
             #[cfg(target_arch = "aarch64")]
@@ -46,15 +42,15 @@ macro_rules! impl_bool_reductions {
                 !self.any()
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_bool_reductions {
-    ($id:ident) => {
+    ($id: ident) => {
         #[test]
         fn all() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
 
             let a = $id::splat(true);
             assert!(a.all());
@@ -72,7 +68,7 @@ macro_rules! test_bool_reductions {
         }
         #[test]
         fn any() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
 
             let a = $id::splat(true);
             assert!(a.any());
@@ -90,7 +86,7 @@ macro_rules! test_bool_reductions {
         }
         #[test]
         fn none() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
 
             let a = $id::splat(true);
             assert!(!a.none());
@@ -106,5 +102,5 @@ macro_rules! test_bool_reductions {
                 assert!(!a.none());
             }
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/cmp.rs
+++ b/coresimd/ppsv/api/cmp.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_cmp {
-    ($id:ident, $bool_ty:ident) => {
+    ($id: ident, $bool_ty: ident) => {
         impl $id {
             /// Lane-wise equality comparison.
             #[inline]
@@ -46,11 +46,11 @@ macro_rules! impl_cmp {
                 unsafe { simd_ge(self, other) }
             }
         }
-    }
+    };
 }
 
 macro_rules! impl_bool_cmp {
-    ($id:ident, $bool_ty:ident) => {
+    ($id: ident, $bool_ty: ident) => {
         impl $id {
             /// Lane-wise equality comparison.
             #[inline]
@@ -94,7 +94,7 @@ macro_rules! impl_bool_cmp {
                 unsafe { simd_le(self, other) }
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]

--- a/coresimd/ppsv/api/default.rs
+++ b/coresimd/ppsv/api/default.rs
@@ -2,26 +2,26 @@
 #![allow(unused)]
 
 macro_rules! impl_default {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl ::default::Default for $id {
             #[inline]
             fn default() -> Self {
                 Self::splat($elem_ty::default())
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_default {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn default() {
-            use ::coresimd::simd::{$id};
+            use coresimd::simd::$id;
             let a = $id::default();
             for i in 0..$id::lanes() {
                 assert_eq!(a.extract(i), $elem_ty::default());
             }
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/eq.rs
+++ b/coresimd/ppsv/api/eq.rs
@@ -2,5 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_eq {
-    ($id:ident) => { impl ::cmp::Eq for $id {} }
+    ($id: ident) => {
+        impl ::cmp::Eq for $id {}
+    };
 }

--- a/coresimd/ppsv/api/fmt.rs
+++ b/coresimd/ppsv/api/fmt.rs
@@ -2,14 +2,12 @@
 #![allow(unused)]
 
 macro_rules! impl_hex_fmt {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl ::fmt::LowerHex for $id {
-            fn fmt(&self, f: &mut ::fmt::Formatter)
-                   -> ::fmt::Result {
-                use ::mem;
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+                use mem;
                 write!(f, "{}(", stringify!($id))?;
-                let n = mem::size_of_val(self)
-                    / mem::size_of::<$elem_ty>();
+                let n = mem::size_of_val(self) / mem::size_of::<$elem_ty>();
                 for i in 0..n {
                     if i > 0 {
                         write!(f, ", ")?;
@@ -20,8 +18,7 @@ macro_rules! impl_hex_fmt {
             }
         }
         impl ::fmt::UpperHex for $id {
-            fn fmt(&self, f: &mut ::fmt::Formatter)
-                   -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 write!(f, "{}(", stringify!($id))?;
                 for i in 0..$id::lanes() {
                     if i > 0 {
@@ -33,8 +30,7 @@ macro_rules! impl_hex_fmt {
             }
         }
         impl ::fmt::Octal for $id {
-            fn fmt(&self, f: &mut ::fmt::Formatter)
-                   -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 write!(f, "{}(", stringify!($id))?;
                 for i in 0..$id::lanes() {
                     if i > 0 {
@@ -46,8 +42,7 @@ macro_rules! impl_hex_fmt {
             }
         }
         impl ::fmt::Binary for $id {
-            fn fmt(&self, f: &mut ::fmt::Formatter)
-                   -> ::fmt::Result {
+            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 write!(f, "{}(", stringify!($id))?;
                 for i in 0..$id::lanes() {
                     if i > 0 {
@@ -58,7 +53,7 @@ macro_rules! impl_hex_fmt {
                 write!(f, ")")
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
@@ -145,7 +140,13 @@ macro_rules! test_hex_fmt_impl {
 
 #[cfg(test)]
 macro_rules! test_hex_fmt {
-    ($id:ident, $elem_ty:ident) => {
-        test_hex_fmt_impl!($id, $elem_ty, 0 as $elem_ty, !(0 as $elem_ty), (1 as $elem_ty));
-    }
+    ($id: ident, $elem_ty: ident) => {
+        test_hex_fmt_impl!(
+            $id,
+            $elem_ty,
+            0 as $elem_ty,
+            !(0 as $elem_ty),
+            (1 as $elem_ty)
+        );
+    };
 }

--- a/coresimd/ppsv/api/from.rs
+++ b/coresimd/ppsv/api/from.rs
@@ -3,7 +3,7 @@
 #![allow(unused)]
 
 macro_rules! impl_from_impl {
-    ($from:ident, $to:ident) => {
+    ($from: ident, $to: ident) => {
         impl ::convert::From<::simd::$from> for $to {
             #[inline]
             fn from(f: ::simd::$from) -> $to {
@@ -11,13 +11,13 @@ macro_rules! impl_from_impl {
                 unsafe { simd_cast(f) }
             }
         }
-    }
+    };
 }
 
 macro_rules! impl_from_ {
-    ($to:ident, $from:ident) => {
+    ($to: ident, $from: ident) => {
         vector_impl!([impl_from_impl, $to, $from]);
-    }
+    };
 }
 
 macro_rules! impl_from {

--- a/coresimd/ppsv/api/hash.rs
+++ b/coresimd/ppsv/api/hash.rs
@@ -2,31 +2,29 @@
 #![allow(unused)]
 
 macro_rules! impl_hash {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl ::hash::Hash for $id {
             #[inline]
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
                 union A {
                     data: [$elem_ty; $id::lanes()],
-                    vec: $id
+                    vec: $id,
                 }
-                unsafe {
-                    A { vec: *self }.data.hash(state)
-                }
+                unsafe { A { vec: *self }.data.hash(state) }
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_hash {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn hash() {
-            use ::coresimd::simd::$id;
-            use ::std::collections::hash_map::DefaultHasher;
-            use ::std::hash::{Hash, Hasher};
-            use ::std::mem;
+            use coresimd::simd::$id;
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::{Hash, Hasher};
+            use std::mem;
             type A = [$elem_ty; $id::lanes()];
             let a: A = [42 as $elem_ty; $id::lanes()];
             assert!(mem::size_of::<A>() == mem::size_of::<$id>());
@@ -38,5 +36,5 @@ macro_rules! test_hash {
             v.hash(&mut v_hash);
             assert_eq!(a_hash.finish(), v_hash.finish());
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/load_store.rs
+++ b/coresimd/ppsv/api/load_store.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_load_store {
-    ($id:ident, $elem_ty:ident, $elem_count:expr) => {
+    ($id: ident, $elem_ty: ident, $elem_count: expr) => {
         impl $id {
             /// Writes the values of the vector to the `slice`.
             ///
@@ -12,11 +12,15 @@ macro_rules! impl_load_store {
             /// aligned to an `align_of::<Self>()` boundary.
             #[inline]
             pub fn store_aligned(self, slice: &mut [$elem_ty]) {
-                use ::slice::SliceExt;
+                use slice::SliceExt;
                 unsafe {
                     assert!(slice.len() >= $elem_count);
-                    let target_ptr = slice.get_unchecked_mut(0) as *mut $elem_ty;
-                    assert!(target_ptr.align_offset(::mem::align_of::<Self>()) == 0);
+                    let target_ptr =
+                        slice.get_unchecked_mut(0) as *mut $elem_ty;
+                    assert!(
+                        target_ptr.align_offset(::mem::align_of::<Self>())
+                            == 0
+                    );
                     self.store_aligned_unchecked(slice);
                 }
             }
@@ -28,7 +32,7 @@ macro_rules! impl_load_store {
             /// If `slice.len() < Self::lanes()`.
             #[inline]
             pub fn store_unaligned(self, slice: &mut [$elem_ty]) {
-                use ::slice::SliceExt;
+                use slice::SliceExt;
                 unsafe {
                     assert!(slice.len() >= $elem_count);
                     self.store_unaligned_unchecked(slice);
@@ -44,12 +48,11 @@ macro_rules! impl_load_store {
             /// undefined.
             #[inline]
             pub unsafe fn store_aligned_unchecked(
-                self,
-                slice: &mut [$elem_ty]
-
+                self, slice: &mut [$elem_ty]
             ) {
-                use ::slice::SliceExt;
-                *(slice.get_unchecked_mut(0) as *mut $elem_ty as *mut Self) = self;
+                use slice::SliceExt;
+                *(slice.get_unchecked_mut(0) as *mut $elem_ty as *mut Self) =
+                    self;
             }
 
             /// Writes the values of the vector to the `slice`.
@@ -59,13 +62,17 @@ macro_rules! impl_load_store {
             /// If `slice.len() < Self::lanes()` the behavior is undefined.
             #[inline]
             pub unsafe fn store_unaligned_unchecked(
-                self,
-                slice: &mut [$elem_ty]
+                self, slice: &mut [$elem_ty]
             ) {
-                use ::slice::SliceExt;
-                let target_ptr = slice.get_unchecked_mut(0) as *mut $elem_ty as *mut u8;
+                use slice::SliceExt;
+                let target_ptr =
+                    slice.get_unchecked_mut(0) as *mut $elem_ty as *mut u8;
                 let self_ptr = &self as *const Self as *const u8;
-                ::ptr::copy_nonoverlapping(self_ptr, target_ptr, ::mem::size_of::<Self>());
+                ::ptr::copy_nonoverlapping(
+                    self_ptr,
+                    target_ptr,
+                    ::mem::size_of::<Self>(),
+                );
             }
 
             /// Instantiates a new vector with the values of the `slice`.
@@ -77,10 +84,13 @@ macro_rules! impl_load_store {
             #[inline]
             pub fn load_aligned(slice: &[$elem_ty]) -> Self {
                 unsafe {
-                    use ::slice::SliceExt;
+                    use slice::SliceExt;
                     assert!(slice.len() >= $elem_count);
                     let target_ptr = slice.get_unchecked(0) as *const $elem_ty;
-                    assert!(target_ptr.align_offset(::mem::align_of::<Self>()) == 0);
+                    assert!(
+                        target_ptr.align_offset(::mem::align_of::<Self>())
+                            == 0
+                    );
                     Self::load_aligned_unchecked(slice)
                 }
             }
@@ -92,7 +102,7 @@ macro_rules! impl_load_store {
             /// If `slice.len() < Self::lanes()`.
             #[inline]
             pub fn load_unaligned(slice: &[$elem_ty]) -> Self {
-                use ::slice::SliceExt;
+                use slice::SliceExt;
                 unsafe {
                     assert!(slice.len() >= $elem_count);
                     Self::load_unaligned_unchecked(slice)
@@ -107,7 +117,7 @@ macro_rules! impl_load_store {
             /// to an `align_of::<Self>()` boundary, the behavior is undefined.
             #[inline]
             pub unsafe fn load_aligned_unchecked(slice: &[$elem_ty]) -> Self {
-                use ::slice::SliceExt;
+                use slice::SliceExt;
                 *(slice.get_unchecked(0) as *const $elem_ty as *const Self)
             }
 
@@ -117,26 +127,33 @@ macro_rules! impl_load_store {
             ///
             /// If `slice.len() < Self::lanes()` the behavior is undefined.
             #[inline]
-            pub unsafe fn load_unaligned_unchecked(slice: &[$elem_ty]) -> Self {
-                use ::slice::SliceExt;
-                use ::mem::size_of;
-                let target_ptr = slice.get_unchecked(0) as *const $elem_ty as *const u8;
+            pub unsafe fn load_unaligned_unchecked(
+                slice: &[$elem_ty]
+            ) -> Self {
+                use slice::SliceExt;
+                use mem::size_of;
+                let target_ptr =
+                    slice.get_unchecked(0) as *const $elem_ty as *const u8;
                 let mut x = Self::splat(0 as $elem_ty);
                 let self_ptr = &mut x as *mut Self as *mut u8;
-                ::ptr::copy_nonoverlapping(target_ptr,self_ptr,size_of::<Self>());
+                ::ptr::copy_nonoverlapping(
+                    target_ptr,
+                    self_ptr,
+                    size_of::<Self>(),
+                );
                 x
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_load_store {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn store_unaligned() {
-            use ::coresimd::simd::$id;
-            use ::std::iter::Iterator;
+            use coresimd::simd::$id;
+            use std::iter::Iterator;
             let mut unaligned = [0 as $elem_ty; $id::lanes() + 1];
             let vec = $id::splat(42 as $elem_ty);
             vec.store_unaligned(&mut unaligned[1..]);
@@ -152,7 +169,7 @@ macro_rules! test_load_store {
         #[test]
         #[should_panic]
         fn store_unaligned_fail() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let mut unaligned = [0 as $elem_ty; $id::lanes() + 1];
             let vec = $id::splat(42 as $elem_ty);
             vec.store_unaligned(&mut unaligned[2..]);
@@ -160,8 +177,8 @@ macro_rules! test_load_store {
 
         #[test]
         fn load_unaligned() {
-            use ::coresimd::simd::$id;
-            use ::std::iter::Iterator;
+            use coresimd::simd::$id;
+            use std::iter::Iterator;
             let mut unaligned = [42 as $elem_ty; $id::lanes() + 1];
             unaligned[0] = 0 as $elem_ty;
             let vec = $id::load_unaligned(&unaligned[1..]);
@@ -177,7 +194,7 @@ macro_rules! test_load_store {
         #[test]
         #[should_panic]
         fn load_unaligned_fail() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let mut unaligned = [42 as $elem_ty; $id::lanes() + 1];
             unaligned[0] = 0 as $elem_ty;
             let _vec = $id::load_unaligned(&unaligned[2..]);
@@ -190,9 +207,11 @@ macro_rules! test_load_store {
 
         #[test]
         fn store_aligned() {
-            use ::coresimd::simd::$id;
-            use ::std::iter::Iterator;
-            let mut aligned = A { data: [0 as $elem_ty; 2 * $id::lanes()] };
+            use coresimd::simd::$id;
+            use std::iter::Iterator;
+            let mut aligned = A {
+                data: [0 as $elem_ty; 2 * $id::lanes()],
+            };
             let vec = $id::splat(42 as $elem_ty);
             unsafe { vec.store_aligned(&mut aligned.data[$id::lanes()..]) };
             for (index, &b) in unsafe { aligned.data.iter().enumerate() } {
@@ -207,25 +226,32 @@ macro_rules! test_load_store {
         #[test]
         #[should_panic]
         fn store_aligned_fail_lanes() {
-            use ::coresimd::simd::$id;
-            let mut aligned = A { data: [0 as $elem_ty; 2 * $id::lanes()] };
+            use coresimd::simd::$id;
+            let mut aligned = A {
+                data: [0 as $elem_ty; 2 * $id::lanes()],
+            };
             let vec = $id::splat(42 as $elem_ty);
-            unsafe { vec.store_aligned(&mut aligned.data[2 * $id::lanes()..]) };
+            unsafe {
+                vec.store_aligned(&mut aligned.data[2 * $id::lanes()..])
+            };
         }
 
         #[test]
         #[should_panic]
         fn store_aligned_fail_align() {
             unsafe {
-                use ::coresimd::simd::$id;
-                use ::std::{slice, mem};
-                let mut aligned = A { data: [0 as $elem_ty; 2 * $id::lanes()] };
+                use coresimd::simd::$id;
+                use std::{mem, slice};
+                let mut aligned = A {
+                    data: [0 as $elem_ty; 2 * $id::lanes()],
+                };
                 // offset the aligned data by one byte:
-                let s: &mut [u8; 2 * $id::lanes() * mem::size_of::<$elem_ty>()]
-                    = mem::transmute(&mut aligned.data);
+                let s: &mut [u8; 2 * $id::lanes()
+                                * mem::size_of::<$elem_ty>()] =
+                    mem::transmute(&mut aligned.data);
                 let s: &mut [$elem_ty] = slice::from_raw_parts_mut(
                     s.get_unchecked_mut(1) as *mut u8 as *mut $elem_ty,
-                    $id::lanes()
+                    $id::lanes(),
                 );
                 let vec = $id::splat(42 as $elem_ty);
                 vec.store_aligned(s);
@@ -234,14 +260,19 @@ macro_rules! test_load_store {
 
         #[test]
         fn load_aligned() {
-            use ::coresimd::simd::$id;
-            use ::std::iter::Iterator;
-            let mut aligned = A { data: [0 as $elem_ty; 2 * $id::lanes()] };
-            for i in $id::lanes()..(2*$id::lanes()) {
-                unsafe { aligned.data[i]  = 42 as $elem_ty; }
+            use coresimd::simd::$id;
+            use std::iter::Iterator;
+            let mut aligned = A {
+                data: [0 as $elem_ty; 2 * $id::lanes()],
+            };
+            for i in $id::lanes()..(2 * $id::lanes()) {
+                unsafe {
+                    aligned.data[i] = 42 as $elem_ty;
+                }
             }
 
-            let vec = unsafe { $id::load_aligned(&aligned.data[$id::lanes()..]) };
+            let vec =
+                unsafe { $id::load_aligned(&aligned.data[$id::lanes()..]) };
             for (index, &b) in unsafe { aligned.data.iter().enumerate() } {
                 if index < $id::lanes() {
                     assert_eq!(b, 0 as $elem_ty);
@@ -254,27 +285,34 @@ macro_rules! test_load_store {
         #[test]
         #[should_panic]
         fn load_aligned_fail_lanes() {
-            use ::coresimd::simd::$id;
-            let aligned = A { data: [0 as $elem_ty; 2 * $id::lanes()] };
-            let _vec = unsafe { $id::load_aligned(&aligned.data[2 * $id::lanes()..]) };
+            use coresimd::simd::$id;
+            let aligned = A {
+                data: [0 as $elem_ty; 2 * $id::lanes()],
+            };
+            let _vec = unsafe {
+                $id::load_aligned(&aligned.data[2 * $id::lanes()..])
+            };
         }
 
         #[test]
         #[should_panic]
         fn load_aligned_fail_align() {
             unsafe {
-                use ::coresimd::simd::$id;
-                use ::std::{slice, mem};
-                let aligned = A { data: [0 as $elem_ty; 2 * $id::lanes()] };
+                use coresimd::simd::$id;
+                use std::{mem, slice};
+                let aligned = A {
+                    data: [0 as $elem_ty; 2 * $id::lanes()],
+                };
                 // offset the aligned data by one byte:
-                let s: &[u8; 2 * $id::lanes() * mem::size_of::<$elem_ty>()]
-                    = mem::transmute(&aligned.data);
+                let s: &[u8; 2 * $id::lanes()
+                            * mem::size_of::<$elem_ty>()] =
+                    mem::transmute(&aligned.data);
                 let s: &[$elem_ty] = slice::from_raw_parts(
                     s.get_unchecked(1) as *const u8 as *const $elem_ty,
-                    $id::lanes()
+                    $id::lanes(),
                 );
-                let _vec =  $id::load_aligned(s);
+                let _vec = $id::load_aligned(s);
             }
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/minimal.rs
+++ b/coresimd/ppsv/api/minimal.rs
@@ -92,10 +92,10 @@ macro_rules! impl_minimal {
 
 #[cfg(test)]
 macro_rules! test_minimal {
-    ($id:ident, $elem_ty:ident, $elem_count:expr) => {
+    ($id: ident, $elem_ty: ident, $elem_count: expr) => {
         #[test]
         fn minimal() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             // TODO: test new
 
             // lanes:
@@ -130,7 +130,7 @@ macro_rules! test_minimal {
         #[test]
         #[should_panic]
         fn minimal_extract_panic_on_out_of_bounds() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             const VAL: $elem_ty = 7 as $elem_ty;
             const VEC: $id = $id::splat(VAL);
             let _ = VEC.extract($id::lanes());
@@ -138,10 +138,10 @@ macro_rules! test_minimal {
         #[test]
         #[should_panic]
         fn minimal_replace_panic_on_out_of_bounds() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             const VAL: $elem_ty = 7 as $elem_ty;
             const VEC: $id = $id::splat(VAL);
             let _ = VEC.replace($id::lanes(), 42 as $elem_ty);
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/minmax_reductions.rs
+++ b/coresimd/ppsv/api/minmax_reductions.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_minmax_reductions {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl $id {
             /// Largest vector value.
             ///
@@ -10,10 +10,8 @@ macro_rules! impl_minmax_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn max(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_max;
-                unsafe {
-                    simd_reduce_max(self)
-                }
+                use coresimd::simd_llvm::simd_reduce_max;
+                unsafe { simd_reduce_max(self) }
             }
             /// Largest vector value.
             ///
@@ -24,8 +22,8 @@ macro_rules! impl_minmax_reductions {
             pub fn max(self) -> $elem_ty {
                 // FIXME: broken on AArch64
                 // https://bugs.llvm.org/show_bug.cgi?id=36796
-                use ::num::Float;
-                use ::cmp::Ord;
+                use num::Float;
+                use cmp::Ord;
                 let mut x = self.extract(0);
                 for i in 1..$id::lanes() {
                     x = x.max(self.extract(i));
@@ -39,10 +37,8 @@ macro_rules! impl_minmax_reductions {
             #[cfg(not(target_arch = "aarch64"))]
             #[inline]
             pub fn min(self) -> $elem_ty {
-                use ::coresimd::simd_llvm::simd_reduce_min;
-                unsafe {
-                    simd_reduce_min(self)
-                }
+                use coresimd::simd_llvm::simd_reduce_min;
+                unsafe { simd_reduce_min(self) }
             }
             /// Smallest vector value.
             ///
@@ -53,8 +49,8 @@ macro_rules! impl_minmax_reductions {
             pub fn min(self) -> $elem_ty {
                 // FIXME: broken on AArch64
                 // https://bugs.llvm.org/show_bug.cgi?id=36796
-                use ::num::Float;
-                use ::cmp::Ord;
+                use num::Float;
+                use cmp::Ord;
                 let mut x = self.extract(0);
                 for i in 1..$id::lanes() {
                     x = x.min(self.extract(i));
@@ -62,15 +58,15 @@ macro_rules! impl_minmax_reductions {
                 x
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_minmax_reductions {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn max() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let v = $id::splat(0 as $elem_ty);
             assert_eq!(v.max(), 0 as $elem_ty);
             let v = v.replace(1, 1 as $elem_ty);
@@ -81,7 +77,7 @@ macro_rules! test_minmax_reductions {
 
         #[test]
         fn min() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let v = $id::splat(0 as $elem_ty);
             assert_eq!(v.min(), 0 as $elem_ty);
             let v = v.replace(1, 1 as $elem_ty);
@@ -93,5 +89,5 @@ macro_rules! test_minmax_reductions {
             let v = v.replace(1, 1 as $elem_ty);
             assert_eq!(v.min(), 1 as $elem_ty);
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/neg.rs
+++ b/coresimd/ppsv/api/neg.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_neg_op {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl ::ops::Neg for $id {
             type Output = Self;
             #[inline]
@@ -15,10 +15,10 @@ macro_rules! impl_neg_op {
 
 #[cfg(test)]
 macro_rules! test_neg_op {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn neg() {
-            use ::coresimd::simd::$id;
+            use coresimd::simd::$id;
             let z = $id::splat(0 as $elem_ty);
             let o = $id::splat(1 as $elem_ty);
             let t = $id::splat(2 as $elem_ty);

--- a/coresimd/ppsv/api/partial_eq.rs
+++ b/coresimd/ppsv/api/partial_eq.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_partial_eq {
-    ($id:ident) => {
+    ($id: ident) => {
         impl ::cmp::PartialEq<$id> for $id {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
@@ -13,15 +13,15 @@ macro_rules! impl_partial_eq {
                 $id::ne(*self, *other).all()
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_partial_eq {
-    ($id:ident, $true:expr, $false:expr) => {
+    ($id: ident, $true: expr, $false: expr) => {
         #[test]
         fn partial_eq() {
-            use ::coresimd::simd::*;
+            use coresimd::simd::*;
 
             let a = $id::splat($false);
             let b = $id::splat($true);
@@ -31,5 +31,5 @@ macro_rules! test_partial_eq {
             assert!(a == a);
             assert!(!(a != a));
         }
-    }
+    };
 }

--- a/coresimd/ppsv/api/scalar_shifts.rs
+++ b/coresimd/ppsv/api/scalar_shifts.rs
@@ -39,13 +39,22 @@ macro_rules! impl_shifts {
 }
 
 macro_rules! impl_all_scalar_shifts {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl_shifts!(
-            $id, $elem_ty,
-            u8, u16, u32, u64, usize,
-            i8, i16, i32, i64, isize);
-
-    }
+            $id,
+            $elem_ty,
+            u8,
+            u16,
+            u32,
+            u64,
+            usize,
+            i8,
+            i16,
+            i32,
+            i64,
+            isize
+        );
+    };
 }
 
 #[cfg(test)]
@@ -114,10 +123,20 @@ macro_rules! test_shift_ops {
 
 #[cfg(test)]
 macro_rules! test_all_scalar_shift_ops {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         test_shift_ops!(
-            $id, $elem_ty,
-            u8, u16, u32, u64, usize,
-            i8, i16, i32, i64, isize);
-    }
+            $id,
+            $elem_ty,
+            u8,
+            u16,
+            u32,
+            u64,
+            usize,
+            i8,
+            i16,
+            i32,
+            i64,
+            isize
+        );
+    };
 }

--- a/coresimd/ppsv/api/shifts.rs
+++ b/coresimd/ppsv/api/shifts.rs
@@ -2,14 +2,14 @@
 #![allow(unused)]
 
 macro_rules! impl_vector_shifts {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         impl ::ops::Shl<$id> for $id {
             type Output = Self;
             #[inline]
             fn shl(self, other: Self) -> Self {
                 use coresimd::simd_llvm::simd_shl;
                 unsafe { simd_shl(self, other) }
-                }
+            }
         }
         impl ::ops::Shr<$id> for $id {
             type Output = Self;
@@ -31,22 +31,23 @@ macro_rules! impl_vector_shifts {
                 *self = *self >> other;
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
 macro_rules! test_vector_shift_ops {
-    ($id:ident, $elem_ty:ident) => {
+    ($id: ident, $elem_ty: ident) => {
         #[test]
         fn shift_ops() {
-            use ::coresimd::simd::$id;
-            use ::std::mem;
+            use coresimd::simd::$id;
+            use std::mem;
             let z = $id::splat(0 as $elem_ty);
             let o = $id::splat(1 as $elem_ty);
             let t = $id::splat(2 as $elem_ty);
             let f = $id::splat(4 as $elem_ty);
 
-            let max = $id::splat((mem::size_of::<$elem_ty>() * 8 - 1) as $elem_ty);
+            let max =
+                $id::splat((mem::size_of::<$elem_ty>() * 8 - 1) as $elem_ty);
 
             // shr
             assert_eq!(z >> z, z);
@@ -77,12 +78,14 @@ macro_rules! test_vector_shift_ops {
             assert_eq!(o << t, f);
             assert_eq!(t << o, f);
 
-            {  // shr_assign
+            {
+                // shr_assign
                 let mut v = o;
                 v >>= o;
                 assert_eq!(v, z);
             }
-            {  // shl_assign
+            {
+                // shl_assign
                 let mut v = o;
                 v <<= o;
                 assert_eq!(v, t);

--- a/coresimd/ppsv/v128.rs
+++ b/coresimd/ppsv/v128.rs
@@ -84,10 +84,10 @@ use coresimd::arch::x86::{__m128, __m128d, __m128i};
 use coresimd::arch::x86_64::{__m128, __m128d, __m128i};
 
 macro_rules! from_bits_x86 {
-    ($id:ident, $elem_ty:ident, $test_mod:ident) => {
+    ($id: ident, $elem_ty: ident, $test_mod: ident) => {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         impl_from_bits_!($id: __m128, __m128i, __m128d);
-    }
+    };
 }
 
 #[cfg(all(target_arch = "arm", target_feature = "v7"))]
@@ -159,7 +159,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(u64x2, u64, u64x2_from_bits_x86);
-from_bits_arm!(u64x2, u64, u64x2_from_bits_arm, u64x2_from_bits_aarch64);
+from_bits_arm!(
+    u64x2,
+    u64,
+    u64x2_from_bits_arm,
+    u64x2_from_bits_aarch64
+);
 
 impl_from_bits!(
     i64x2: i64,
@@ -176,7 +181,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(i64x2, i64, i64x2_from_bits_x86);
-from_bits_arm!(i64x2, i64, i64x2_from_bits_arm, i64x2_from_bits_aarch64);
+from_bits_arm!(
+    i64x2,
+    i64,
+    i64x2_from_bits_arm,
+    i64x2_from_bits_aarch64
+);
 
 impl_from_bits!(
     f64x2: f64,
@@ -193,7 +203,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(f64x2, f64, f64x2_from_bits_x86);
-from_bits_arm!(f64x2, f64, f64x2_from_bits_arm, f64x2_from_bits_aarch64);
+from_bits_arm!(
+    f64x2,
+    f64,
+    f64x2_from_bits_arm,
+    f64x2_from_bits_aarch64
+);
 
 impl_from_bits!(
     u32x4: u32,
@@ -210,7 +225,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(u32x4, u32, u32x4_from_bits_x86);
-from_bits_arm!(u32x4, u32, u32x4_from_bits_arm, u32x4_from_bits_aarch64);
+from_bits_arm!(
+    u32x4,
+    u32,
+    u32x4_from_bits_arm,
+    u32x4_from_bits_aarch64
+);
 
 impl_from_bits!(
     i32x4: i32,
@@ -227,7 +247,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(i32x4, i32, i32x4_from_bits_x86);
-from_bits_arm!(i32x4, i32, i32x4_from_bits_arm, i32x4_from_bits_aarch64);
+from_bits_arm!(
+    i32x4,
+    i32,
+    i32x4_from_bits_arm,
+    i32x4_from_bits_aarch64
+);
 
 impl_from_bits!(
     f32x4: f32,
@@ -244,7 +269,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(f32x4, f32, f32x4_from_bits_x86);
-from_bits_arm!(f32x4, f32, f32x4_from_bits_arm, f32x4_from_bits_aarch64);
+from_bits_arm!(
+    f32x4,
+    f32,
+    f32x4_from_bits_arm,
+    f32x4_from_bits_aarch64
+);
 
 impl_from_bits!(
     u16x8: u16,
@@ -261,7 +291,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(u16x8, u16, u16x8_from_bits_x86);
-from_bits_arm!(u16x8, u16, u16x8_from_bits_arm, u16x8_from_bits_aarch64);
+from_bits_arm!(
+    u16x8,
+    u16,
+    u16x8_from_bits_arm,
+    u16x8_from_bits_aarch64
+);
 
 impl_from_bits!(
     i16x8: i16,
@@ -278,7 +313,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(i16x8, i16, i16x8_from_bits_x86);
-from_bits_arm!(i16x8, i16, i16x8_from_bits_arm, i16x8_from_bits_aarch64);
+from_bits_arm!(
+    i16x8,
+    i16,
+    i16x8_from_bits_arm,
+    i16x8_from_bits_aarch64
+);
 
 impl_from_bits!(
     u8x16: u8,
@@ -295,7 +335,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(u8x16, u8, u8x16_from_bits_x86);
-from_bits_arm!(u8x16, u8, u8x16_from_bits_arm, u8x16_from_bits_aarch64);
+from_bits_arm!(
+    u8x16,
+    u8,
+    u8x16_from_bits_arm,
+    u8x16_from_bits_aarch64
+);
 
 impl_from_bits!(
     i8x16: i8,
@@ -312,7 +357,12 @@ impl_from_bits!(
     b8x16
 );
 from_bits_x86!(i8x16, i8, i8x16_from_bits_x86);
-from_bits_arm!(i8x16, i8, i8x16_from_bits_arm, i8x16_from_bits_aarch64);
+from_bits_arm!(
+    i8x16,
+    i8,
+    i8x16_from_bits_arm,
+    i8x16_from_bits_aarch64
+);
 
 impl_from!(
     f64x2: f64,

--- a/coresimd/ppsv/v256.rs
+++ b/coresimd/ppsv/v256.rs
@@ -100,10 +100,10 @@ use coresimd::arch::x86::{__m256, __m256d, __m256i};
 use coresimd::arch::x86_64::{__m256, __m256d, __m256i};
 
 macro_rules! from_bits_x86 {
-    ($id:ident, $elem_ty:ident, $test_mod:ident) => {
+    ($id: ident, $elem_ty: ident, $test_mod: ident) => {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         impl_from_bits_!($id: __m256, __m256i, __m256d);
-    }
+    };
 }
 
 impl_from_bits!(
@@ -364,5 +364,17 @@ impl_from!(
     u8x16,
     i8x16
 );
-impl_from!(i8x32: i8, i8x32_from, test_v256 | u16x32, i16x32, u8x32);
-impl_from!(u8x32: u8, u8x32_from, test_v256 | u16x32, i16x32, i8x32);
+impl_from!(
+    i8x32: i8,
+    i8x32_from,
+    test_v256 | u16x32,
+    i16x32,
+    u8x32
+);
+impl_from!(
+    u8x32: u8,
+    u8x32_from,
+    test_v256 | u16x32,
+    i16x32,
+    i8x32
+);

--- a/coresimd/ppsv/v512.rs
+++ b/coresimd/ppsv/v512.rs
@@ -337,8 +337,20 @@ impl_from!(
     i8x16
 );
 
-impl_from!(i16x32: i16, i16x32_from, test_v512 | u16x32, u8x32, i8x32);
-impl_from!(u16x32: u16, u16x32_from, test_v512 | i16x32, u8x32, i8x32);
+impl_from!(
+    i16x32: i16,
+    i16x32_from,
+    test_v512 | u16x32,
+    u8x32,
+    i8x32
+);
+impl_from!(
+    u16x32: u16,
+    u16x32_from,
+    test_v512 | i16x32,
+    u8x32,
+    i8x32
+);
 
 impl_from!(i8x64: i8, i8x64_from, test_v512 | u8x64);
 impl_from!(u8x64: u8, u8x64_from, test_v512 | i8x64);

--- a/coresimd/ppsv/v64.rs
+++ b/coresimd/ppsv/v64.rs
@@ -64,10 +64,10 @@ use coresimd::arch::x86::__m64;
 use coresimd::arch::x86_64::__m64;
 
 macro_rules! from_bits_x86 {
-    ($id:ident, $elem_ty:ident, $test_mod:ident) => {
+    ($id: ident, $elem_ty: ident, $test_mod: ident) => {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         impl_from_bits_!($id: __m64);
-    }
+    };
 }
 
 #[cfg(all(target_arch = "arm", target_feature = "v7"))]
@@ -136,7 +136,12 @@ impl_from_bits!(
     b8x8
 );
 from_bits_x86!(u32x2, u32, u32x2_from_bits_x86);
-from_bits_arm!(u32x2, u32, u32x2_from_bits_arm, u32x2_from_bits_aarch64);
+from_bits_arm!(
+    u32x2,
+    u32,
+    u32x2_from_bits_arm,
+    u32x2_from_bits_aarch64
+);
 
 impl_from_bits!(
     i32x2: i32,
@@ -150,7 +155,12 @@ impl_from_bits!(
     b8x8
 );
 from_bits_x86!(i32x2, i32, i32x2_from_bits_x86);
-from_bits_arm!(i32x2, i32, i32x2_from_bits_arm, i32x2_from_bits_aarch64);
+from_bits_arm!(
+    i32x2,
+    i32,
+    i32x2_from_bits_arm,
+    i32x2_from_bits_aarch64
+);
 
 impl_from_bits!(
     f32x2: f32,
@@ -164,7 +174,12 @@ impl_from_bits!(
     b8x8
 );
 from_bits_x86!(f32x2, f32, f32x2_from_bits_x86);
-from_bits_arm!(f32x2, f32, f32x2_from_bits_arm, f32x2_from_bits_aarch64);
+from_bits_arm!(
+    f32x2,
+    f32,
+    f32x2_from_bits_arm,
+    f32x2_from_bits_aarch64
+);
 
 impl_from_bits!(
     u16x4: u16,
@@ -177,7 +192,12 @@ impl_from_bits!(
     b8x8
 );
 from_bits_x86!(u16x4, u16, u16x4_from_bits_x86);
-from_bits_arm!(u16x4, u16, u16x4_from_bits_arm, u16x4_from_bits_aarch64);
+from_bits_arm!(
+    u16x4,
+    u16,
+    u16x4_from_bits_arm,
+    u16x4_from_bits_aarch64
+);
 
 impl_from_bits!(
     i16x4: i16,
@@ -190,7 +210,12 @@ impl_from_bits!(
     b8x8
 );
 from_bits_x86!(i16x4, i16, i16x4_from_bits_x86);
-from_bits_arm!(i16x4, i16, i16x4_from_bits_arm, i16x4_from_bits_aarch64);
+from_bits_arm!(
+    i16x4,
+    i16,
+    i16x4_from_bits_arm,
+    i16x4_from_bits_aarch64
+);
 
 impl_from_bits!(
     u8x8: u8,
@@ -203,7 +228,12 @@ impl_from_bits!(
     b8x8
 );
 from_bits_x86!(u8x8, u8, u8x8_from_bits_x86);
-from_bits_arm!(u8x8, u8, u8x8_from_bits_arm, u8x8_from_bits_aarch64);
+from_bits_arm!(
+    u8x8,
+    u8,
+    u8x8_from_bits_arm,
+    u8x8_from_bits_aarch64
+);
 
 impl_from_bits!(
     i8x8: i8,
@@ -216,7 +246,12 @@ impl_from_bits!(
     b8x8
 );
 from_bits_x86!(i8x8, i8, i8x8_from_bits_x86);
-from_bits_arm!(i8x8, i8, i8x8_from_bits_arm, i8x8_from_bits_aarch64);
+from_bits_arm!(
+    i8x8,
+    i8,
+    i8x8_from_bits_arm,
+    i8x8_from_bits_aarch64
+);
 
 impl_from!(
     f32x2: f32,

--- a/coresimd/x86/aes.rs
+++ b/coresimd/x86/aes.rs
@@ -79,7 +79,9 @@ pub unsafe fn _mm_aesimc_si128(a: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_aeskeygenassist_si128(a: __m128i, imm8: i32) -> __m128i {
     macro_rules! call {
-        ($imm8:expr) => (aeskeygenassist(a, $imm8))
+        ($imm8: expr) => {
+            aeskeygenassist(a, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }

--- a/coresimd/x86/avx.rs
+++ b/coresimd/x86/avx.rs
@@ -99,33 +99,33 @@ pub unsafe fn _mm256_or_ps(a: __m256, b: __m256) -> __m256 {
 pub unsafe fn _mm256_shuffle_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
             simd_shuffle4(a, b, [$a, $b, $c, $d]);
-        }
+        };
     }
     macro_rules! shuffle3 {
-        ($a:expr, $b: expr, $c: expr) => {
+        ($a: expr, $b: expr, $c: expr) => {
             match (imm8 >> 3) & 0x1 {
                 0 => shuffle4!($a, $b, $c, 6),
                 _ => shuffle4!($a, $b, $c, 7),
             }
-        }
+        };
     }
     macro_rules! shuffle2 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match (imm8 >> 2) & 0x1 {
                 0 => shuffle3!($a, $b, 2),
                 _ => shuffle3!($a, $b, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle1 {
-        ($a:expr) => {
+        ($a: expr) => {
             match (imm8 >> 1) & 0x1 {
                 0 => shuffle2!($a, 4),
                 _ => shuffle2!($a, 5),
             }
-        }
+        };
     }
     match imm8 & 0x1 {
         0 => shuffle1!(0),
@@ -147,34 +147,34 @@ pub unsafe fn _mm256_shuffle_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
         }
     }
     macro_rules! shuffle3 {
-        ($a:expr, $b: expr, $c: expr, $e:expr, $f:expr, $g:expr) => {
+        ($a: expr, $b: expr, $c: expr, $e: expr, $f: expr, $g: expr) => {
             match (imm8 >> 6) & 0x3 {
                 0 => shuffle4!($a, $b, $c, 8, $e, $f, $g, 12),
                 1 => shuffle4!($a, $b, $c, 9, $e, $f, $g, 13),
                 2 => shuffle4!($a, $b, $c, 10, $e, $f, $g, 14),
                 _ => shuffle4!($a, $b, $c, 11, $e, $f, $g, 15),
             }
-        }
+        };
     }
     macro_rules! shuffle2 {
-        ($a:expr, $b:expr, $e:expr, $f:expr) => {
+        ($a: expr, $b: expr, $e: expr, $f: expr) => {
             match (imm8 >> 4) & 0x3 {
                 0 => shuffle3!($a, $b, 8, $e, $f, 12),
                 1 => shuffle3!($a, $b, 9, $e, $f, 13),
                 2 => shuffle3!($a, $b, 10, $e, $f, 14),
                 _ => shuffle3!($a, $b, 11, $e, $f, 15),
             }
-        }
+        };
     }
     macro_rules! shuffle1 {
-        ($a:expr, $e:expr) => {
+        ($a: expr, $e: expr) => {
             match (imm8 >> 2) & 0x3 {
                 0 => shuffle2!($a, 0, $e, 4),
                 1 => shuffle2!($a, 1, $e, 5),
                 2 => shuffle2!($a, 2, $e, 6),
                 _ => shuffle2!($a, 3, $e, 7),
             }
-        }
+        };
     }
     match imm8 & 0x3 {
         0 => shuffle1!(0, 4),
@@ -334,7 +334,9 @@ pub unsafe fn _mm256_div_pd(a: __m256d, b: __m256d) -> __m256d {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm256_round_pd(a: __m256d, b: i32) -> __m256d {
     macro_rules! call {
-        ($imm8:expr) => { roundpd256(a, $imm8) }
+        ($imm8: expr) => {
+            roundpd256(a, $imm8)
+        };
     }
     constify_imm8!(b, call)
 }
@@ -374,9 +376,9 @@ pub unsafe fn _mm256_floor_pd(a: __m256d) -> __m256d {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm256_round_ps(a: __m256, b: i32) -> __m256 {
     macro_rules! call {
-        ($imm8:expr) => {
+        ($imm8: expr) => {
             roundps256(a, $imm8)
-        }
+        };
     }
     constify_imm8!(b, call)
 }
@@ -426,33 +428,33 @@ pub unsafe fn _mm256_sqrt_pd(a: __m256d) -> __m256d {
 pub unsafe fn _mm256_blend_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! blend4 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
             simd_shuffle4(a, b, [$a, $b, $c, $d]);
-        }
+        };
     }
     macro_rules! blend3 {
-        ($a:expr, $b: expr, $c: expr) => {
+        ($a: expr, $b: expr, $c: expr) => {
             match imm8 & 0x8 {
                 0 => blend4!($a, $b, $c, 3),
                 _ => blend4!($a, $b, $c, 7),
             }
-        }
+        };
     }
     macro_rules! blend2 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match imm8 & 0x4 {
                 0 => blend3!($a, $b, 2),
                 _ => blend3!($a, $b, 6),
             }
-        }
+        };
     }
     macro_rules! blend1 {
-        ($a:expr) => {
+        ($a: expr) => {
             match imm8 & 0x2 {
                 0 => blend2!($a, 1),
                 _ => blend2!($a, 5),
             }
-        }
+        };
     }
     match imm8 & 0x1 {
         0 => blend1!(0),
@@ -474,34 +476,34 @@ pub unsafe fn _mm256_blend_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
         }
     }
     macro_rules! blend3 {
-        ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr, $e: expr, $f: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => blend4!($a, $b, $c, $d, $e, $f, 6, 7),
                 0b01 => blend4!($a, $b, $c, $d, $e, $f, 14, 7),
                 0b10 => blend4!($a, $b, $c, $d, $e, $f, 6, 15),
                 _ => blend4!($a, $b, $c, $d, $e, $f, 14, 15),
             }
-        }
+        };
     }
     macro_rules! blend2 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => blend3!($a, $b, $c, $d, 4, 5),
                 0b01 => blend3!($a, $b, $c, $d, 12, 5),
                 0b10 => blend3!($a, $b, $c, $d, 4, 13),
                 _ => blend3!($a, $b, $c, $d, 12, 13),
             }
-        }
+        };
     }
     macro_rules! blend1 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => blend2!($a, $b, 2, 3),
                 0b01 => blend2!($a, $b, 10, 3),
                 0b10 => blend2!($a, $b, 2, 11),
                 _ => blend2!($a, $b, 10, 11),
             }
-        }
+        };
     }
     match imm8 & 0b11 {
         0b00 => blend1!(0, 1),
@@ -539,7 +541,9 @@ pub unsafe fn _mm256_blendv_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm256_dp_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
     macro_rules! call {
-        ($imm8:expr) => { vdpps(a, b, $imm8) }
+        ($imm8: expr) => {
+            vdpps(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -687,7 +691,9 @@ pub const _CMP_TRUE_US: i32 = 0x1f;
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_cmp_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
     macro_rules! call {
-        ($imm8:expr) => { vcmppd(a, b, $imm8) }
+        ($imm8: expr) => {
+            vcmppd(a, b, $imm8)
+        };
     }
     constify_imm6!(imm8, call)
 }
@@ -701,7 +707,9 @@ pub unsafe fn _mm_cmp_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm256_cmp_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     macro_rules! call {
-        ($imm8:expr) => { vcmppd256(a, b, $imm8) }
+        ($imm8: expr) => {
+            vcmppd256(a, b, $imm8)
+        };
     }
     constify_imm6!(imm8, call)
 }
@@ -715,7 +723,9 @@ pub unsafe fn _mm256_cmp_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_cmp_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
-        ($imm8:expr) => { vcmpps(a, b, $imm8) }
+        ($imm8: expr) => {
+            vcmpps(a, b, $imm8)
+        };
     }
     constify_imm6!(imm8, call)
 }
@@ -729,7 +739,9 @@ pub unsafe fn _mm_cmp_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm256_cmp_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
     macro_rules! call {
-        ($imm8:expr) => { vcmpps256(a, b, $imm8) }
+        ($imm8: expr) => {
+            vcmpps256(a, b, $imm8)
+        };
     }
     constify_imm6!(imm8, call)
 }
@@ -745,7 +757,9 @@ pub unsafe fn _mm256_cmp_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_cmp_sd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
     macro_rules! call {
-        ($imm8:expr) => { vcmpsd(a, b, $imm8) }
+        ($imm8: expr) => {
+            vcmpsd(a, b, $imm8)
+        };
     }
     constify_imm6!(imm8, call)
 }
@@ -761,7 +775,9 @@ pub unsafe fn _mm_cmp_sd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_cmp_ss(a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
-        ($imm8:expr) => { vcmpss(a, b, $imm8) }
+        ($imm8: expr) => {
+            vcmpss(a, b, $imm8)
+        };
     }
     constify_imm6!(imm8, call)
 }
@@ -922,41 +938,43 @@ pub unsafe fn _mm_permutevar_ps(a: __m128, b: __m128i) -> __m128 {
 pub unsafe fn _mm256_permute_ps(a: __m256, imm8: i32) -> __m256 {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
-            simd_shuffle8(a, _mm256_undefined_ps(), [
-                $a, $b, $c, $d, $a + 4, $b + 4, $c + 4, $d + 4
-            ])
-        }
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+            simd_shuffle8(
+                a,
+                _mm256_undefined_ps(),
+                [$a, $b, $c, $d, $a + 4, $b + 4, $c + 4, $d + 4],
+            )
+        };
     }
     macro_rules! shuffle3 {
-        ($a:expr, $b:expr, $c:expr) => {
+        ($a: expr, $b: expr, $c: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle4!($a, $b, $c, 0),
                 0b01 => shuffle4!($a, $b, $c, 1),
                 0b10 => shuffle4!($a, $b, $c, 2),
                 _ => shuffle4!($a, $b, $c, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle2 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle3!($a, $b, 0),
                 0b01 => shuffle3!($a, $b, 1),
                 0b10 => shuffle3!($a, $b, 2),
                 _ => shuffle3!($a, $b, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle1 {
-        ($a:expr) => {
+        ($a: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle2!($a, 0),
                 0b01 => shuffle2!($a, 1),
                 0b10 => shuffle2!($a, 2),
                 _ => shuffle2!($a, 3),
             }
-        }
+        };
     }
     match imm8 & 0b11 {
         0b00 => shuffle1!(0),
@@ -975,41 +993,39 @@ pub unsafe fn _mm256_permute_ps(a: __m256, imm8: i32) -> __m256 {
 pub unsafe fn _mm_permute_ps(a: __m128, imm8: i32) -> __m128 {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
-            simd_shuffle4(a, _mm_undefined_ps(), [
-                $a, $b, $c, $d
-            ])
-        }
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+            simd_shuffle4(a, _mm_undefined_ps(), [$a, $b, $c, $d])
+        };
     }
     macro_rules! shuffle3 {
-        ($a:expr, $b:expr, $c:expr) => {
+        ($a: expr, $b: expr, $c: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle4!($a, $b, $c, 0),
                 0b01 => shuffle4!($a, $b, $c, 1),
                 0b10 => shuffle4!($a, $b, $c, 2),
                 _ => shuffle4!($a, $b, $c, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle2 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle3!($a, $b, 0),
                 0b01 => shuffle3!($a, $b, 1),
                 0b10 => shuffle3!($a, $b, 2),
                 _ => shuffle3!($a, $b, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle1 {
-        ($a:expr) => {
+        ($a: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle2!($a, 0),
                 0b01 => shuffle2!($a, 1),
                 0b10 => shuffle2!($a, 2),
                 _ => shuffle2!($a, 3),
             }
-        }
+        };
     }
     match imm8 & 0b11 {
         0b00 => shuffle1!(0),
@@ -1046,33 +1062,33 @@ pub unsafe fn _mm_permutevar_pd(a: __m128d, b: __m128i) -> __m128d {
 pub unsafe fn _mm256_permute_pd(a: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
             simd_shuffle4(a, _mm256_undefined_pd(), [$a, $b, $c, $d]);
-        }
+        };
     }
     macro_rules! shuffle3 {
-        ($a:expr, $b: expr, $c: expr) => {
+        ($a: expr, $b: expr, $c: expr) => {
             match (imm8 >> 3) & 0x1 {
                 0 => shuffle4!($a, $b, $c, 2),
                 _ => shuffle4!($a, $b, $c, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle2 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match (imm8 >> 2) & 0x1 {
                 0 => shuffle3!($a, $b, 2),
                 _ => shuffle3!($a, $b, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle1 {
-        ($a:expr) => {
+        ($a: expr) => {
             match (imm8 >> 1) & 0x1 {
                 0 => shuffle2!($a, 0),
                 _ => shuffle2!($a, 1),
             }
-        }
+        };
     }
     match imm8 & 0x1 {
         0 => shuffle1!(0),
@@ -1089,17 +1105,17 @@ pub unsafe fn _mm256_permute_pd(a: __m256d, imm8: i32) -> __m256d {
 pub unsafe fn _mm_permute_pd(a: __m128d, imm8: i32) -> __m128d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle2 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             simd_shuffle2(a, _mm_undefined_pd(), [$a, $b]);
-        }
+        };
     }
     macro_rules! shuffle1 {
-        ($a:expr) => {
+        ($a: expr) => {
             match (imm8 >> 1) & 0x1 {
                 0 => shuffle2!($a, 0),
                 _ => shuffle2!($a, 1),
             }
-        }
+        };
     }
     match imm8 & 0x1 {
         0 => shuffle1!(0),
@@ -1117,7 +1133,9 @@ pub unsafe fn _mm256_permute2f128_ps(
     a: __m256, b: __m256, imm8: i32
 ) -> __m256 {
     macro_rules! call {
-        ($imm8:expr) => { vperm2f128ps256(a, b, $imm8) }
+        ($imm8: expr) => {
+            vperm2f128ps256(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -1132,7 +1150,9 @@ pub unsafe fn _mm256_permute2f128_pd(
     a: __m256d, b: __m256d, imm8: i32
 ) -> __m256d {
     macro_rules! call {
-        ($imm8:expr) => { vperm2f128pd256(a, b, $imm8) }
+        ($imm8: expr) => {
+            vperm2f128pd256(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -1149,7 +1169,9 @@ pub unsafe fn _mm256_permute2f128_si256(
     let a = a.as_i32x8();
     let b = b.as_i32x8();
     macro_rules! call {
-        ($imm8:expr) => { vperm2f128si256(a, b, $imm8) }
+        ($imm8: expr) => {
+            vperm2f128si256(a, b, $imm8)
+        };
     }
     let r = constify_imm8!(imm8, call);
     mem::transmute(r)
@@ -1255,7 +1277,11 @@ pub unsafe fn _mm256_insertf128_si256(
 // This intrinsic has no corresponding instruction.
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm256_insert_epi8(a: __m256i, i: i8, index: i32) -> __m256i {
-    mem::transmute(simd_insert(a.as_i8x32(), (index as u32) & 31, i))
+    mem::transmute(simd_insert(
+        a.as_i8x32(),
+        (index as u32) & 31,
+        i,
+    ))
 }
 
 /// Copy `a` to result, and insert the 16-bit integer `i` into result
@@ -1265,7 +1291,11 @@ pub unsafe fn _mm256_insert_epi8(a: __m256i, i: i8, index: i32) -> __m256i {
 // This intrinsic has no corresponding instruction.
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm256_insert_epi16(a: __m256i, i: i16, index: i32) -> __m256i {
-    mem::transmute(simd_insert(a.as_i16x16(), (index as u32) & 15, i))
+    mem::transmute(simd_insert(
+        a.as_i16x16(),
+        (index as u32) & 15,
+        i,
+    ))
 }
 
 /// Copy `a` to result, and insert the 32-bit integer `i` into result
@@ -2868,11 +2898,20 @@ mod tests {
         let a = _mm256_setr_ps(1., 4., 5., 8., 9., 12., 13., 16.);
         let b = _mm256_setr_ps(2., 3., 6., 7., 10., 11., 14., 15.);
         let r = _mm256_blend_ps(a, b, 0x0);
-        assert_eq_m256(r, _mm256_setr_ps(1., 4., 5., 8., 9., 12., 13., 16.));
+        assert_eq_m256(
+            r,
+            _mm256_setr_ps(1., 4., 5., 8., 9., 12., 13., 16.),
+        );
         let r = _mm256_blend_ps(a, b, 0x3);
-        assert_eq_m256(r, _mm256_setr_ps(2., 3., 5., 8., 9., 12., 13., 16.));
+        assert_eq_m256(
+            r,
+            _mm256_setr_ps(2., 3., 5., 8., 9., 12., 13., 16.),
+        );
         let r = _mm256_blend_ps(a, b, 0xF);
-        assert_eq_m256(r, _mm256_setr_ps(2., 3., 6., 7., 9., 12., 13., 16.));
+        assert_eq_m256(
+            r,
+            _mm256_setr_ps(2., 3., 6., 7., 9., 12., 13., 16.),
+        );
     }
 
     #[simd_test = "avx"]
@@ -2903,8 +2942,16 @@ mod tests {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let r = _mm256_dp_ps(a, b, 0xFF);
-        let e =
-            _mm256_setr_ps(200., 200., 200., 200., 2387., 2387., 2387., 2387.);
+        let e = _mm256_setr_ps(
+            200.,
+            200.,
+            200.,
+            200.,
+            2387.,
+            2387.,
+            2387.,
+            2387.,
+        );
         assert_eq_m256(r, e);
     }
 
@@ -3585,7 +3632,9 @@ mod tests {
             pub data: [f64; 4],
         }
         let a = _mm256_set1_pd(7.0);
-        let mut mem = Memory { data: [-1.0; 4] };
+        let mut mem = Memory {
+            data: [-1.0; 4],
+        };
 
         _mm256_stream_pd(&mut mem.data[0] as *mut f64, a);
         for i in 0..4 {
@@ -3600,7 +3649,9 @@ mod tests {
             pub data: [f32; 8],
         }
         let a = _mm256_set1_ps(7.0);
-        let mut mem = Memory { data: [-1.0; 8] };
+        let mut mem = Memory {
+            data: [-1.0; 8],
+        };
 
         _mm256_stream_ps(&mut mem.data[0] as *mut f32, a);
         for i in 0..8 {
@@ -3881,7 +3932,10 @@ mod tests {
     #[simd_test = "avx"]
     unsafe fn test_mm256_set_ps() {
         let r = _mm256_set_ps(1., 2., 3., 4., 5., 6., 7., 8.);
-        assert_eq_m256(r, _mm256_setr_ps(8., 7., 6., 5., 4., 3., 2., 1.));
+        assert_eq_m256(
+            r,
+            _mm256_setr_ps(8., 7., 6., 5., 4., 3., 2., 1.),
+        );
     }
 
     #[simd_test = "avx"]
@@ -3939,7 +3993,10 @@ mod tests {
     #[simd_test = "avx"]
     unsafe fn test_mm256_setr_ps() {
         let r = _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.);
-        assert_eq_m256(r, _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.));
+        assert_eq_m256(
+            r,
+            _mm256_setr_ps(1., 2., 3., 4., 5., 6., 7., 8.),
+        );
     }
 
     #[simd_test = "avx"]

--- a/coresimd/x86/avx2.rs
+++ b/coresimd/x86/avx2.rs
@@ -330,19 +330,19 @@ pub unsafe fn _mm_blend_epi32(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i32x4();
     let b = b.as_i32x4();
     macro_rules! blend2 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
             simd_shuffle4(a, b, [$a, $b, $c, $d]);
-        }
+        };
     }
     macro_rules! blend1 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => blend2!($a, $b, 2, 3),
                 0b01 => blend2!($a, $b, 6, 3),
                 0b10 => blend2!($a, $b, 2, 7),
                 _ => blend2!($a, $b, 6, 7),
             }
-        }
+        };
     }
     let r: i32x4 = match imm8 & 0b11 {
         0b00 => blend1!(0, 1),
@@ -370,34 +370,34 @@ pub unsafe fn _mm256_blend_epi32(
         }
     }
     macro_rules! blend3 {
-        ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr, $e: expr, $f: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => blend4!($a, $b, $c, $d, $e, $f, 6, 7),
                 0b01 => blend4!($a, $b, $c, $d, $e, $f, 14, 7),
                 0b10 => blend4!($a, $b, $c, $d, $e, $f, 6, 15),
                 _ => blend4!($a, $b, $c, $d, $e, $f, 14, 15),
             }
-        }
+        };
     }
     macro_rules! blend2 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => blend3!($a, $b, $c, $d, 4, 5),
                 0b01 => blend3!($a, $b, $c, $d, 12, 5),
                 0b10 => blend3!($a, $b, $c, $d, 4, 13),
                 _ => blend3!($a, $b, $c, $d, 12, 13),
             }
-        }
+        };
     }
     macro_rules! blend1 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => blend2!($a, $b, 2, 3),
                 0b01 => blend2!($a, $b, 10, 3),
                 0b10 => blend2!($a, $b, 2, 11),
                 _ => blend2!($a, $b, 10, 11),
             }
-        }
+        };
     }
     let r: i32x8 = match imm8 & 0b11 {
         0b00 => blend1!(0, 1),
@@ -447,14 +447,14 @@ pub unsafe fn _mm256_blend_epi16(
         }
     }
     macro_rules! blend1 {
-        ($a1:expr, $b1:expr, $a2:expr, $b2:expr) => {
+        ($a1: expr, $b1: expr, $a2: expr, $b2: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => blend2!($a1, $b1, 2, 3, $a2, $b2, 10, 11),
                 0b01 => blend2!($a1, $b1, 18, 3, $a2, $b2, 26, 11),
                 0b10 => blend2!($a1, $b1, 2, 19, $a2, $b2, 10, 27),
                 _ => blend2!($a1, $b1, 18, 19, $a2, $b2, 26, 27),
             }
-        }
+        };
     }
     let r: i16x16 = match imm8 & 0b11 {
         0b00 => blend1!(0, 1, 8, 9),
@@ -472,7 +472,11 @@ pub unsafe fn _mm256_blend_epi16(
 pub unsafe fn _mm256_blendv_epi8(
     a: __m256i, b: __m256i, mask: __m256i
 ) -> __m256i {
-    mem::transmute(pblendvb(a.as_i8x32(), b.as_i8x32(), mask.as_i8x32()))
+    mem::transmute(pblendvb(
+        a.as_i8x32(),
+        b.as_i8x32(),
+        mask.as_i8x32(),
+    ))
 }
 
 /// Broadcast the low packed 8-bit integer from `a` to all elements of
@@ -873,7 +877,9 @@ pub unsafe fn _mm_i32gather_epi32(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherdd(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            pgatherdd(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -896,7 +902,9 @@ pub unsafe fn _mm_mask_i32gather_epi32(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherdd(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            pgatherdd(src, slice, offsets, mask, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -917,7 +925,9 @@ pub unsafe fn _mm256_i32gather_epi32(
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherdd(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            vpgatherdd(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -940,7 +950,9 @@ pub unsafe fn _mm256_mask_i32gather_epi32(
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherdd(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            vpgatherdd(src, slice, offsets, mask, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -961,7 +973,9 @@ pub unsafe fn _mm_i32gather_ps(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherdps(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            pgatherdps(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -980,7 +994,9 @@ pub unsafe fn _mm_mask_i32gather_ps(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherdps(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            pgatherdps(src, slice, offsets, mask, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1000,7 +1016,9 @@ pub unsafe fn _mm256_i32gather_ps(
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherdps(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            vpgatherdps(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1019,7 +1037,9 @@ pub unsafe fn _mm256_mask_i32gather_ps(
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherdps(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            vpgatherdps(src, slice, offsets, mask, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1039,7 +1059,9 @@ pub unsafe fn _mm_i32gather_epi64(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherdq(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            pgatherdq(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1062,7 +1084,9 @@ pub unsafe fn _mm_mask_i32gather_epi64(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherdq(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            pgatherdq(src, slice, offsets, mask, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1083,7 +1107,9 @@ pub unsafe fn _mm256_i32gather_epi64(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherdq(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            vpgatherdq(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1106,7 +1132,9 @@ pub unsafe fn _mm256_mask_i32gather_epi64(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherdq(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            vpgatherdq(src, slice, offsets, mask, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1127,7 +1155,9 @@ pub unsafe fn _mm_i32gather_pd(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherdpd(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            pgatherdpd(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1147,7 +1177,9 @@ pub unsafe fn _mm_mask_i32gather_pd(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherdpd(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            pgatherdpd(src, slice, offsets, mask, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1167,7 +1199,9 @@ pub unsafe fn _mm256_i32gather_pd(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherdpd(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            vpgatherdpd(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1187,7 +1221,9 @@ pub unsafe fn _mm256_mask_i32gather_pd(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherdpd(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            vpgatherdpd(src, slice, offsets, mask, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1207,7 +1243,9 @@ pub unsafe fn _mm_i64gather_epi32(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherqd(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            pgatherqd(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1230,7 +1268,9 @@ pub unsafe fn _mm_mask_i64gather_epi32(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherqd(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            pgatherqd(src, slice, offsets, mask, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1251,7 +1291,9 @@ pub unsafe fn _mm256_i64gather_epi32(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherqd(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            vpgatherqd(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1274,7 +1316,9 @@ pub unsafe fn _mm256_mask_i64gather_epi32(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherqd(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            vpgatherqd(src, slice, offsets, mask, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1295,7 +1339,9 @@ pub unsafe fn _mm_i64gather_ps(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherqps(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            pgatherqps(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1314,7 +1360,9 @@ pub unsafe fn _mm_mask_i64gather_ps(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherqps(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            pgatherqps(src, slice, offsets, mask, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1334,7 +1382,9 @@ pub unsafe fn _mm256_i64gather_ps(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherqps(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            vpgatherqps(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1353,7 +1403,9 @@ pub unsafe fn _mm256_mask_i64gather_ps(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherqps(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            vpgatherqps(src, slice, offsets, mask, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1373,7 +1425,9 @@ pub unsafe fn _mm_i64gather_epi64(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x2();
     macro_rules! call {
-        ($imm8:expr) => (pgatherqq(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            pgatherqq(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1396,7 +1450,9 @@ pub unsafe fn _mm_mask_i64gather_epi64(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (pgatherqq(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            pgatherqq(src, slice, offsets, mask, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1417,7 +1473,9 @@ pub unsafe fn _mm256_i64gather_epi64(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x4();
     macro_rules! call {
-        ($imm8:expr) => (vpgatherqq(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            vpgatherqq(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1440,7 +1498,9 @@ pub unsafe fn _mm256_mask_i64gather_epi64(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8:expr) => (vpgatherqq(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            vpgatherqq(src, slice, offsets, mask, $imm8)
+        };
     }
     let r = constify_imm8!(scale, call);
     mem::transmute(r)
@@ -1461,7 +1521,9 @@ pub unsafe fn _mm_i64gather_pd(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x2();
     macro_rules! call {
-        ($imm8:expr) => (pgatherqpd(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            pgatherqpd(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1481,7 +1543,9 @@ pub unsafe fn _mm_mask_i64gather_pd(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x2();
     macro_rules! call {
-        ($imm8:expr) => (pgatherqpd(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            pgatherqpd(src, slice, offsets, mask, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1501,7 +1565,9 @@ pub unsafe fn _mm256_i64gather_pd(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x4();
     macro_rules! call {
-        ($imm8:expr) => (vpgatherqpd(zero, slice, offsets, neg_one, $imm8))
+        ($imm8: expr) => {
+            vpgatherqpd(zero, slice, offsets, neg_one, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1521,7 +1587,9 @@ pub unsafe fn _mm256_mask_i64gather_pd(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x4();
     macro_rules! call {
-        ($imm8:expr) => (vpgatherqpd(src, slice, offsets, mask, $imm8))
+        ($imm8: expr) => {
+            vpgatherqpd(src, slice, offsets, mask, $imm8)
+        };
     }
     constify_imm8!(scale, call)
 }
@@ -1574,7 +1642,10 @@ pub unsafe fn _mm256_maddubs_epi16(a: __m256i, b: __m256i) -> __m256i {
 pub unsafe fn _mm_maskload_epi32(
     mem_addr: *const i32, mask: __m128i
 ) -> __m128i {
-    mem::transmute(maskloadd(mem_addr as *const i8, mask.as_i32x4()))
+    mem::transmute(maskloadd(
+        mem_addr as *const i8,
+        mask.as_i32x4(),
+    ))
 }
 
 /// Load packed 32-bit integers from memory pointed by `mem_addr` using `mask`
@@ -1586,7 +1657,10 @@ pub unsafe fn _mm_maskload_epi32(
 pub unsafe fn _mm256_maskload_epi32(
     mem_addr: *const i32, mask: __m256i
 ) -> __m256i {
-    mem::transmute(maskloadd256(mem_addr as *const i8, mask.as_i32x8()))
+    mem::transmute(maskloadd256(
+        mem_addr as *const i8,
+        mask.as_i32x8(),
+    ))
 }
 
 /// Load packed 64-bit integers from memory pointed by `mem_addr` using `mask`
@@ -1598,7 +1672,10 @@ pub unsafe fn _mm256_maskload_epi32(
 pub unsafe fn _mm_maskload_epi64(
     mem_addr: *const i64, mask: __m128i
 ) -> __m128i {
-    mem::transmute(maskloadq(mem_addr as *const i8, mask.as_i64x2()))
+    mem::transmute(maskloadq(
+        mem_addr as *const i8,
+        mask.as_i64x2(),
+    ))
 }
 
 /// Load packed 64-bit integers from memory pointed by `mem_addr` using `mask`
@@ -1610,7 +1687,10 @@ pub unsafe fn _mm_maskload_epi64(
 pub unsafe fn _mm256_maskload_epi64(
     mem_addr: *const i64, mask: __m256i
 ) -> __m256i {
-    mem::transmute(maskloadq256(mem_addr as *const i8, mask.as_i64x4()))
+    mem::transmute(maskloadq256(
+        mem_addr as *const i8,
+        mask.as_i64x4(),
+    ))
 }
 
 /// Store packed 32-bit integers from `a` into memory pointed by `mem_addr`
@@ -1622,7 +1702,11 @@ pub unsafe fn _mm256_maskload_epi64(
 pub unsafe fn _mm_maskstore_epi32(
     mem_addr: *mut i32, mask: __m128i, a: __m128i
 ) {
-    maskstored(mem_addr as *mut i8, mask.as_i32x4(), a.as_i32x4())
+    maskstored(
+        mem_addr as *mut i8,
+        mask.as_i32x4(),
+        a.as_i32x4(),
+    )
 }
 
 /// Store packed 32-bit integers from `a` into memory pointed by `mem_addr`
@@ -1634,7 +1718,11 @@ pub unsafe fn _mm_maskstore_epi32(
 pub unsafe fn _mm256_maskstore_epi32(
     mem_addr: *mut i32, mask: __m256i, a: __m256i
 ) {
-    maskstored256(mem_addr as *mut i8, mask.as_i32x8(), a.as_i32x8())
+    maskstored256(
+        mem_addr as *mut i8,
+        mask.as_i32x8(),
+        a.as_i32x8(),
+    )
 }
 
 /// Store packed 64-bit integers from `a` into memory pointed by `mem_addr`
@@ -1646,7 +1734,11 @@ pub unsafe fn _mm256_maskstore_epi32(
 pub unsafe fn _mm_maskstore_epi64(
     mem_addr: *mut i64, mask: __m128i, a: __m128i
 ) {
-    maskstoreq(mem_addr as *mut i8, mask.as_i64x2(), a.as_i64x2())
+    maskstoreq(
+        mem_addr as *mut i8,
+        mask.as_i64x2(),
+        a.as_i64x2(),
+    )
 }
 
 /// Store packed 64-bit integers from `a` into memory pointed by `mem_addr`
@@ -1658,7 +1750,11 @@ pub unsafe fn _mm_maskstore_epi64(
 pub unsafe fn _mm256_maskstore_epi64(
     mem_addr: *mut i64, mask: __m256i, a: __m256i
 ) {
-    maskstoreq256(mem_addr as *mut i8, mask.as_i64x4(), a.as_i64x4())
+    maskstoreq256(
+        mem_addr as *mut i8,
+        mask.as_i64x4(),
+        a.as_i64x4(),
+    )
 }
 
 /// Compare packed 16-bit integers in `a` and `b`, and return the packed
@@ -1795,7 +1891,9 @@ pub unsafe fn _mm256_mpsadbw_epu8(
     let a = a.as_u8x32();
     let b = b.as_u8x32();
     macro_rules! call {
-        ($imm8:expr) => (mpsadbw(a, b, $imm8))
+        ($imm8: expr) => {
+            mpsadbw(a, b, $imm8)
+        };
     }
     let r = constify_imm8!(imm8, call);
     mem::transmute(r)
@@ -1940,39 +2038,39 @@ pub unsafe fn _mm256_permute4x64_epi64(a: __m256i, imm8: i32) -> __m256i {
     let zero = _mm256_setzero_si256().as_i64x4();
     let a = a.as_i64x4();
     macro_rules! permute4 {
-        ($a:expr, $b:expr, $c:expr, $d:expr) => {
+        ($a: expr, $b: expr, $c: expr, $d: expr) => {
             simd_shuffle4(a, zero, [$a, $b, $c, $d]);
-        }
+        };
     }
     macro_rules! permute3 {
-        ($a:expr, $b:expr, $c:expr) => {
+        ($a: expr, $b: expr, $c: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => permute4!($a, $b, $c, 0),
                 0b01 => permute4!($a, $b, $c, 1),
                 0b10 => permute4!($a, $b, $c, 2),
                 _ => permute4!($a, $b, $c, 3),
             }
-        }
+        };
     }
     macro_rules! permute2 {
-        ($a:expr, $b:expr) => {
+        ($a: expr, $b: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => permute3!($a, $b, 0),
                 0b01 => permute3!($a, $b, 1),
                 0b10 => permute3!($a, $b, 2),
                 _ => permute3!($a, $b, 3),
             }
-        }
+        };
     }
     macro_rules! permute1 {
-        ($a:expr) => {
+        ($a: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => permute2!($a, 0),
                 0b01 => permute2!($a, 1),
                 0b10 => permute2!($a, 2),
                 _ => permute2!($a, 3),
             }
-        }
+        };
     }
     let r: i64x4 = match imm8 & 0b11 {
         0b00 => permute1!(0),
@@ -1994,9 +2092,9 @@ pub unsafe fn _mm256_permute2x128_si256(
     let a = a.as_i64x4();
     let b = b.as_i64x4();
     macro_rules! call {
-        ($imm8:expr) => {
+        ($imm8: expr) => {
             vperm2i128(a, b, $imm8)
-        }
+        };
     }
     mem::transmute(constify_imm8!(imm8, call))
 }
@@ -2011,39 +2109,39 @@ pub unsafe fn _mm256_permute4x64_pd(a: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     let undef = _mm256_undefined_pd();
     macro_rules! shuffle_done {
-        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
             simd_shuffle4(a, undef, [$x01, $x23, $x45, $x67])
-        }
+        };
     }
     macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
                 0b10 => shuffle_done!($x01, $x23, $x45, 2),
                 _ => shuffle_done!($x01, $x23, $x45, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
+        ($x01: expr, $x23: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
                 0b10 => shuffle_x67!($x01, $x23, 2),
                 _ => shuffle_x67!($x01, $x23, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x23 {
-        ($x01:expr) => {
+        ($x01: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
                 0b10 => shuffle_x45!($x01, 2),
                 _ => shuffle_x45!($x01, 3),
             }
-        }
+        };
     }
     match imm8 & 0b11 {
         0b00 => shuffle_x23!(0),
@@ -2161,39 +2259,52 @@ pub unsafe fn _mm256_shuffle_epi32(a: __m256i, imm8: i32) -> __m256i {
 
     let a = a.as_i32x8();
     macro_rules! shuffle_done {
-        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
-            simd_shuffle8(a, a, [$x01, $x23, $x45, $x67, 4+$x01, 4+$x23, 4+$x45, 4+$x67])
-        }
+        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
+            simd_shuffle8(
+                a,
+                a,
+                [
+                    $x01,
+                    $x23,
+                    $x45,
+                    $x67,
+                    4 + $x01,
+                    4 + $x23,
+                    4 + $x45,
+                    4 + $x67,
+                ],
+            )
+        };
     }
     macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
                 0b10 => shuffle_done!($x01, $x23, $x45, 2),
                 _ => shuffle_done!($x01, $x23, $x45, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
+        ($x01: expr, $x23: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
                 0b10 => shuffle_x67!($x01, $x23, 2),
                 _ => shuffle_x67!($x01, $x23, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x23 {
-        ($x01:expr) => {
+        ($x01: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
                 0b10 => shuffle_x45!($x01, 2),
                 _ => shuffle_x45!($x01, 3),
             }
-        }
+        };
     }
     let r: i32x8 = match imm8 & 0b11 {
         0b00 => shuffle_x23!(0),
@@ -2224,34 +2335,34 @@ pub unsafe fn _mm256_shufflehi_epi16(a: __m256i, imm8: i32) -> __m256i {
         }
     }
     macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
                 0b10 => shuffle_done!($x01, $x23, $x45, 2),
                 _ => shuffle_done!($x01, $x23, $x45, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
+        ($x01: expr, $x23: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
                 0b10 => shuffle_x67!($x01, $x23, 2),
                 _ => shuffle_x67!($x01, $x23, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x23 {
-        ($x01:expr) => {
+        ($x01: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
                 0b10 => shuffle_x45!($x01, 2),
                 _ => shuffle_x45!($x01, 3),
             }
-        }
+        };
     }
     let r: i16x16 = match imm8 & 0b11 {
         0b00 => shuffle_x23!(0),
@@ -2273,43 +2384,43 @@ pub unsafe fn _mm256_shufflelo_epi16(a: __m256i, imm8: i32) -> __m256i {
     let imm8 = (imm8 & 0xFF) as u8;
     let a = a.as_i16x16();
     macro_rules! shuffle_done {
-        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
             #[cfg_attr(rustfmt, rustfmt_skip)]
-            simd_shuffle16(a, a, [
-                0+$x01, 0+$x23, 0+$x45, 0+$x67, 4, 5, 6, 7,
-                8+$x01, 8+$x23, 8+$x45, 8+$x67, 12, 13, 14, 15,
-            ]);
-        }
+                        simd_shuffle16(a, a, [
+                            0+$x01, 0+$x23, 0+$x45, 0+$x67, 4, 5, 6, 7,
+                            8+$x01, 8+$x23, 8+$x45, 8+$x67, 12, 13, 14, 15,
+                        ]);
+        };
     }
     macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
                 0b10 => shuffle_done!($x01, $x23, $x45, 2),
                 _ => shuffle_done!($x01, $x23, $x45, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
+        ($x01: expr, $x23: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
                 0b10 => shuffle_x67!($x01, $x23, 2),
                 _ => shuffle_x67!($x01, $x23, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x23 {
-        ($x01:expr) => {
+        ($x01: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
                 0b10 => shuffle_x45!($x01, 2),
                 _ => shuffle_x45!($x01, 3),
             }
-        }
+        };
     }
     let r: i16x16 = match imm8 & 0b11 {
         0b00 => shuffle_x23!(0),
@@ -2412,9 +2523,9 @@ pub unsafe fn _mm256_slli_epi64(a: __m256i, imm8: i32) -> __m256i {
 pub unsafe fn _mm256_slli_si256(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! call {
-        ($imm8:expr) => {
+        ($imm8: expr) => {
             vpslldq(a, $imm8)
-        }
+        };
     }
     mem::transmute(constify_imm8!(imm8 * 8, call))
 }
@@ -2427,9 +2538,9 @@ pub unsafe fn _mm256_slli_si256(a: __m256i, imm8: i32) -> __m256i {
 pub unsafe fn _mm256_bslli_epi128(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! call {
-        ($imm8:expr) => {
+        ($imm8: expr) => {
             vpslldq(a, $imm8)
-        }
+        };
     }
     mem::transmute(constify_imm8!(imm8 * 8, call))
 }
@@ -2536,9 +2647,9 @@ pub unsafe fn _mm256_srav_epi32(a: __m256i, count: __m256i) -> __m256i {
 pub unsafe fn _mm256_srli_si256(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! call {
-        ($imm8:expr) => {
+        ($imm8: expr) => {
             vpsrldq(a, $imm8)
-        }
+        };
     }
     mem::transmute(constify_imm8!(imm8 * 8, call))
 }
@@ -2551,9 +2662,9 @@ pub unsafe fn _mm256_srli_si256(a: __m256i, imm8: i32) -> __m256i {
 pub unsafe fn _mm256_bsrli_epi128(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! call {
-        ($imm8:expr) => {
+        ($imm8: expr) => {
             vpsrldq(a, $imm8)
-        }
+        };
     }
     mem::transmute(constify_imm8!(imm8 * 8, call))
 }
@@ -2863,7 +2974,9 @@ pub unsafe fn _mm256_unpackhi_epi16(a: __m256i, b: __m256i) -> __m256i {
     let r: i16x16 = simd_shuffle16(
         a.as_i16x16(),
         b.as_i16x16(),
-        [4, 20, 5, 21, 6, 22, 7, 23, 12, 28, 13, 29, 14, 30, 15, 31],
+        [
+            4, 20, 5, 21, 6, 22, 7, 23, 12, 28, 13, 29, 14, 30, 15, 31
+        ],
     );
     mem::transmute(r)
 }
@@ -2911,7 +3024,9 @@ pub unsafe fn _mm256_unpacklo_epi16(a: __m256i, b: __m256i) -> __m256i {
     let r: i16x16 = simd_shuffle16(
         a.as_i16x16(),
         b.as_i16x16(),
-        [0, 16, 1, 17, 2, 18, 3, 19, 8, 24, 9, 25, 10, 26, 11, 27],
+        [
+            0, 16, 1, 17, 2, 18, 3, 19, 8, 24, 9, 25, 10, 26, 11, 27
+        ],
     );
     mem::transmute(r)
 }
@@ -3000,8 +3115,11 @@ pub unsafe fn _mm256_unpackhi_epi32(a: __m256i, b: __m256i) -> __m256i {
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vunpcklps))]
 pub unsafe fn _mm256_unpacklo_epi32(a: __m256i, b: __m256i) -> __m256i {
-    let r: i32x8 =
-        simd_shuffle8(a.as_i32x8(), b.as_i32x8(), [0, 8, 1, 9, 4, 12, 5, 13]);
+    let r: i32x8 = simd_shuffle8(
+        a.as_i32x8(),
+        b.as_i32x8(),
+        [0, 8, 1, 9, 4, 12, 5, 13],
+    );
     mem::transmute(r)
 }
 
@@ -3863,7 +3981,10 @@ mod tests {
             7, 6, 5, 4, 3, 2, 1, 0,
         );
         let r = _mm256_cmpeq_epi8(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi8(_mm256_set1_epi8(0), !0, 2));
+        assert_eq_m256i(
+            r,
+            _mm256_insert_epi8(_mm256_set1_epi8(0), !0, 2),
+        );
     }
 
     #[simd_test = "avx2"]
@@ -3879,7 +4000,10 @@ mod tests {
             7, 6, 5, 4, 3, 2, 1, 0,
         );
         let r = _mm256_cmpeq_epi16(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 2));
+        assert_eq_m256i(
+            r,
+            _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 2),
+        );
     }
 
     #[simd_test = "avx2"]
@@ -3897,7 +4021,10 @@ mod tests {
         let a = _mm256_setr_epi64x(0, 1, 2, 3);
         let b = _mm256_setr_epi64x(3, 2, 2, 0);
         let r = _mm256_cmpeq_epi64(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi64(_mm256_set1_epi64x(0), !0, 2));
+        assert_eq_m256i(
+            r,
+            _mm256_insert_epi64(_mm256_set1_epi64x(0), !0, 2),
+        );
     }
 
     #[simd_test = "avx2"]
@@ -3905,7 +4032,10 @@ mod tests {
         let a = _mm256_insert_epi8(_mm256_set1_epi8(0), 5, 0);
         let b = _mm256_set1_epi8(0);
         let r = _mm256_cmpgt_epi8(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi8(_mm256_set1_epi8(0), !0, 0));
+        assert_eq_m256i(
+            r,
+            _mm256_insert_epi8(_mm256_set1_epi8(0), !0, 0),
+        );
     }
 
     #[simd_test = "avx2"]
@@ -3913,7 +4043,10 @@ mod tests {
         let a = _mm256_insert_epi16(_mm256_set1_epi16(0), 5, 0);
         let b = _mm256_set1_epi16(0);
         let r = _mm256_cmpgt_epi16(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 0));
+        assert_eq_m256i(
+            r,
+            _mm256_insert_epi16(_mm256_set1_epi16(0), !0, 0),
+        );
     }
 
     #[simd_test = "avx2"]
@@ -3921,7 +4054,10 @@ mod tests {
         let a = _mm256_insert_epi32(_mm256_set1_epi32(0), 5, 0);
         let b = _mm256_set1_epi32(0);
         let r = _mm256_cmpgt_epi32(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi32(_mm256_set1_epi32(0), !0, 0));
+        assert_eq_m256i(
+            r,
+            _mm256_insert_epi32(_mm256_set1_epi32(0), !0, 0),
+        );
     }
 
     #[simd_test = "avx2"]
@@ -3929,7 +4065,10 @@ mod tests {
         let a = _mm256_insert_epi64(_mm256_set1_epi64x(0), 5, 0);
         let b = _mm256_set1_epi64x(0);
         let r = _mm256_cmpgt_epi64(a, b);
-        assert_eq_m256i(r, _mm256_insert_epi64(_mm256_set1_epi64x(0), !0, 0));
+        assert_eq_m256i(
+            r,
+            _mm256_insert_epi64(_mm256_set1_epi64x(0), !0, 0),
+        );
     }
 
     #[simd_test = "avx2"]
@@ -5121,7 +5260,16 @@ mod tests {
         );
         assert_eq_m256(
             r,
-            _mm256_setr_ps(0.0, 16.0, 64.0, 256.0, 256.0, 256.0, 256.0, 256.0),
+            _mm256_setr_ps(
+                0.0,
+                16.0,
+                64.0,
+                256.0,
+                256.0,
+                256.0,
+                256.0,
+                256.0,
+            ),
         );
     }
 

--- a/coresimd/x86/bmi.rs
+++ b/coresimd/x86/bmi.rs
@@ -18,7 +18,10 @@ use stdsimd_test::assert_instr;
 #[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(bextr))]
 pub unsafe fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
-    _bextr2_u32(a, (start & 0xff_u32) | ((len & 0xff_u32) << 8_u32))
+    _bextr2_u32(
+        a,
+        (start & 0xff_u32) | ((len & 0xff_u32) << 8_u32),
+    )
 }
 
 /// Extracts bits of `a` specified by `control` into

--- a/coresimd/x86/macros.rs
+++ b/coresimd/x86/macros.rs
@@ -1,7 +1,7 @@
 //! Utility macros.
 
 macro_rules! constify_imm8 {
-    ($imm8:expr, $expand:ident) => {
+    ($imm8: expr, $expand: ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b1111_1111 {
             0 => $expand!(0),
@@ -261,11 +261,11 @@ macro_rules! constify_imm8 {
             254 => $expand!(254),
             _ => $expand!(255),
         }
-    }
+    };
 }
 
 macro_rules! constify_imm6 {
-    ($imm8:expr, $expand:ident) => {
+    ($imm8: expr, $expand: ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b1_1111 {
             0 => $expand!(0),
@@ -301,11 +301,11 @@ macro_rules! constify_imm6 {
             30 => $expand!(30),
             _ => $expand!(31),
         }
-    }
+    };
 }
 
 macro_rules! constify_imm4 {
-    ($imm8:expr, $expand:ident) => {
+    ($imm8: expr, $expand: ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b1111 {
             0 => $expand!(0),
@@ -325,11 +325,11 @@ macro_rules! constify_imm4 {
             14 => $expand!(14),
             _ => $expand!(15),
         }
-    }
+    };
 }
 
 macro_rules! constify_imm3 {
-    ($imm8:expr, $expand:ident) => {
+    ($imm8: expr, $expand: ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b111 {
             0 => $expand!(0),
@@ -341,11 +341,11 @@ macro_rules! constify_imm3 {
             6 => $expand!(6),
             _ => $expand!(7),
         }
-    }
+    };
 }
 
 macro_rules! constify_imm2 {
-    ($imm8:expr, $expand:ident) => {
+    ($imm8: expr, $expand: ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b11 {
             0 => $expand!(0),
@@ -353,7 +353,7 @@ macro_rules! constify_imm2 {
             2 => $expand!(2),
             _ => $expand!(3),
         }
-    }
+    };
 }
 
 #[cfg(test)]

--- a/coresimd/x86/mmx.rs
+++ b/coresimd/x86/mmx.rs
@@ -514,8 +514,12 @@ mod tests {
             -30001,
             i16::max_value() - 1,
         );
-        let e =
-            _mm_setr_pi16(i16::min_value(), 30000, -30000, i16::max_value());
+        let e = _mm_setr_pi16(
+            i16::min_value(),
+            30000,
+            -30000,
+            i16::max_value(),
+        );
         assert_eq_m64(e, _mm_add_pi16(a, b));
         assert_eq_m64(e, _m_paddw(a, b));
     }
@@ -533,8 +537,16 @@ mod tests {
     unsafe fn test_mm_adds_pi8() {
         let a = _mm_setr_pi8(-100, -1, 1, 100, -1, 0, 1, 0);
         let b = _mm_setr_pi8(-100, 1, -1, 100, 0, -1, 0, 1);
-        let e =
-            _mm_setr_pi8(i8::min_value(), 0, 0, i8::max_value(), -1, -1, 1, 1);
+        let e = _mm_setr_pi8(
+            i8::min_value(),
+            0,
+            0,
+            i8::max_value(),
+            -1,
+            -1,
+            1,
+            1,
+        );
         assert_eq_m64(e, _mm_adds_pi8(a, b));
         assert_eq_m64(e, _m_paddsb(a, b));
     }

--- a/coresimd/x86/mod.rs
+++ b/coresimd/x86/mod.rs
@@ -443,7 +443,16 @@ use coresimd::simd::{b8x16, b8x32, b8x8, f32x2, f32x4, f32x8, f64x2, f64x4,
                      i8x16, i8x32, i8x8, u16x16, u16x4, u16x8, u32x2, u32x4,
                      u32x8, u64x2, u64x4, u8x16, u8x32, u8x8};
 
-impl_from_bits_!(__m64: u32x2, i32x2, f32x2, u16x4, i16x4, u8x8, i8x8, b8x8);
+impl_from_bits_!(
+    __m64: u32x2,
+    i32x2,
+    f32x2,
+    u16x4,
+    i16x4,
+    u8x8,
+    i8x8,
+    b8x8
+);
 impl_from_bits_!(
     __m128: u64x2,
     i64x2,

--- a/coresimd/x86/pclmulqdq.rs
+++ b/coresimd/x86/pclmulqdq.rs
@@ -38,7 +38,9 @@ pub unsafe fn _mm_clmulepi64_si128(
     a: __m128i, b: __m128i, imm8: i32
 ) -> __m128i {
     macro_rules! call {
-        ($imm8:expr) => (pclmulqdq(a, b, $imm8))
+        ($imm8: expr) => {
+            pclmulqdq(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }

--- a/coresimd/x86/sse.rs
+++ b/coresimd/x86/sse.rs
@@ -768,39 +768,39 @@ pub unsafe fn _mm_shuffle_ps(a: __m128, b: __m128, mask: u32) -> __m128 {
     let mask = (mask & 0xFF) as u8;
 
     macro_rules! shuffle_done {
-        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
             simd_shuffle4(a, b, [$x01, $x23, $x45, $x67])
-        }
+        };
     }
     macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr) => {
             match (mask >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 4),
                 0b01 => shuffle_done!($x01, $x23, $x45, 5),
                 0b10 => shuffle_done!($x01, $x23, $x45, 6),
                 _ => shuffle_done!($x01, $x23, $x45, 7),
             }
-        }
+        };
     }
     macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
+        ($x01: expr, $x23: expr) => {
             match (mask >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 4),
                 0b01 => shuffle_x67!($x01, $x23, 5),
                 0b10 => shuffle_x67!($x01, $x23, 6),
                 _ => shuffle_x67!($x01, $x23, 7),
             }
-        }
+        };
     }
     macro_rules! shuffle_x23 {
-        ($x01:expr) => {
+        ($x01: expr) => {
             match (mask >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
                 0b10 => shuffle_x45!($x01, 2),
                 _ => shuffle_x45!($x01, 3),
             }
-        }
+        };
     }
     match mask & 0b11 {
         0b00 => shuffle_x23!(0),
@@ -1524,8 +1524,8 @@ pub const _MM_HINT_NTA: i32 = 0;
 ///
 /// * [`_MM_HINT_T1`](constant._MM_HINT_T1.html): Fetch into L2 and higher.
 ///
-/// * [`_MM_HINT_T2`](constant._MM_HINT_T2.html): Fetch into L3 and higher or an
-///   implementation-specific choice (e.g., L2 if there is no L3).
+/// * [`_MM_HINT_T2`](constant._MM_HINT_T2.html): Fetch into L3 and higher or
+/// an   implementation-specific choice (e.g., L2 if there is no L3).
 ///
 /// * [`_MM_HINT_NTA`](constant._MM_HINT_NTA.html): Fetch data using the
 ///   non-temporal access (NTA) hint. It may be a place closer than main memory
@@ -1535,8 +1535,8 @@ pub const _MM_HINT_NTA: i32 = 0;
 /// The actual implementation depends on the particular CPU. This instruction
 /// is considered a hint, so the CPU is also free to simply ignore the request.
 ///
-/// The amount of prefetched data depends on the cache line size of the specific
-/// CPU, but it will be at least 32 bytes.
+/// The amount of prefetched data depends on the cache line size of the
+/// specific CPU, but it will be at least 32 bytes.
 ///
 /// Common caveats:
 ///
@@ -1564,14 +1564,14 @@ pub unsafe fn _mm_prefetch(p: *const i8, strategy: i32) {
     // We use the `llvm.prefetch` instrinsic with `rw` = 0 (read), and
     // `cache type` = 1 (data cache). `locality` is based on our `strategy`.
     macro_rules! pref {
-        ($imm8:expr) => {
+        ($imm8: expr) => {
             match $imm8 {
                 0 => prefetch(p, 0, 0, 1),
                 1 => prefetch(p, 0, 1, 1),
                 2 => prefetch(p, 0, 2, 1),
                 _ => prefetch(p, 0, 3, 1),
             }
-        }
+        };
     }
     pref!(strategy)
 }
@@ -2010,7 +2010,9 @@ pub unsafe fn _m_maskmovq(a: __m64, mask: __m64, mem_addr: *mut i8) {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_extract_pi16(a: __m64, imm2: i32) -> i32 {
     macro_rules! call {
-        ($imm2:expr) => { pextrw(a, $imm2) as i32 }
+        ($imm2: expr) => {
+            pextrw(a, $imm2) as i32
+        };
     }
     constify_imm2!(imm2, call)
 }
@@ -2023,7 +2025,9 @@ pub unsafe fn _mm_extract_pi16(a: __m64, imm2: i32) -> i32 {
 #[rustc_args_required_const(1)]
 pub unsafe fn _m_pextrw(a: __m64, imm2: i32) -> i32 {
     macro_rules! call {
-        ($imm2:expr) => { pextrw(a, $imm2) as i32 }
+        ($imm2: expr) => {
+            pextrw(a, $imm2) as i32
+        };
     }
     constify_imm2!(imm2, call)
 }
@@ -2037,7 +2041,9 @@ pub unsafe fn _m_pextrw(a: __m64, imm2: i32) -> i32 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_insert_pi16(a: __m64, d: i32, imm2: i32) -> __m64 {
     macro_rules! call {
-        ($imm2:expr) => { pinsrw(a, d, $imm2) }
+        ($imm2: expr) => {
+            pinsrw(a, d, $imm2)
+        };
     }
     constify_imm2!(imm2, call)
 }
@@ -2051,7 +2057,9 @@ pub unsafe fn _mm_insert_pi16(a: __m64, d: i32, imm2: i32) -> __m64 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _m_pinsrw(a: __m64, d: i32, imm2: i32) -> __m64 {
     macro_rules! call {
-        ($imm2:expr) => { pinsrw(a, d, $imm2) }
+        ($imm2: expr) => {
+            pinsrw(a, d, $imm2)
+        };
     }
     constify_imm2!(imm2, call)
 }
@@ -2084,7 +2092,9 @@ pub unsafe fn _m_pmovmskb(a: __m64) -> i32 {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_shuffle_pi16(a: __m64, imm8: i32) -> __m64 {
     macro_rules! call {
-        ($imm8:expr) => { pshufw(a, $imm8) }
+        ($imm8: expr) => {
+            pshufw(a, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -2097,7 +2107,9 @@ pub unsafe fn _mm_shuffle_pi16(a: __m64, imm8: i32) -> __m64 {
 #[rustc_args_required_const(1)]
 pub unsafe fn _m_pshufw(a: __m64, imm8: i32) -> __m64 {
     macro_rules! call {
-        ($imm8:expr) => { pshufw(a, $imm8) }
+        ($imm8: expr) => {
+            pshufw(a, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -2371,8 +2383,12 @@ mod tests {
 
         let b2 = _mm_setr_ps(1.0, 5.0, 6.0, 7.0);
         let r2: u32x4 = transmute(_mm_cmpeq_ss(a, b2));
-        let e2: u32x4 =
-            transmute(_mm_setr_ps(transmute(0xffffffffu32), 2.0, 3.0, 4.0));
+        let e2: u32x4 = transmute(_mm_setr_ps(
+            transmute(0xffffffffu32),
+            2.0,
+            3.0,
+            4.0,
+        ));
         assert_eq!(r2, e2);
     }
 
@@ -3086,9 +3102,22 @@ mod tests {
 
     #[simd_test = "sse"]
     unsafe fn test_mm_cvtss_si32() {
-        let inputs = &[42.0f32, -3.1, 4.0e10, 4.0e-20, NAN, 2147483500.1];
-        let result =
-            &[42i32, -3, i32::min_value(), 0, i32::min_value(), 2147483520];
+        let inputs = &[
+            42.0f32,
+            -3.1,
+            4.0e10,
+            4.0e-20,
+            NAN,
+            2147483500.1,
+        ];
+        let result = &[
+            42i32,
+            -3,
+            i32::min_value(),
+            0,
+            i32::min_value(),
+            2147483520,
+        ];
         for i in 0..inputs.len() {
             let x = _mm_setr_ps(inputs[i], 1.0, 3.0, 4.0);
             let e = result[i];
@@ -3292,8 +3321,10 @@ mod tests {
         }
 
         let r = _mm_load_ps(p);
-        let e =
-            _mm_add_ps(_mm_setr_ps(1.0, 2.0, 3.0, 4.0), _mm_set1_ps(fixup));
+        let e = _mm_add_ps(
+            _mm_setr_ps(1.0, 2.0, 3.0, 4.0),
+            _mm_set1_ps(fixup),
+        );
         assert_eq_m128(r, e);
     }
 
@@ -3323,8 +3354,10 @@ mod tests {
         }
 
         let r = _mm_loadr_ps(p);
-        let e =
-            _mm_add_ps(_mm_setr_ps(4.0, 3.0, 2.0, 1.0), _mm_set1_ps(fixup));
+        let e = _mm_add_ps(
+            _mm_setr_ps(4.0, 3.0, 2.0, 1.0),
+            _mm_set1_ps(fixup),
+        );
         assert_eq_m128(r, e);
     }
 
@@ -3563,7 +3596,9 @@ mod tests {
     #[simd_test = "sse"]
     unsafe fn test_mm_stream_ps() {
         let a = _mm_set1_ps(7.0);
-        let mut mem = Memory { data: [-1.0; 4] };
+        let mut mem = Memory {
+            data: [-1.0; 4],
+        };
 
         _mm_stream_ps(&mut mem.data[0] as *mut f32, a);
         for i in 0..4 {
@@ -3764,8 +3799,12 @@ mod tests {
 
     #[simd_test = "sse,mmx"]
     unsafe fn test_mm_movemask_pi8() {
-        let a =
-            _mm_setr_pi16(0b1000_0000, 0b0100_0000, 0b1000_0000, 0b0100_0000);
+        let a = _mm_setr_pi16(
+            0b1000_0000,
+            0b0100_0000,
+            0b1000_0000,
+            0b0100_0000,
+        );
         let r = _mm_movemask_pi8(a);
         assert_eq!(r, 0b10001);
 

--- a/coresimd/x86/sse2.rs
+++ b/coresimd/x86/sse2.rs
@@ -326,18 +326,30 @@ unsafe fn _mm_slli_si128_impl(a: __m128i, imm8: i32) -> __m128i {
     let (zero, imm8) = (_mm_set1_epi8(0).as_i8x16(), imm8 as u32);
     let a = a.as_i8x16();
     macro_rules! shuffle {
-        ($shift:expr) => {
-            simd_shuffle16::<i8x16, i8x16>(zero, a, [
-                16 - $shift, 17 - $shift,
-                18 - $shift, 19 - $shift,
-                20 - $shift, 21 - $shift,
-                22 - $shift, 23 - $shift,
-                24 - $shift, 25 - $shift,
-                26 - $shift, 27 - $shift,
-                28 - $shift, 29 - $shift,
-                30 - $shift, 31 - $shift,
-            ])
-        }
+        ($shift: expr) => {
+            simd_shuffle16::<i8x16, i8x16>(
+                zero,
+                a,
+                [
+                    16 - $shift,
+                    17 - $shift,
+                    18 - $shift,
+                    19 - $shift,
+                    20 - $shift,
+                    21 - $shift,
+                    22 - $shift,
+                    23 - $shift,
+                    24 - $shift,
+                    25 - $shift,
+                    26 - $shift,
+                    27 - $shift,
+                    28 - $shift,
+                    29 - $shift,
+                    30 - $shift,
+                    31 - $shift,
+                ],
+            )
+        };
     }
     let x = match imm8 {
         0 => shuffle!(0),
@@ -488,18 +500,30 @@ unsafe fn _mm_srli_si128_impl(a: __m128i, imm8: i32) -> __m128i {
     let (zero, imm8) = (_mm_set1_epi8(0).as_i8x16(), imm8 as u32);
     let a = a.as_i8x16();
     macro_rules! shuffle {
-        ($shift:expr) => {
-            simd_shuffle16(a, zero, [
-                0 + $shift, 1 + $shift,
-                2 + $shift, 3 + $shift,
-                4 + $shift, 5 + $shift,
-                6 + $shift, 7 + $shift,
-                8 + $shift, 9 + $shift,
-                10 + $shift, 11 + $shift,
-                12 + $shift, 13 + $shift,
-                14 + $shift, 15 + $shift,
-            ])
-        }
+        ($shift: expr) => {
+            simd_shuffle16(
+                a,
+                zero,
+                [
+                    0 + $shift,
+                    1 + $shift,
+                    2 + $shift,
+                    3 + $shift,
+                    4 + $shift,
+                    5 + $shift,
+                    6 + $shift,
+                    7 + $shift,
+                    8 + $shift,
+                    9 + $shift,
+                    10 + $shift,
+                    11 + $shift,
+                    12 + $shift,
+                    13 + $shift,
+                    14 + $shift,
+                    15 + $shift,
+                ],
+            )
+        };
     }
     let x: i8x16 = match imm8 {
         0 => shuffle!(0),
@@ -1023,7 +1047,11 @@ pub unsafe fn _mm_extract_epi16(a: __m128i, imm8: i32) -> i32 {
 #[cfg_attr(test, assert_instr(pinsrw, imm8 = 9))]
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_insert_epi16(a: __m128i, i: i32, imm8: i32) -> __m128i {
-    mem::transmute(simd_insert(a.as_i16x8(), (imm8 & 7) as u32, i as i16))
+    mem::transmute(simd_insert(
+        a.as_i16x8(),
+        (imm8 & 7) as u32,
+        i as i16,
+    ))
 }
 
 /// Return a mask of the most significant bit of each element in `a`.
@@ -1051,39 +1079,39 @@ pub unsafe fn _mm_shuffle_epi32(a: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i32x4();
 
     macro_rules! shuffle_done {
-        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
             simd_shuffle4(a, a, [$x01, $x23, $x45, $x67])
-        }
+        };
     }
     macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
                 0b10 => shuffle_done!($x01, $x23, $x45, 2),
                 _ => shuffle_done!($x01, $x23, $x45, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
+        ($x01: expr, $x23: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
                 0b10 => shuffle_x67!($x01, $x23, 2),
                 _ => shuffle_x67!($x01, $x23, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x23 {
-        ($x01:expr) => {
+        ($x01: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
                 0b10 => shuffle_x45!($x01, 2),
                 _ => shuffle_x45!($x01, 3),
             }
-        }
+        };
     }
     let x: i32x4 = match imm8 & 0b11 {
         0b00 => shuffle_x23!(0),
@@ -1108,41 +1136,52 @@ pub unsafe fn _mm_shufflehi_epi16(a: __m128i, imm8: i32) -> __m128i {
     let imm8 = (imm8 & 0xFF) as u8;
     let a = a.as_i16x8();
     macro_rules! shuffle_done {
-        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
-            simd_shuffle8(a, a, [
-                0, 1, 2, 3, $x01 + 4, $x23 + 4, $x45 + 4, $x67 + 4,
-            ])
-        }
+        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
+            simd_shuffle8(
+                a,
+                a,
+                [
+                    0,
+                    1,
+                    2,
+                    3,
+                    $x01 + 4,
+                    $x23 + 4,
+                    $x45 + 4,
+                    $x67 + 4,
+                ],
+            )
+        };
     }
     macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
                 0b10 => shuffle_done!($x01, $x23, $x45, 2),
                 _ => shuffle_done!($x01, $x23, $x45, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
+        ($x01: expr, $x23: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
                 0b10 => shuffle_x67!($x01, $x23, 2),
                 _ => shuffle_x67!($x01, $x23, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x23 {
-        ($x01:expr) => {
+        ($x01: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
                 0b10 => shuffle_x45!($x01, 2),
                 _ => shuffle_x45!($x01, 3),
             }
-        }
+        };
     }
     let x: i16x8 = match imm8 & 0b11 {
         0b00 => shuffle_x23!(0),
@@ -1168,39 +1207,39 @@ pub unsafe fn _mm_shufflelo_epi16(a: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i16x8();
 
     macro_rules! shuffle_done {
-        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
             simd_shuffle8(a, a, [$x01, $x23, $x45, $x67, 4, 5, 6, 7])
-        }
+        };
     }
     macro_rules! shuffle_x67 {
-        ($x01:expr, $x23:expr, $x45:expr) => {
+        ($x01: expr, $x23: expr, $x45: expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
                 0b10 => shuffle_done!($x01, $x23, $x45, 2),
                 _ => shuffle_done!($x01, $x23, $x45, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x45 {
-        ($x01:expr, $x23:expr) => {
+        ($x01: expr, $x23: expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
                 0b10 => shuffle_x67!($x01, $x23, 2),
                 _ => shuffle_x67!($x01, $x23, 3),
             }
-        }
+        };
     }
     macro_rules! shuffle_x23 {
-        ($x01:expr) => {
+        ($x01: expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
                 0b10 => shuffle_x45!($x01, 2),
                 _ => shuffle_x45!($x01, 3),
             }
-        }
+        };
     }
     let x: i16x8 = match imm8 & 0b11 {
         0b00 => shuffle_x23!(0),
@@ -1219,7 +1258,9 @@ pub unsafe fn _mm_unpackhi_epi8(a: __m128i, b: __m128i) -> __m128i {
     mem::transmute::<i8x16, _>(simd_shuffle16(
         a.as_i8x16(),
         b.as_i8x16(),
-        [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31],
+        [
+            8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31
+        ],
     ))
 }
 
@@ -1268,7 +1309,9 @@ pub unsafe fn _mm_unpacklo_epi8(a: __m128i, b: __m128i) -> __m128i {
     mem::transmute::<i8x16, _>(simd_shuffle16(
         a.as_i8x16(),
         b.as_i8x16(),
-        [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23],
+        [
+            0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23
+        ],
     ))
 }
 
@@ -1277,8 +1320,11 @@ pub unsafe fn _mm_unpacklo_epi8(a: __m128i, b: __m128i) -> __m128i {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpcklwd))]
 pub unsafe fn _mm_unpacklo_epi16(a: __m128i, b: __m128i) -> __m128i {
-    let x =
-        simd_shuffle8(a.as_i16x8(), b.as_i16x8(), [0, 8, 1, 9, 2, 10, 3, 11]);
+    let x = simd_shuffle8(
+        a.as_i16x8(),
+        b.as_i16x8(),
+        [0, 8, 1, 9, 2, 10, 3, 11],
+    );
     mem::transmute::<i16x8, _>(x)
 }
 
@@ -1505,7 +1551,11 @@ pub unsafe fn _mm_cmple_sd(a: __m128d, b: __m128d) -> __m128d {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpltsd))]
 pub unsafe fn _mm_cmpgt_sd(a: __m128d, b: __m128d) -> __m128d {
-    simd_insert(_mm_cmplt_sd(b, a), 1, simd_extract::<_, f64>(a, 1))
+    simd_insert(
+        _mm_cmplt_sd(b, a),
+        1,
+        simd_extract::<_, f64>(a, 1),
+    )
 }
 
 /// Return a new vector with the low element of `a` replaced by the
@@ -1514,7 +1564,11 @@ pub unsafe fn _mm_cmpgt_sd(a: __m128d, b: __m128d) -> __m128d {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmplesd))]
 pub unsafe fn _mm_cmpge_sd(a: __m128d, b: __m128d) -> __m128d {
-    simd_insert(_mm_cmple_sd(b, a), 1, simd_extract::<_, f64>(a, 1))
+    simd_insert(
+        _mm_cmple_sd(b, a),
+        1,
+        simd_extract::<_, f64>(a, 1),
+    )
 }
 
 /// Return a new vector with the low element of `a` replaced by the result
@@ -1571,7 +1625,11 @@ pub unsafe fn _mm_cmpnle_sd(a: __m128d, b: __m128d) -> __m128d {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnltsd))]
 pub unsafe fn _mm_cmpngt_sd(a: __m128d, b: __m128d) -> __m128d {
-    simd_insert(_mm_cmpnlt_sd(b, a), 1, simd_extract::<_, f64>(a, 1))
+    simd_insert(
+        _mm_cmpnlt_sd(b, a),
+        1,
+        simd_extract::<_, f64>(a, 1),
+    )
 }
 
 /// Return a new vector with the low element of `a` replaced by the
@@ -1580,7 +1638,11 @@ pub unsafe fn _mm_cmpngt_sd(a: __m128d, b: __m128d) -> __m128d {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnlesd))]
 pub unsafe fn _mm_cmpnge_sd(a: __m128d, b: __m128d) -> __m128d {
-    simd_insert(_mm_cmpnle_sd(b, a), 1, simd_extract::<_, f64>(a, 1))
+    simd_insert(
+        _mm_cmpnle_sd(b, a),
+        1,
+        simd_extract::<_, f64>(a, 1),
+    )
 }
 
 /// Compare corresponding elements in `a` and `b` for equality.
@@ -3213,8 +3275,24 @@ mod tests {
             14,
             15,
         );
-        let b =
-            _mm_setr_epi8(15, 14, 2, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+        let b = _mm_setr_epi8(
+            15,
+            14,
+            2,
+            12,
+            11,
+            10,
+            9,
+            8,
+            7,
+            6,
+            5,
+            4,
+            3,
+            2,
+            1,
+            0,
+        );
         let r = _mm_cmpeq_epi8(a, b);
         #[cfg_attr(rustfmt, rustfmt_skip)]
         assert_eq_m128i(
@@ -4161,7 +4239,9 @@ mod tests {
             pub data: [f64; 2],
         }
         let a = _mm_set1_pd(7.0);
-        let mut mem = Memory { data: [-1.0; 2] };
+        let mut mem = Memory {
+            data: [-1.0; 2],
+        };
 
         _mm_stream_pd(&mut mem.data[0] as *mut f64, a);
         for i in 0..2 {
@@ -4179,7 +4259,9 @@ mod tests {
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_store_pd() {
-        let mut mem = Memory { data: [0.0f64; 4] };
+        let mut mem = Memory {
+            data: [0.0f64; 4],
+        };
         let vals = &mut mem.data;
         let a = _mm_setr_pd(1.0, 2.0);
         let d = vals.as_mut_ptr();
@@ -4191,7 +4273,9 @@ mod tests {
 
     #[simd_test = "sse"]
     unsafe fn test_mm_storeu_pd() {
-        let mut mem = Memory { data: [0.0f64; 4] };
+        let mut mem = Memory {
+            data: [0.0f64; 4],
+        };
         let vals = &mut mem.data;
         let a = _mm_setr_pd(1.0, 2.0);
 
@@ -4215,7 +4299,9 @@ mod tests {
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_store1_pd() {
-        let mut mem = Memory { data: [0.0f64; 4] };
+        let mut mem = Memory {
+            data: [0.0f64; 4],
+        };
         let vals = &mut mem.data;
         let a = _mm_setr_pd(1.0, 2.0);
         let d = vals.as_mut_ptr();
@@ -4227,7 +4313,9 @@ mod tests {
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_store_pd1() {
-        let mut mem = Memory { data: [0.0f64; 4] };
+        let mut mem = Memory {
+            data: [0.0f64; 4],
+        };
         let vals = &mut mem.data;
         let a = _mm_setr_pd(1.0, 2.0);
         let d = vals.as_mut_ptr();
@@ -4239,7 +4327,9 @@ mod tests {
 
     #[simd_test = "sse2"]
     unsafe fn test_mm_storer_pd() {
-        let mut mem = Memory { data: [0.0f64; 4] };
+        let mut mem = Memory {
+            data: [0.0f64; 4],
+        };
         let vals = &mut mem.data;
         let a = _mm_setr_pd(1.0, 2.0);
         let d = vals.as_mut_ptr();
@@ -4293,7 +4383,10 @@ mod tests {
         }
 
         let r = _mm_loadu_pd(d);
-        let e = _mm_add_pd(_mm_setr_pd(1.0, 2.0), _mm_set1_pd(offset as f64));
+        let e = _mm_add_pd(
+            _mm_setr_pd(1.0, 2.0),
+            _mm_set1_pd(offset as f64),
+        );
         assert_eq_m128d(r, e);
     }
 
@@ -4368,8 +4461,12 @@ mod tests {
 
         assert_eq_m128(r, _mm_setr_ps(2.0, -2.2, 3.3, 4.4));
 
-        let a =
-            _mm_setr_ps(-1.1, f32::NEG_INFINITY, f32::MAX, f32::NEG_INFINITY);
+        let a = _mm_setr_ps(
+            -1.1,
+            f32::NEG_INFINITY,
+            f32::MAX,
+            f32::NEG_INFINITY,
+        );
         let b = _mm_setr_pd(f64::INFINITY, -5.0);
 
         let r = _mm_cvtsd_ss(a, b);
@@ -4434,8 +4531,12 @@ mod tests {
         let r = _mm_cvttps_epi32(a);
         assert_eq_m128i(r, _mm_setr_epi32(-1, 2, -3, 6));
 
-        let a =
-            _mm_setr_ps(f32::NEG_INFINITY, f32::INFINITY, f32::MIN, f32::MAX);
+        let a = _mm_setr_ps(
+            f32::NEG_INFINITY,
+            f32::INFINITY,
+            f32::MIN,
+            f32::MAX,
+        );
         let r = _mm_cvttps_epi32(a);
         assert_eq_m128i(
             r,

--- a/coresimd/x86/sse41.rs
+++ b/coresimd/x86/sse41.rs
@@ -52,7 +52,11 @@ pub const _MM_FROUND_NEARBYINT: i32 =
 pub unsafe fn _mm_blendv_epi8(
     a: __m128i, b: __m128i, mask: __m128i
 ) -> __m128i {
-    mem::transmute(pblendvb(a.as_i8x16(), b.as_i8x16(), mask.as_i8x16()))
+    mem::transmute(pblendvb(
+        a.as_i8x16(),
+        b.as_i8x16(),
+        mask.as_i8x16(),
+    ))
 }
 
 /// Blend packed 16-bit integers from `a` and `b` using the mask `imm8`.
@@ -68,7 +72,9 @@ pub unsafe fn _mm_blend_epi16(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i16x8();
     let b = b.as_i16x8();
     macro_rules! call {
-        ($imm8:expr) => { pblendw(a, b, $imm8) }
+        ($imm8: expr) => {
+            pblendw(a, b, $imm8)
+        };
     }
     mem::transmute(constify_imm8!(imm8, call))
 }
@@ -99,7 +105,9 @@ pub unsafe fn _mm_blendv_ps(a: __m128, b: __m128, mask: __m128) -> __m128 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_blend_pd(a: __m128d, b: __m128d, imm2: i32) -> __m128d {
     macro_rules! call {
-        ($imm2:expr) => { blendpd(a, b, $imm2) }
+        ($imm2: expr) => {
+            blendpd(a, b, $imm2)
+        };
     }
     constify_imm2!(imm2, call)
 }
@@ -112,7 +120,9 @@ pub unsafe fn _mm_blend_pd(a: __m128d, b: __m128d, imm2: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_blend_ps(a: __m128, b: __m128, imm4: i32) -> __m128 {
     macro_rules! call {
-        ($imm4:expr) => { blendps(a, b, $imm4) }
+        ($imm4: expr) => {
+            blendps(a, b, $imm4)
+        };
     }
     constify_imm4!(imm4, call)
 }
@@ -180,7 +190,9 @@ pub unsafe fn _mm_extract_epi32(a: __m128i, imm8: i32) -> i32 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_insert_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
-        ($imm8:expr) => { insertps(a, b, $imm8) }
+        ($imm8: expr) => {
+            insertps(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -192,7 +204,11 @@ pub unsafe fn _mm_insert_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
 #[cfg_attr(test, assert_instr(pinsrb, imm8 = 0))]
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_insert_epi8(a: __m128i, i: i32, imm8: i32) -> __m128i {
-    mem::transmute(simd_insert(a.as_i8x16(), (imm8 & 0b1111) as u32, i as i8))
+    mem::transmute(simd_insert(
+        a.as_i8x16(),
+        (imm8 & 0b1111) as u32,
+        i as i8,
+    ))
 }
 
 /// Return a copy of `a` with the 32-bit integer from `i` inserted at a
@@ -202,7 +218,11 @@ pub unsafe fn _mm_insert_epi8(a: __m128i, i: i32, imm8: i32) -> __m128i {
 #[cfg_attr(test, assert_instr(pinsrd, imm8 = 0))]
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_insert_epi32(a: __m128i, i: i32, imm8: i32) -> __m128i {
-    mem::transmute(simd_insert(a.as_i32x4(), (imm8 & 0b11) as u32, i))
+    mem::transmute(simd_insert(
+        a.as_i32x4(),
+        (imm8 & 0b11) as u32,
+        i,
+    ))
 }
 
 /// Compare packed 8-bit integers in `a` and `b` and return packed maximum
@@ -431,7 +451,9 @@ pub unsafe fn _mm_cvtepu32_epi64(a: __m128i) -> __m128i {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_dp_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
     macro_rules! call {
-        ($imm8:expr) => { dppd(a, b, $imm8) }
+        ($imm8: expr) => {
+            dppd(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -449,7 +471,9 @@ pub unsafe fn _mm_dp_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_dp_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
-        ($imm8:expr) => { dpps(a, b, $imm8) }
+        ($imm8: expr) => {
+            dpps(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -584,7 +608,9 @@ pub unsafe fn _mm_ceil_ss(a: __m128, b: __m128) -> __m128 {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_round_pd(a: __m128d, rounding: i32) -> __m128d {
     macro_rules! call {
-        ($imm4:expr) => { roundpd(a, $imm4) }
+        ($imm4: expr) => {
+            roundpd(a, $imm4)
+        };
     }
     constify_imm4!(rounding, call)
 }
@@ -632,7 +658,9 @@ pub unsafe fn _mm_round_pd(a: __m128d, rounding: i32) -> __m128d {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_round_ps(a: __m128, rounding: i32) -> __m128 {
     macro_rules! call {
-        ($imm4:expr) => { roundps(a, $imm4) }
+        ($imm4: expr) => {
+            roundps(a, $imm4)
+        };
     }
     constify_imm4!(rounding, call)
 }
@@ -681,7 +709,9 @@ pub unsafe fn _mm_round_ps(a: __m128, rounding: i32) -> __m128 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_round_sd(a: __m128d, b: __m128d, rounding: i32) -> __m128d {
     macro_rules! call {
-        ($imm4:expr) => { roundsd(a, b, $imm4) }
+        ($imm4: expr) => {
+            roundsd(a, b, $imm4)
+        };
     }
     constify_imm4!(rounding, call)
 }
@@ -730,7 +760,9 @@ pub unsafe fn _mm_round_sd(a: __m128d, b: __m128d, rounding: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_round_ss(a: __m128, b: __m128, rounding: i32) -> __m128 {
     macro_rules! call {
-        ($imm4:expr) => { roundss(a, b, $imm4) }
+        ($imm4: expr) => {
+            roundss(a, b, $imm4)
+        };
     }
     constify_imm4!(rounding, call)
 }
@@ -822,7 +854,9 @@ pub unsafe fn _mm_mpsadbw_epu8(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let a = a.as_u8x16();
     let b = b.as_u8x16();
     macro_rules! call {
-        ($imm8:expr) => { mpsadbw(a, b, $imm8) }
+        ($imm8: expr) => {
+            mpsadbw(a, b, $imm8)
+        };
     }
     mem::transmute(constify_imm3!(imm8, call))
 }

--- a/coresimd/x86/sse42.rs
+++ b/coresimd/x86/sse42.rs
@@ -57,7 +57,9 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpistrm128(a, b, $imm8) }
+        ($imm8: expr) => {
+            pcmpistrm128(a, b, $imm8)
+        };
     }
     mem::transmute(constify_imm8!(imm8, call))
 }
@@ -302,7 +304,9 @@ pub unsafe fn _mm_cmpistri(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpistri128(a, b, $imm8) }
+        ($imm8: expr) => {
+            pcmpistri128(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -318,7 +322,9 @@ pub unsafe fn _mm_cmpistrz(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpistriz128(a, b, $imm8) }
+        ($imm8: expr) => {
+            pcmpistriz128(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -334,7 +340,9 @@ pub unsafe fn _mm_cmpistrc(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpistric128(a, b, $imm8) }
+        ($imm8: expr) => {
+            pcmpistric128(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -350,7 +358,9 @@ pub unsafe fn _mm_cmpistrs(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpistris128(a, b, $imm8) }
+        ($imm8: expr) => {
+            pcmpistris128(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -365,7 +375,9 @@ pub unsafe fn _mm_cmpistro(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpistrio128(a, b, $imm8) }
+        ($imm8: expr) => {
+            pcmpistrio128(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -381,7 +393,9 @@ pub unsafe fn _mm_cmpistra(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpistria128(a, b, $imm8) }
+        ($imm8: expr) => {
+            pcmpistria128(a, b, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -398,7 +412,9 @@ pub unsafe fn _mm_cmpestrm(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpestrm128(a, la, b, lb, $imm8) }
+        ($imm8: expr) => {
+            pcmpestrm128(a, la, b, lb, $imm8)
+        };
     }
     mem::transmute(constify_imm8!(imm8, call))
 }
@@ -500,7 +516,9 @@ pub unsafe fn _mm_cmpestri(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpestri128(a, la, b, lb, $imm8) }
+        ($imm8: expr) => {
+            pcmpestri128(a, la, b, lb, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -518,7 +536,9 @@ pub unsafe fn _mm_cmpestrz(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpestriz128(a, la, b, lb, $imm8) }
+        ($imm8: expr) => {
+            pcmpestriz128(a, la, b, lb, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -536,7 +556,9 @@ pub unsafe fn _mm_cmpestrc(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpestric128(a, la, b, lb, $imm8) }
+        ($imm8: expr) => {
+            pcmpestric128(a, la, b, lb, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -554,7 +576,9 @@ pub unsafe fn _mm_cmpestrs(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpestris128(a, la, b, lb, $imm8) }
+        ($imm8: expr) => {
+            pcmpestris128(a, la, b, lb, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -572,7 +596,9 @@ pub unsafe fn _mm_cmpestro(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpestrio128(a, la, b, lb, $imm8) }
+        ($imm8: expr) => {
+            pcmpestrio128(a, la, b, lb, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -591,7 +617,9 @@ pub unsafe fn _mm_cmpestra(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8:expr) => { pcmpestria128(a, la, b, lb, $imm8) }
+        ($imm8: expr) => {
+            pcmpestria128(a, la, b, lb, $imm8)
+        };
     }
     constify_imm8!(imm8, call)
 }
@@ -829,8 +857,13 @@ mod tests {
     unsafe fn test_mm_cmpestra() {
         let a = str_to_m128i(b"Cannot match a");
         let b = str_to_m128i(b"Null after 14");
-        let i =
-            _mm_cmpestra(a, 14, b, 16, _SIDD_CMP_EQUAL_EACH | _SIDD_UNIT_MASK);
+        let i = _mm_cmpestra(
+            a,
+            14,
+            b,
+            16,
+            _SIDD_CMP_EQUAL_EACH | _SIDD_UNIT_MASK,
+        );
         assert_eq!(1, i);
     }
 

--- a/coresimd/x86/ssse3.rs
+++ b/coresimd/x86/ssse3.rs
@@ -92,18 +92,30 @@ pub unsafe fn _mm_alignr_epi8(a: __m128i, b: __m128i, n: i32) -> __m128i {
     let b = b.as_i8x16();
 
     macro_rules! shuffle {
-        ($shift:expr) => {
-            simd_shuffle16(b, a, [
-                0 + $shift, 1 + $shift,
-                2 + $shift, 3 + $shift,
-                4 + $shift, 5 + $shift,
-                6 + $shift, 7 + $shift,
-                8 + $shift, 9 + $shift,
-                10 + $shift, 11 + $shift,
-                12 + $shift, 13 + $shift,
-                14 + $shift, 15 + $shift,
-            ])
-        }
+        ($shift: expr) => {
+            simd_shuffle16(
+                b,
+                a,
+                [
+                    0 + $shift,
+                    1 + $shift,
+                    2 + $shift,
+                    3 + $shift,
+                    4 + $shift,
+                    5 + $shift,
+                    6 + $shift,
+                    7 + $shift,
+                    8 + $shift,
+                    9 + $shift,
+                    10 + $shift,
+                    11 + $shift,
+                    12 + $shift,
+                    13 + $shift,
+                    14 + $shift,
+                    15 + $shift,
+                ],
+            )
+        };
     }
     let r: i8x16 = match n {
         0 => shuffle!(0),
@@ -283,9 +295,9 @@ pub unsafe fn _mm_shuffle_pi8(a: __m64, b: __m64) -> __m64 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_alignr_pi8(a: __m64, b: __m64, n: i32) -> __m64 {
     macro_rules! call {
-        ($imm8:expr) => {
+        ($imm8: expr) => {
             palignrb(a, b, $imm8)
-        }
+        };
     }
     constify_imm8!(n, call)
 }
@@ -536,8 +548,24 @@ mod tests {
             12, 5, 5, 10,
             4, 1, 8, 0,
         );
-        let expected =
-            _mm_setr_epi8(5, 0, 5, 4, 9, 13, 7, 4, 13, 6, 6, 11, 5, 2, 9, 1);
+        let expected = _mm_setr_epi8(
+            5,
+            0,
+            5,
+            4,
+            9,
+            13,
+            7,
+            4,
+            13,
+            6,
+            6,
+            11,
+            5,
+            2,
+            9,
+            1,
+        );
         let r = _mm_shuffle_epi8(a, b);
         assert_eq_m128i(r, expected);
     }

--- a/coresimd/x86/xsave.rs
+++ b/coresimd/x86/xsave.rs
@@ -35,7 +35,11 @@ extern "C" {
 #[target_feature(enable = "xsave")]
 #[cfg_attr(test, assert_instr(xsave))]
 pub unsafe fn _xsave(mem_addr: *mut u8, save_mask: u64) {
-    xsave(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
+    xsave(
+        mem_addr,
+        (save_mask >> 32) as u32,
+        save_mask as u32,
+    );
 }
 
 /// Perform a full or partial restore of the enabled processor states using
@@ -90,7 +94,11 @@ pub unsafe fn _xgetbv(xcr_no: u32) -> u64 {
 #[target_feature(enable = "xsave,xsaveopt")]
 #[cfg_attr(test, assert_instr(xsaveopt))]
 pub unsafe fn _xsaveopt(mem_addr: *mut u8, save_mask: u64) {
-    xsaveopt(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
+    xsaveopt(
+        mem_addr,
+        (save_mask >> 32) as u32,
+        save_mask as u32,
+    );
 }
 
 /// Perform a full or partial save of the enabled processor states to memory
@@ -103,7 +111,11 @@ pub unsafe fn _xsaveopt(mem_addr: *mut u8, save_mask: u64) {
 #[target_feature(enable = "xsave,xsavec")]
 #[cfg_attr(test, assert_instr(xsavec))]
 pub unsafe fn _xsavec(mem_addr: *mut u8, save_mask: u64) {
-    xsavec(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
+    xsavec(
+        mem_addr,
+        (save_mask >> 32) as u32,
+        save_mask as u32,
+    );
 }
 
 /// Perform a full or partial save of the enabled processor states to memory at
@@ -117,7 +129,11 @@ pub unsafe fn _xsavec(mem_addr: *mut u8, save_mask: u64) {
 #[target_feature(enable = "xsave,xsaves")]
 #[cfg_attr(test, assert_instr(xsaves))]
 pub unsafe fn _xsaves(mem_addr: *mut u8, save_mask: u64) {
-    xsaves(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
+    xsaves(
+        mem_addr,
+        (save_mask >> 32) as u32,
+        save_mask as u32,
+    );
 }
 
 /// Perform a full or partial restore of the enabled processor states using the
@@ -155,7 +171,9 @@ mod tests {
 
     impl XsaveArea {
         fn new() -> XsaveArea {
-            XsaveArea { data: [0; 2560] }
+            XsaveArea {
+                data: [0; 2560],
+            }
         }
         fn ptr(&mut self) -> *mut u8 {
             &mut self.data[0] as *mut _ as *mut u8

--- a/coresimd/x86_64/xsave.rs
+++ b/coresimd/x86_64/xsave.rs
@@ -33,7 +33,11 @@ extern "C" {
 #[target_feature(enable = "xsave")]
 #[cfg_attr(test, assert_instr(xsave64))]
 pub unsafe fn _xsave64(mem_addr: *mut u8, save_mask: u64) {
-    xsave64(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
+    xsave64(
+        mem_addr,
+        (save_mask >> 32) as u32,
+        save_mask as u32,
+    );
 }
 
 /// Perform a full or partial restore of the enabled processor states using
@@ -60,7 +64,11 @@ pub unsafe fn _xrstor64(mem_addr: *const u8, rs_mask: u64) {
 #[target_feature(enable = "xsave,xsaveopt")]
 #[cfg_attr(test, assert_instr(xsaveopt64))]
 pub unsafe fn _xsaveopt64(mem_addr: *mut u8, save_mask: u64) {
-    xsaveopt64(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
+    xsaveopt64(
+        mem_addr,
+        (save_mask >> 32) as u32,
+        save_mask as u32,
+    );
 }
 
 /// Perform a full or partial save of the enabled processor states to memory
@@ -73,7 +81,11 @@ pub unsafe fn _xsaveopt64(mem_addr: *mut u8, save_mask: u64) {
 #[target_feature(enable = "xsave,xsavec")]
 #[cfg_attr(test, assert_instr(xsavec64))]
 pub unsafe fn _xsavec64(mem_addr: *mut u8, save_mask: u64) {
-    xsavec64(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
+    xsavec64(
+        mem_addr,
+        (save_mask >> 32) as u32,
+        save_mask as u32,
+    );
 }
 
 /// Perform a full or partial save of the enabled processor states to memory at
@@ -87,7 +99,11 @@ pub unsafe fn _xsavec64(mem_addr: *mut u8, save_mask: u64) {
 #[target_feature(enable = "xsave,xsaves")]
 #[cfg_attr(test, assert_instr(xsaves64))]
 pub unsafe fn _xsaves64(mem_addr: *mut u8, save_mask: u64) {
-    xsaves64(mem_addr, (save_mask >> 32) as u32, save_mask as u32);
+    xsaves64(
+        mem_addr,
+        (save_mask >> 32) as u32,
+        save_mask as u32,
+    );
 }
 
 /// Perform a full or partial restore of the enabled processor states using the

--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -62,7 +62,11 @@ pub fn assert_instr(
             syn::Pat::Ident(ref i) => &i.ident,
             _ => panic!("must have bare arguments"),
         };
-        match invoc.args.iter().find(|a| a.0 == ident.as_ref()) {
+        match invoc
+            .args
+            .iter()
+            .find(|a| a.0 == ident.as_ref())
+        {
             Some(&(_, ref tts)) => {
                 input_vals.push(quote! { #tts });
             }
@@ -116,8 +120,9 @@ pub fn assert_instr(
         }
     }.into();
     // why? necessary now to get tests to work?
-    let tts: TokenStream =
-        tts.to_string().parse().expect("cannot parse tokenstream");
+    let tts: TokenStream = tts.to_string()
+        .parse()
+        .expect("cannot parse tokenstream");
 
     let tts: TokenStream = quote! {
         #item

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -44,12 +44,24 @@ extern crate stdsimd_test;
 #[cfg(test)]
 extern crate test;
 
-macro_rules! test_v16 { ($item:item) => {} }
-macro_rules! test_v32 { ($item:item) => {} }
-macro_rules! test_v64 { ($item:item) => {} }
-macro_rules! test_v128 { ($item:item) => {} }
-macro_rules! test_v256 { ($item:item) => {} }
-macro_rules! test_v512 { ($item:item) => {} }
+macro_rules! test_v16 {
+    ($item: item) => {};
+}
+macro_rules! test_v32 {
+    ($item: item) => {};
+}
+macro_rules! test_v64 {
+    ($item: item) => {};
+}
+macro_rules! test_v128 {
+    ($item: item) => {};
+}
+macro_rules! test_v256 {
+    ($item: item) => {};
+}
+macro_rules! test_v512 {
+    ($item: item) => {};
+}
 macro_rules! vector_impl {
     ($([$f:ident, $($args:tt)*]),*) => { $($f!($($args)*);)* }
 }

--- a/crates/coresimd/tests/cpu-detection.rs
+++ b/crates/coresimd/tests/cpu-detection.rs
@@ -14,20 +14,53 @@ fn x86_all() {
     println!("sse2: {:?}", is_x86_feature_detected!("sse2"));
     println!("sse3: {:?}", is_x86_feature_detected!("sse3"));
     println!("ssse3: {:?}", is_x86_feature_detected!("ssse3"));
-    println!("sse4.1: {:?}", is_x86_feature_detected!("sse4.1"));
-    println!("sse4.2: {:?}", is_x86_feature_detected!("sse4.2"));
+    println!(
+        "sse4.1: {:?}",
+        is_x86_feature_detected!("sse4.1")
+    );
+    println!(
+        "sse4.2: {:?}",
+        is_x86_feature_detected!("sse4.2")
+    );
     println!("sse4a: {:?}", is_x86_feature_detected!("sse4a"));
     println!("avx: {:?}", is_x86_feature_detected!("avx"));
     println!("avx2: {:?}", is_x86_feature_detected!("avx2"));
-    println!("avx512f {:?}", is_x86_feature_detected!("avx512f"));
-    println!("avx512cd {:?}", is_x86_feature_detected!("avx512cd"));
-    println!("avx512er {:?}", is_x86_feature_detected!("avx512er"));
-    println!("avx512pf {:?}", is_x86_feature_detected!("avx512pf"));
-    println!("avx512bw {:?}", is_x86_feature_detected!("avx512bw"));
-    println!("avx512dq {:?}", is_x86_feature_detected!("avx512dq"));
-    println!("avx512vl {:?}", is_x86_feature_detected!("avx512vl"));
-    println!("avx512_ifma {:?}", is_x86_feature_detected!("avx512ifma"));
-    println!("avx512_vbmi {:?}", is_x86_feature_detected!("avx512vbmi"));
+    println!(
+        "avx512f {:?}",
+        is_x86_feature_detected!("avx512f")
+    );
+    println!(
+        "avx512cd {:?}",
+        is_x86_feature_detected!("avx512cd")
+    );
+    println!(
+        "avx512er {:?}",
+        is_x86_feature_detected!("avx512er")
+    );
+    println!(
+        "avx512pf {:?}",
+        is_x86_feature_detected!("avx512pf")
+    );
+    println!(
+        "avx512bw {:?}",
+        is_x86_feature_detected!("avx512bw")
+    );
+    println!(
+        "avx512dq {:?}",
+        is_x86_feature_detected!("avx512dq")
+    );
+    println!(
+        "avx512vl {:?}",
+        is_x86_feature_detected!("avx512vl")
+    );
+    println!(
+        "avx512_ifma {:?}",
+        is_x86_feature_detected!("avx512ifma")
+    );
+    println!(
+        "avx512_vbmi {:?}",
+        is_x86_feature_detected!("avx512vbmi")
+    );
     println!(
         "avx512_vpopcntdq {:?}",
         is_x86_feature_detected!("avx512vpopcntdq")
@@ -37,11 +70,23 @@ fn x86_all() {
     println!("bmi: {:?}", is_x86_feature_detected!("bmi1"));
     println!("bmi2: {:?}", is_x86_feature_detected!("bmi2"));
     println!("tbm: {:?}", is_x86_feature_detected!("tbm"));
-    println!("popcnt: {:?}", is_x86_feature_detected!("popcnt"));
+    println!(
+        "popcnt: {:?}",
+        is_x86_feature_detected!("popcnt")
+    );
     println!("lzcnt: {:?}", is_x86_feature_detected!("lzcnt"));
     println!("fxsr: {:?}", is_x86_feature_detected!("fxsr"));
     println!("xsave: {:?}", is_x86_feature_detected!("xsave"));
-    println!("xsaveopt: {:?}", is_x86_feature_detected!("xsaveopt"));
-    println!("xsaves: {:?}", is_x86_feature_detected!("xsaves"));
-    println!("xsavec: {:?}", is_x86_feature_detected!("xsavec"));
+    println!(
+        "xsaveopt: {:?}",
+        is_x86_feature_detected!("xsaveopt")
+    );
+    println!(
+        "xsaves: {:?}",
+        is_x86_feature_detected!("xsaves")
+    );
+    println!(
+        "xsavec: {:?}",
+        is_x86_feature_detected!("xsavec")
+    );
 }

--- a/crates/coresimd/tests/endian_tests.rs
+++ b/crates/coresimd/tests/endian_tests.rs
@@ -1,0 +1,60 @@
+#![feature(cfg_target_feature, stdsimd)]
+#![cfg_attr(feature = "strict", deny(warnings))]
+
+extern crate core;
+extern crate coresimd;
+
+use core::{mem, slice};
+use coresimd::simd::*;
+
+#[test]
+fn endian_indexing() {
+    let v = i32x4::new(0, 1, 2, 3);
+    assert_eq!(v.extract(0), 0);
+    assert_eq!(v.extract(1), 1);
+    assert_eq!(v.extract(2), 2);
+    assert_eq!(v.extract(3), 3);
+}
+
+#[test]
+fn endian_bitcasts() {
+    let x = i8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    let t: i16x8 = unsafe { mem::transmute(x) };
+    if cfg!(target_endian = "little") {
+        let t_el = i16x8::new(256, 770, 1284, 1798, 2312, 2826, 3340, 3854);
+        assert_eq!(t, t_el);
+    } else if cfg!(target_endian = "big") {
+        let t_be = i16x8::new(1, 515, 1029, 1543, 2057, 2571, 3085, 3599);
+        assert_eq!(t, t_be);
+    }
+}
+
+#[test]
+fn endian_casts() {
+    let x = i8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    let t: i16x16 = x.into(); // simd_cast
+    let e = i16x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    assert_eq!(t, e);
+}
+
+#[test]
+fn endian_load_and_stores() {
+    let x = i8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    let mut y: [i16; 8] = [0; 8];
+    x.store_unaligned(unsafe {
+        slice::from_raw_parts_mut(&mut y as *mut _ as *mut i8, 16)
+    });
+
+    if cfg!(target_endian = "little") {
+        let e: [i16; 8] = [256, 770, 1284, 1798, 2312, 2826, 3340, 3854];
+        assert_eq!(y, e);
+    } else if cfg!(target_endian = "big") {
+        let e: [i16; 8] = [1, 515, 1029, 1543, 2057, 2571, 3085, 3599];
+        assert_eq!(y, e);
+    }
+
+    let z = i8x16::load_unaligned(unsafe {
+        slice::from_raw_parts(&y as *const _ as *const i8, 16)
+    });
+    assert_eq!(z, x);
+}

--- a/crates/coresimd/tests/endian_tests.rs
+++ b/crates/coresimd/tests/endian_tests.rs
@@ -18,7 +18,24 @@ fn endian_indexing() {
 
 #[test]
 fn endian_bitcasts() {
-    let x = i8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    let x = i8x16::new(
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+    );
     let t: i16x8 = unsafe { mem::transmute(x) };
     if cfg!(target_endian = "little") {
         let t_el = i16x8::new(256, 770, 1284, 1798, 2312, 2826, 3340, 3854);
@@ -31,15 +48,66 @@ fn endian_bitcasts() {
 
 #[test]
 fn endian_casts() {
-    let x = i8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    let x = i8x16::new(
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+    );
     let t: i16x16 = x.into(); // simd_cast
-    let e = i16x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    let e = i16x16::new(
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+    );
     assert_eq!(t, e);
 }
 
 #[test]
 fn endian_load_and_stores() {
-    let x = i8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    let x = i8x16::new(
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+    );
     let mut y: [i16; 8] = [0; 8];
     x.store_unaligned(unsafe {
         slice::from_raw_parts_mut(&mut y as *mut _ as *mut i8, 16)

--- a/crates/coresimd/tests/v128.rs
+++ b/crates/coresimd/tests/v128.rs
@@ -9,21 +9,35 @@
 extern crate coresimd;
 
 #[cfg(test)]
-macro_rules! test_v16 { ($item:item) => {} }
+macro_rules! test_v16 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v32 { ($item:item) => {} }
+macro_rules! test_v32 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v64 { ($item:item) => {} }
+macro_rules! test_v64 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v128 { ($item:item) => { $item } }
+macro_rules! test_v128 {
+    ($item: item) => {
+        $item
+    };
+}
 #[cfg(test)]
-macro_rules! test_v256 { ($item:item) => {} }
+macro_rules! test_v256 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v512 { ($item:item) => {} }
+macro_rules! test_v512 {
+    ($item: item) => {};
+}
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f:ident, $($args:tt)*]),*) => { }
+    ($([$f: ident, $($args: tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v16.rs
+++ b/crates/coresimd/tests/v16.rs
@@ -9,21 +9,35 @@
 extern crate coresimd;
 
 #[cfg(test)]
-macro_rules! test_v16 { ($item:item) => { $item } }
+macro_rules! test_v16 {
+    ($item: item) => {
+        $item
+    };
+}
 #[cfg(test)]
-macro_rules! test_v32 { ($item:item) => {} }
+macro_rules! test_v32 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v64 { ($item:item) => {} }
+macro_rules! test_v64 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v128 { ($item:item) => {} }
+macro_rules! test_v128 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v256 { ($item:item) => {} }
+macro_rules! test_v256 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v512 { ($item:item) => {} }
+macro_rules! test_v512 {
+    ($item: item) => {};
+}
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f:ident, $($args:tt)*]),*) => { }
+    ($([$f: ident, $($args: tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v256.rs
+++ b/crates/coresimd/tests/v256.rs
@@ -9,21 +9,35 @@
 extern crate coresimd;
 
 #[cfg(test)]
-macro_rules! test_v16 { ($item:item) => {} }
+macro_rules! test_v16 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v32 { ($item:item) => {} }
+macro_rules! test_v32 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v64 { ($item:item) => {} }
+macro_rules! test_v64 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v128 { ($item:item) => {} }
+macro_rules! test_v128 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v256 { ($item:item) => { $item } }
+macro_rules! test_v256 {
+    ($item: item) => {
+        $item
+    };
+}
 #[cfg(test)]
-macro_rules! test_v512 { ($item:item) => {} }
+macro_rules! test_v512 {
+    ($item: item) => {};
+}
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f:ident, $($args:tt)*]),*) => { }
+    ($([$f: ident, $($args: tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v32.rs
+++ b/crates/coresimd/tests/v32.rs
@@ -9,21 +9,35 @@
 extern crate coresimd;
 
 #[cfg(test)]
-macro_rules! test_v16 { ($item:item) => { } }
+macro_rules! test_v16 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v32 { ($item:item) => { $item } }
+macro_rules! test_v32 {
+    ($item: item) => {
+        $item
+    };
+}
 #[cfg(test)]
-macro_rules! test_v64 { ($item:item) => {} }
+macro_rules! test_v64 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v128 { ($item:item) => {} }
+macro_rules! test_v128 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v256 { ($item:item) => {} }
+macro_rules! test_v256 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v512 { ($item:item) => {} }
+macro_rules! test_v512 {
+    ($item: item) => {};
+}
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f:ident, $($args:tt)*]),*) => { }
+    ($([$f: ident, $($args: tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v512.rs
+++ b/crates/coresimd/tests/v512.rs
@@ -9,21 +9,35 @@
 extern crate coresimd;
 
 #[cfg(test)]
-macro_rules! test_v16 { ($item:item) => {} }
+macro_rules! test_v16 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v32 { ($item:item) => {} }
+macro_rules! test_v32 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v64 { ($item:item) => {} }
+macro_rules! test_v64 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v128 { ($item:item) => {} }
+macro_rules! test_v128 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v256 { ($item:item) => {} }
+macro_rules! test_v256 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v512 { ($item:item) => { $item } }
+macro_rules! test_v512 {
+    ($item: item) => {
+        $item
+    };
+}
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f:ident, $($args:tt)*]),*) => { }
+    ($([$f: ident, $($args: tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v64.rs
+++ b/crates/coresimd/tests/v64.rs
@@ -9,21 +9,35 @@
 extern crate coresimd;
 
 #[cfg(test)]
-macro_rules! test_v16 { ($item:item) => {} }
+macro_rules! test_v16 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v32 { ($item:item) => {} }
+macro_rules! test_v32 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v64 { ($item:item) => { $item } }
+macro_rules! test_v64 {
+    ($item: item) => {
+        $item
+    };
+}
 #[cfg(test)]
-macro_rules! test_v128 { ($item:item) => {} }
+macro_rules! test_v128 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v256 { ($item:item) => {} }
+macro_rules! test_v256 {
+    ($item: item) => {};
+}
 #[cfg(test)]
-macro_rules! test_v512 { ($item:item) => {} }
+macro_rules! test_v512 {
+    ($item: item) => {};
+}
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f:ident, $($args:tt)*]),*) => { }
+    ($([$f: ident, $($args: tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -23,7 +23,9 @@ fn string(s: &str) -> TokenTree {
 pub fn simd_test(
     attr: proc_macro::TokenStream, item: proc_macro::TokenStream
 ) -> proc_macro::TokenStream {
-    let tokens = TokenStream::from(attr).into_iter().collect::<Vec<_>>();
+    let tokens = TokenStream::from(attr)
+        .into_iter()
+        .collect::<Vec<_>>();
     if tokens.len() != 2 {
         panic!("expected #[simd_test = \"feature\"]");
     }
@@ -53,9 +55,10 @@ pub fn simd_test(
     let item = TokenStream::from(item);
     let name = find_name(item.clone());
 
-    let name: TokenStream = name.as_str()
-        .parse()
-        .expect(&format!("failed to parse name: {}", name.clone().as_str()));
+    let name: TokenStream = name.as_str().parse().expect(&format!(
+        "failed to parse name: {}",
+        name.clone().as_str()
+    ));
 
     let default_target = if cfg!(target_os = "windows") {
         Some("x86_64-pc-windows-msvc")
@@ -71,11 +74,10 @@ pub fn simd_test(
         default_target.expect("TARGET environment variable not set and no default target known for the current target.").to_string()
     });
     let mut force_test = false;
-    let macro_test = match target
-        .split('-')
-        .next()
-        .expect(&format!("target triple contained no \"-\": {}", target))
-    {
+    let macro_test = match target.split('-').next().expect(&format!(
+        "target triple contained no \"-\": {}",
+        target
+    )) {
         "i686" | "x86_64" | "i586" => "is_x86_feature_detected",
         "arm" | "armv7" => "is_arm_feature_detected",
         "aarch64" => "is_aarch64_feature_detected",

--- a/crates/stdsimd-test/src/lib.rs
+++ b/crates/stdsimd-test/src/lib.rs
@@ -25,8 +25,7 @@ pub use assert_instr_macro::*;
 pub use simd_test_macro::*;
 
 lazy_static! {
-    static ref DISASSEMBLY: HashMap<String, Vec<Function>>
-        = disassemble_myself();
+    static ref DISASSEMBLY: HashMap<String, Vec<Function>> = disassemble_myself();
 }
 
 struct Function {
@@ -258,7 +257,9 @@ pub fn assert(fnptr: usize, fnname: &str, expected: &str) {
     // in the disassembly.
     let mut sym = None;
     backtrace::resolve(fnptr as *mut _, |name| {
-        sym = name.name().and_then(|s| s.as_str()).map(normalize);
+        sym = name.name()
+            .and_then(|s| s.as_str())
+            .map(normalize);
     });
 
     let functions =
@@ -269,17 +270,26 @@ pub fn assert(fnptr: usize, fnname: &str, expected: &str) {
                 println!("assumed symbol name: `{}`", sym);
             }
             println!("maybe related functions");
-            for f in DISASSEMBLY.keys().filter(|k| k.contains(fnname)) {
+            for f in DISASSEMBLY
+                .keys()
+                .filter(|k| k.contains(fnname))
+            {
                 println!("\t- {}", f);
             }
-            panic!("failed to find disassembly of {:#x} ({})", fnptr, fnname);
+            panic!(
+                "failed to find disassembly of {:#x} ({})",
+                fnptr, fnname
+            );
         };
 
     assert_eq!(functions.len(), 1);
     let function = &functions[0];
 
     let mut instrs = &function.instrs[..];
-    while instrs.last().map_or(false, |s| s.parts == ["nop"]) {
+    while instrs
+        .last()
+        .map_or(false, |s| s.parts == ["nop"])
+    {
         instrs = &instrs[..instrs.len() - 1];
     }
 
@@ -390,5 +400,8 @@ pub fn assert_skip_test_ok(name: &str) {
     if env::var("STDSIMD_TEST_EVERYTHING").is_err() {
         return;
     }
-    panic!("skipped test `{}` when it shouldn't be skipped", name);
+    panic!(
+        "skipped test `{}` when it shouldn't be skipped",
+        name
+    );
 }

--- a/crates/stdsimd-verify/tests/x86-intel.rs
+++ b/crates/stdsimd-verify/tests/x86-intel.rs
@@ -249,8 +249,10 @@ fn matches(rust: &Function, intel: &Intrinsic) -> Result<(), String> {
             .flat_map(|c| c.to_lowercase())
             .collect::<String>();
 
-        let rust_feature = rust.target_feature
-            .expect(&format!("no target feature listed for {}", rust.name));
+        let rust_feature = rust.target_feature.expect(&format!(
+            "no target feature listed for {}",
+            rust.name
+        ));
         if rust_feature.contains(&cpuid) {
             continue;
         }
@@ -312,20 +314,25 @@ fn matches(rust: &Function, intel: &Intrinsic) -> Result<(), String> {
         if rust.arguments.len() != intel.parameters.len() {
             bail!("wrong number of arguments on {}", rust.name)
         }
-        for (i, (a, b)) in
-            intel.parameters.iter().zip(rust.arguments).enumerate()
+        for (i, (a, b)) in intel
+            .parameters
+            .iter()
+            .zip(rust.arguments)
+            .enumerate()
         {
             let is_const = rust.required_const.contains(&i);
             equate(b, &a.type_, &intel.name, is_const)?;
         }
     }
 
-    let any_i64 = rust.arguments.iter().cloned().chain(rust.ret).any(|arg| {
-        match *arg {
+    let any_i64 = rust.arguments
+        .iter()
+        .cloned()
+        .chain(rust.ret)
+        .any(|arg| match *arg {
             Type::PrimSigned(64) | Type::PrimUnsigned(64) => true,
             _ => false,
-        }
-    });
+        });
     let any_i64_exempt = match rust.name {
         // These intrinsics have all been manually verified against Clang's
         // headers to be available on x86, and the u64 arguments seem
@@ -364,7 +371,9 @@ fn equate(
         if is_const {
             return Ok(());
         }
-        Err(format!("argument required to be const but isn't"))
+        Err(format!(
+            "argument required to be const but isn't"
+        ))
     };
     match (t, &intel[..]) {
         (&Type::PrimFloat(32), "float") => {}

--- a/crates/stdsimd/tests/cpu-detection.rs
+++ b/crates/stdsimd/tests/cpu-detection.rs
@@ -22,22 +22,37 @@ fn aarch64_linux() {
     println!("fp: {}", is_aarch64_feature_detected!("fp"));
     println!("fp16: {}", is_aarch64_feature_detected!("fp16"));
     println!("neon: {}", is_aarch64_feature_detected!("neon"));
-    println!("asimd: {}", is_aarch64_feature_detected!("asimd"));
+    println!(
+        "asimd: {}",
+        is_aarch64_feature_detected!("asimd")
+    );
     println!("sve: {}", is_aarch64_feature_detected!("sve"));
     println!("crc: {}", is_aarch64_feature_detected!("crc"));
-    println!("crypto: {}", is_aarch64_feature_detected!("crypto"));
+    println!(
+        "crypto: {}",
+        is_aarch64_feature_detected!("crypto")
+    );
     println!("lse: {}", is_aarch64_feature_detected!("lse"));
     println!("rdm: {}", is_aarch64_feature_detected!("rdm"));
     println!("rcpc: {}", is_aarch64_feature_detected!("rcpc"));
-    println!("dotprod: {}", is_aarch64_feature_detected!("dotprod"));
+    println!(
+        "dotprod: {}",
+        is_aarch64_feature_detected!("dotprod")
+    );
 }
 
 #[test]
 #[cfg(all(target_arch = "powerpc64", target_os = "linux"))]
 fn powerpc64_linux() {
-    println!("altivec: {}", is_powerpc64_feature_detected!("altivec"));
+    println!(
+        "altivec: {}",
+        is_powerpc64_feature_detected!("altivec")
+    );
     println!("vsx: {}", is_powerpc64_feature_detected!("vsx"));
-    println!("power8: {}", is_powerpc64_feature_detected!("power8"));
+    println!(
+        "power8: {}",
+        is_powerpc64_feature_detected!("power8")
+    );
 }
 
 #[test]
@@ -47,20 +62,53 @@ fn x86_all() {
     println!("sse2: {:?}", is_x86_feature_detected!("sse2"));
     println!("sse3: {:?}", is_x86_feature_detected!("sse3"));
     println!("ssse3: {:?}", is_x86_feature_detected!("ssse3"));
-    println!("sse4.1: {:?}", is_x86_feature_detected!("sse4.1"));
-    println!("sse4.2: {:?}", is_x86_feature_detected!("sse4.2"));
+    println!(
+        "sse4.1: {:?}",
+        is_x86_feature_detected!("sse4.1")
+    );
+    println!(
+        "sse4.2: {:?}",
+        is_x86_feature_detected!("sse4.2")
+    );
     println!("sse4a: {:?}", is_x86_feature_detected!("sse4a"));
     println!("avx: {:?}", is_x86_feature_detected!("avx"));
     println!("avx2: {:?}", is_x86_feature_detected!("avx2"));
-    println!("avx512f {:?}", is_x86_feature_detected!("avx512f"));
-    println!("avx512cd {:?}", is_x86_feature_detected!("avx512cd"));
-    println!("avx512er {:?}", is_x86_feature_detected!("avx512er"));
-    println!("avx512pf {:?}", is_x86_feature_detected!("avx512pf"));
-    println!("avx512bw {:?}", is_x86_feature_detected!("avx512bw"));
-    println!("avx512dq {:?}", is_x86_feature_detected!("avx512dq"));
-    println!("avx512vl {:?}", is_x86_feature_detected!("avx512vl"));
-    println!("avx512_ifma {:?}", is_x86_feature_detected!("avx512ifma"));
-    println!("avx512_vbmi {:?}", is_x86_feature_detected!("avx512vbmi"));
+    println!(
+        "avx512f {:?}",
+        is_x86_feature_detected!("avx512f")
+    );
+    println!(
+        "avx512cd {:?}",
+        is_x86_feature_detected!("avx512cd")
+    );
+    println!(
+        "avx512er {:?}",
+        is_x86_feature_detected!("avx512er")
+    );
+    println!(
+        "avx512pf {:?}",
+        is_x86_feature_detected!("avx512pf")
+    );
+    println!(
+        "avx512bw {:?}",
+        is_x86_feature_detected!("avx512bw")
+    );
+    println!(
+        "avx512dq {:?}",
+        is_x86_feature_detected!("avx512dq")
+    );
+    println!(
+        "avx512vl {:?}",
+        is_x86_feature_detected!("avx512vl")
+    );
+    println!(
+        "avx512_ifma {:?}",
+        is_x86_feature_detected!("avx512ifma")
+    );
+    println!(
+        "avx512_vbmi {:?}",
+        is_x86_feature_detected!("avx512vbmi")
+    );
     println!(
         "avx512_vpopcntdq {:?}",
         is_x86_feature_detected!("avx512vpopcntdq")
@@ -70,11 +118,23 @@ fn x86_all() {
     println!("bmi: {:?}", is_x86_feature_detected!("bmi1"));
     println!("bmi2: {:?}", is_x86_feature_detected!("bmi2"));
     println!("tbm: {:?}", is_x86_feature_detected!("tbm"));
-    println!("popcnt: {:?}", is_x86_feature_detected!("popcnt"));
+    println!(
+        "popcnt: {:?}",
+        is_x86_feature_detected!("popcnt")
+    );
     println!("lzcnt: {:?}", is_x86_feature_detected!("lzcnt"));
     println!("fxsr: {:?}", is_x86_feature_detected!("fxsr"));
     println!("xsave: {:?}", is_x86_feature_detected!("xsave"));
-    println!("xsaveopt: {:?}", is_x86_feature_detected!("xsaveopt"));
-    println!("xsaves: {:?}", is_x86_feature_detected!("xsaves"));
-    println!("xsavec: {:?}", is_x86_feature_detected!("xsavec"));
+    println!(
+        "xsaveopt: {:?}",
+        is_x86_feature_detected!("xsaveopt")
+    );
+    println!(
+        "xsaves: {:?}",
+        is_x86_feature_detected!("xsaves")
+    );
+    println!(
+        "xsavec: {:?}",
+        is_x86_feature_detected!("xsavec")
+    );
 }

--- a/examples/hex.rs
+++ b/examples/hex.rs
@@ -115,7 +115,9 @@ unsafe fn hex_encode_avx2<'a>(
     let i = i as usize;
     let _ = hex_encode_sse41(src, &mut dst[i * 2..]);
 
-    Ok(str::from_utf8_unchecked(&dst[..src.len() * 2 + i * 2]))
+    Ok(str::from_utf8_unchecked(
+        &dst[..src.len() * 2 + i * 2],
+    ))
 }
 
 // copied from https://github.com/Matherunner/bin2hex-sse/blob/master/base16_sse4.cpp
@@ -155,7 +157,10 @@ unsafe fn hex_encode_sse41<'a>(
         let res2 = _mm_unpackhi_epi8(masked2, masked1);
 
         _mm_storeu_si128(dst.as_mut_ptr().offset(i * 2) as *mut _, res1);
-        _mm_storeu_si128(dst.as_mut_ptr().offset(i * 2 + 16) as *mut _, res2);
+        _mm_storeu_si128(
+            dst.as_mut_ptr().offset(i * 2 + 16) as *mut _,
+            res2,
+        );
         src = &src[16..];
         i += 16;
     }
@@ -163,7 +168,9 @@ unsafe fn hex_encode_sse41<'a>(
     let i = i as usize;
     let _ = hex_encode_fallback(src, &mut dst[i * 2..]);
 
-    Ok(str::from_utf8_unchecked(&dst[..src.len() * 2 + i * 2]))
+    Ok(str::from_utf8_unchecked(
+        &dst[..src.len() * 2 + i * 2],
+    ))
 }
 
 fn hex_encode_fallback<'a>(
@@ -192,7 +199,10 @@ mod tests {
     fn test(input: &[u8], output: &str) {
         let tmp = || vec![0; input.len() * 2];
 
-        assert_eq!(hex_encode_fallback(input, &mut tmp()).unwrap(), output);
+        assert_eq!(
+            hex_encode_fallback(input, &mut tmp()).unwrap(),
+            output
+        );
         assert_eq!(hex_encode(input, &mut tmp()).unwrap(), output);
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -229,7 +239,9 @@ mod tests {
     fn odd() {
         test(
             &[0; 313],
-            &iter::repeat('0').take(313 * 2).collect::<String>(),
+            &iter::repeat('0')
+                .take(313 * 2)
+                .collect::<String>(),
         );
     }
 

--- a/stdsimd/arch/detect/error_macros.rs
+++ b/stdsimd/arch/detect/error_macros.rs
@@ -6,16 +6,18 @@
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_x86_feature_detected {
-    ($t:tt) => {
-        compile_error!(r#"
-is_x86_feature_detected can only be used on x86 and x86_64 targets.
-You can prevent it from being used in other architectures by
-guarding it behind a cfg(target_arch) as follows:
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-        if is_x86_feature_detected(...) { ... }
-    }
-"#)
+    ($t: tt) => {
+        compile_error!(
+            r#"
+        is_x86_feature_detected can only be used on x86 and x86_64 targets.
+        You can prevent it from being used in other architectures by
+        guarding it behind a cfg(target_arch) as follows:
+            
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+                if is_x86_feature_detected(...) { ... }
+            }
+        "#
+        )
     };
 }
 
@@ -23,16 +25,18 @@ guarding it behind a cfg(target_arch) as follows:
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_arm_feature_detected {
-    ($t:tt) => {
-        compile_error!(r#"
-is_arm_feature_detected can only be used on ARM targets.
-You can prevent it from being used in other architectures by
-guarding it behind a cfg(target_arch) as follows:
-
-    #[cfg(target_arch = "arm")] {
-        if is_arm_feature_detected(...) { ... }
-    }
-"#)
+    ($t: tt) => {
+        compile_error!(
+            r#"
+        is_arm_feature_detected can only be used on ARM targets.
+        You can prevent it from being used in other architectures by
+        guarding it behind a cfg(target_arch) as follows:
+            
+            #[cfg(target_arch = "arm")] {
+                if is_arm_feature_detected(...) { ... }
+            }
+        "#
+        )
     };
 }
 
@@ -40,16 +44,18 @@ guarding it behind a cfg(target_arch) as follows:
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_aarch64_feature_detected {
-    ($t:tt) => {
-        compile_error!(r#"
-is_aarch64_feature_detected can only be used on AArch64 targets.
-You can prevent it from being used in other architectures by
-guarding it behind a cfg(target_arch) as follows:
-
-    #[cfg(target_arch = "aarch64")] {
-        if is_aarch64_feature_detected(...) { ... }
-    }
-"#)
+    ($t: tt) => {
+        compile_error!(
+            r#"
+        is_aarch64_feature_detected can only be used on AArch64 targets.
+        You can prevent it from being used in other architectures by
+        guarding it behind a cfg(target_arch) as follows:
+            
+            #[cfg(target_arch = "aarch64")] {
+                if is_aarch64_feature_detected(...) { ... }
+            }
+        "#
+        )
     };
 }
 
@@ -74,16 +80,18 @@ guarding it behind a cfg(target_arch) as follows:
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_mips_feature_detected {
-    ($t:tt) => {
-        compile_error!(r#"
-is_mips_feature_detected can only be used on MIPS targets.
-You can prevent it from being used in other architectures by
-guarding it behind a cfg(target_arch) as follows:
-
-    #[cfg(target_arch = "mips")] {
-        if is_mips_feature_detected(...) { ... }
-    }
-"#)
+    ($t: tt) => {
+        compile_error!(
+            r#"
+        is_mips_feature_detected can only be used on MIPS targets.
+        You can prevent it from being used in other architectures by
+        guarding it behind a cfg(target_arch) as follows:
+            
+            #[cfg(target_arch = "mips")] {
+                if is_mips_feature_detected(...) { ... }
+            }
+        "#
+        )
     };
 }
 
@@ -91,15 +99,17 @@ guarding it behind a cfg(target_arch) as follows:
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
 macro_rules! is_mips64_feature_detected {
-        ($t:tt) => {
-            compile_error!(r#"
-is_mips64_feature_detected can only be used on MIPS64 targets.
-You can prevent it from being used in other architectures by
-guarding it behind a cfg(target_arch) as follows:
-
-    #[cfg(target_arch = "mips64")] {
-        if is_mips64_feature_detected(...) { ... }
-    }
-"#)
+    ($t: tt) => {
+        compile_error!(
+            r#"
+        is_mips64_feature_detected can only be used on MIPS64 targets.
+        You can prevent it from being used in other architectures by
+        guarding it behind a cfg(target_arch) as follows:
+            
+            #[cfg(target_arch = "mips64")] {
+                if is_mips64_feature_detected(...) { ... }
+            }
+        "#
+        )
     };
 }

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -322,8 +322,8 @@
 ///         let res2 = _mm_unpackhi_epi8(masked2, masked1);
 ///
 ///         _mm_storeu_si128(dst.as_mut_ptr().offset(i * 2) as *mut _, res1);
-///         _mm_storeu_si128(dst.as_mut_ptr().offset(i * 2 + 16) as *mut _, res2);
-///         src = &src[16..];
+/// _mm_storeu_si128(dst.as_mut_ptr().offset(i * 2 + 16) as *mut _,
+/// res2);         src = &src[16..];
 ///         i += 16;
 ///     }
 ///


### PR DESCRIPTION
The behavior of `mem::transmute` and memory load/stores is endian dependent. These tests document this behavior.