### PR TITLE
Fix default `cargo test` experience

### DIFF
--- a/crates/coresimd/build.rs
+++ b/crates/coresimd/build.rs
@@ -1,0 +1,8 @@
+use std::env;
+
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        env::var("TARGET").unwrap()
+    );
+}

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -60,19 +60,8 @@ pub fn simd_test(
         name.clone().as_str()
     ));
 
-    let default_target = if cfg!(target_os = "windows") {
-        Some("x86_64-pc-windows-msvc")
-    } else if cfg!(target_os = "linux") {
-        Some("x86_64-unknown-linux-gnu")
-    } else if cfg!(target_os = "macos") {
-        Some("x86_64-apple-darwin")
-    } else {
-        None
-    };
-
-    let target = env::var("TARGET").unwrap_or_else(|_| {
-        default_target.expect("TARGET environment variable not set and no default target known for the current target.").to_string()
-    });
+    let target = env::var("TARGET")
+        .expect("TARGET environment variable should be set for rustc");
     let mut force_test = false;
     let macro_test = match target.split('-').next().expect(&format!(
         "target triple contained no \"-\": {}",


### PR DESCRIPTION
Turns out Cargo doesn't automatically set `TARGET` for rustc invocations so
carry it forward manually from the build script over to the rustc invocation.