### PR TITLE
Fix the build on 0.0.4 branch

### DIFF
--- a/ci/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i586-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc-multilib \
   libc6-dev \

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc-multilib \
   libc6-dev \

--- a/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   libc6-dev \

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   libc6-dev \

--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -22,12 +22,18 @@ dox() {
   rm -rf target/doc/$arch
   mkdir target/doc/$arch
 
-  cargo build --target $target
+  cargo build --target $target --manifest-path crates/stdsimd/Cargo.toml
 
   rustdoc --target $target \
-          -o target/doc/$arch src/lib.rs \
-          --crate-name stdsimd \
+          -o target/doc/$arch crates/coresimd/src/lib.rs \
+          --crate-name coresimd \
           --library-path target/$target/debug/deps
+  rustdoc --target $target \
+          -o target/doc/$arch crates/stdsimd/src/lib.rs \
+          --crate-name stdsimd \
+          --library-path target/$target/debug/deps \
+          --extern cfg_if=`ls target/$target/debug/deps/libcfg_if-*.rlib` \
+          --extern libc=`ls target/$target/debug/deps/liblibc-*.rlib`
 }
 
 dox i686 i686-unknown-linux-gnu
@@ -36,6 +42,8 @@ dox arm armv7-unknown-linux-gnueabihf
 dox aarch64 aarch64-unknown-linux-gnu
 dox powerpc powerpc-unknown-linux-gnu
 dox powerpc64 powerpc64-unknown-linux-gnu
+dox mips mips-unknown-linux-gnu
+dox mips64 mips64-unknown-linux-gnuabi64
 
 # If we're on travis, not a PR, and on the right branch, publish!
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then

--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -22,14 +22,14 @@ dox() {
   rm -rf target/doc/$arch
   mkdir target/doc/$arch
 
-  cargo build --target $target --manifest-path crates/stdsimd/Cargo.toml
+  cargo build --target $target
 
   rustdoc --target $target \
-          -o target/doc/$arch crates/coresimd/src/lib.rs \
+          -o target/doc/$arch coresimd/src/lib.rs \
           --crate-name coresimd \
           --library-path target/$target/debug/deps
   rustdoc --target $target \
-          -o target/doc/$arch crates/stdsimd/src/lib.rs \
+          -o target/doc/$arch src/lib.rs \
           --crate-name stdsimd \
           --library-path target/$target/debug/deps \
           --extern cfg_if=`ls target/$target/debug/deps/libcfg_if-*.rlib` \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -29,7 +29,7 @@ echo "OBJDUMP=${OBJDUMP}"
 cargo_test() {
     cmd="cargo test --target=$TARGET --features $FEATURES $1"
     cmd="$cmd -p coresimd -p stdsimd"
-    cmd="$cmd --manifest-path crates/stdsimd/Cargo.toml"
+    cmd="$cmd"
     cmd="$cmd -- $2"
     $cmd
 }

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -2,20 +2,25 @@
 
 set -ex
 
+: ${TARGET?"The TARGET environment variable must be set."}
+
 # Tests are all super fast anyway, and they fault often enough on travis that
 # having only one thread increases debuggability to be worth it.
 export RUST_TEST_THREADS=1
+#export RUST_BACKTRACE=1
+#export RUST_TEST_NOCAPTURE=1
 
-# FIXME(rust-lang-nursery/stdsimd#120) run-time feature detection for ARM Neon
+FEATURES="strict,$FEATURES"
+
+# FIXME: on armv7 neon intrinsics require the neon target-feature to be
+# unconditionally enabled.
 case ${TARGET} in
-    aarch*)
+    armv7*)
         export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+neon"
         ;;
     *)
         ;;
 esac
-
-FEATURES="strict,$FEATURES"
 
 echo "RUSTFLAGS=${RUSTFLAGS}"
 echo "FEATURES=${FEATURES}"
@@ -24,6 +29,7 @@ echo "OBJDUMP=${OBJDUMP}"
 cargo_test() {
     cmd="cargo test --target=$TARGET --features $FEATURES $1"
     cmd="$cmd -p coresimd -p stdsimd"
+    cmd="$cmd --manifest-path crates/stdsimd/Cargo.toml"
     cmd="$cmd -- $2"
     $cmd
 }

--- a/coresimd/src/aarch64/neon.rs
+++ b/coresimd/src/aarch64/neon.rs
@@ -8,7 +8,7 @@ use simd_llvm::simd_add;
 use v128::f64x2;
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(fadd))]
 pub unsafe fn vadd_f64(a: f64, b: f64) -> f64 {
@@ -16,7 +16,7 @@ pub unsafe fn vadd_f64(a: f64, b: f64) -> f64 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(fadd))]
 pub unsafe fn vaddq_f64(a: f64x2, b: f64x2) -> f64x2 {
@@ -24,7 +24,7 @@ pub unsafe fn vaddq_f64(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddd_s64(a: i64, b: i64) -> i64 {
@@ -32,7 +32,7 @@ pub unsafe fn vaddd_s64(a: i64, b: i64) -> i64 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddd_u64(a: u64, b: u64) -> u64 {

--- a/coresimd/src/aarch64/v8.rs
+++ b/coresimd/src/aarch64/v8.rs
@@ -9,14 +9,14 @@
 use stdsimd_test::assert_instr;
 
 /// Reverse the order of the bytes.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(rev))]
 pub unsafe fn _rev_u64(x: u64) -> u64 {
     x.swap_bytes() as u64
 }
 
 /// Count Leading Zeros.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(clz))]
 pub unsafe fn _clz_u64(x: u64) -> u64 {
     x.leading_zeros() as u64
@@ -29,7 +29,7 @@ extern "C" {
 }
 
 /// Reverse the bit order.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(rbit))]
 pub unsafe fn _rbit_u64(x: u64) -> u64 {
     rbit_u64(x as i64) as u64
@@ -39,7 +39,7 @@ pub unsafe fn _rbit_u64(x: u64) -> u64 {
 ///
 /// When all bits of the operand are set it returns the size of the operand in
 /// bits.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(cls))]
 pub unsafe fn _cls_u32(x: u32) -> u32 {
     u32::leading_zeros(((((((x as i32) >> 31) as u32) ^ x) << 1) | 1)) as u32
@@ -49,7 +49,7 @@ pub unsafe fn _cls_u32(x: u32) -> u32 {
 ///
 /// When all bits of the operand are set it returns the size of the operand in
 /// bits.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(cls))]
 pub unsafe fn _cls_u64(x: u64) -> u64 {
     u64::leading_zeros(((((((x as i64) >> 63) as u64) ^ x) << 1) | 1)) as u64

--- a/coresimd/src/arm/neon.rs
+++ b/coresimd/src/arm/neon.rs
@@ -9,7 +9,7 @@ use v64::{f32x2, i16x4, i32x2, i8x8, u16x4, u32x2, u8x8};
 use v128::{f32x4, i16x8, i32x4, i64x2, i8x16, u16x8, u32x4, u64x2, u8x16};
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vadd_s8(a: i8x8, b: i8x8) -> i8x8 {
@@ -17,7 +17,7 @@ pub unsafe fn vadd_s8(a: i8x8, b: i8x8) -> i8x8 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddq_s8(a: i8x16, b: i8x16) -> i8x16 {
@@ -25,7 +25,7 @@ pub unsafe fn vaddq_s8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vadd_s16(a: i16x4, b: i16x4) -> i16x4 {
@@ -33,7 +33,7 @@ pub unsafe fn vadd_s16(a: i16x4, b: i16x4) -> i16x4 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddq_s16(a: i16x8, b: i16x8) -> i16x8 {
@@ -41,7 +41,7 @@ pub unsafe fn vaddq_s16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vadd_s32(a: i32x2, b: i32x2) -> i32x2 {
@@ -49,7 +49,7 @@ pub unsafe fn vadd_s32(a: i32x2, b: i32x2) -> i32x2 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddq_s32(a: i32x4, b: i32x4) -> i32x4 {
@@ -57,7 +57,7 @@ pub unsafe fn vaddq_s32(a: i32x4, b: i32x4) -> i32x4 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddq_s64(a: i64x2, b: i64x2) -> i64x2 {
@@ -65,7 +65,7 @@ pub unsafe fn vaddq_s64(a: i64x2, b: i64x2) -> i64x2 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vadd_u8(a: u8x8, b: u8x8) -> u8x8 {
@@ -73,7 +73,7 @@ pub unsafe fn vadd_u8(a: u8x8, b: u8x8) -> u8x8 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddq_u8(a: u8x16, b: u8x16) -> u8x16 {
@@ -81,7 +81,7 @@ pub unsafe fn vaddq_u8(a: u8x16, b: u8x16) -> u8x16 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vadd_u16(a: u16x4, b: u16x4) -> u16x4 {
@@ -89,7 +89,7 @@ pub unsafe fn vadd_u16(a: u16x4, b: u16x4) -> u16x4 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddq_u16(a: u16x8, b: u16x8) -> u16x8 {
@@ -97,7 +97,7 @@ pub unsafe fn vaddq_u16(a: u16x8, b: u16x8) -> u16x8 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vadd_u32(a: u32x2, b: u32x2) -> u32x2 {
@@ -105,7 +105,7 @@ pub unsafe fn vadd_u32(a: u32x2, b: u32x2) -> u32x2 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddq_u32(a: u32x4, b: u32x4) -> u32x4 {
@@ -113,7 +113,7 @@ pub unsafe fn vaddq_u32(a: u32x4, b: u32x4) -> u32x4 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(add))]
 pub unsafe fn vaddq_u64(a: u64x2, b: u64x2) -> u64x2 {
@@ -121,7 +121,7 @@ pub unsafe fn vaddq_u64(a: u64x2, b: u64x2) -> u64x2 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(fadd))]
 pub unsafe fn vadd_f32(a: f32x2, b: f32x2) -> f32x2 {
@@ -129,7 +129,7 @@ pub unsafe fn vadd_f32(a: f32x2, b: f32x2) -> f32x2 {
 }
 
 /// Vector add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(fadd))]
 pub unsafe fn vaddq_f32(a: f32x4, b: f32x4) -> f32x4 {
@@ -137,7 +137,7 @@ pub unsafe fn vaddq_f32(a: f32x4, b: f32x4) -> f32x4 {
 }
 
 /// Vector long add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(saddl))]
 pub unsafe fn vaddl_s8(a: i8x8, b: i8x8) -> i16x8 {
@@ -147,7 +147,7 @@ pub unsafe fn vaddl_s8(a: i8x8, b: i8x8) -> i16x8 {
 }
 
 /// Vector long add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(saddl))]
 pub unsafe fn vaddl_s16(a: i16x4, b: i16x4) -> i32x4 {
@@ -157,7 +157,7 @@ pub unsafe fn vaddl_s16(a: i16x4, b: i16x4) -> i32x4 {
 }
 
 /// Vector long add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(saddl))]
 pub unsafe fn vaddl_s32(a: i32x2, b: i32x2) -> i64x2 {
@@ -167,7 +167,7 @@ pub unsafe fn vaddl_s32(a: i32x2, b: i32x2) -> i64x2 {
 }
 
 /// Vector long add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(uaddl))]
 pub unsafe fn vaddl_u8(a: u8x8, b: u8x8) -> u16x8 {
@@ -177,7 +177,7 @@ pub unsafe fn vaddl_u8(a: u8x8, b: u8x8) -> u16x8 {
 }
 
 /// Vector long add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(uaddl))]
 pub unsafe fn vaddl_u16(a: u16x4, b: u16x4) -> u32x4 {
@@ -187,7 +187,7 @@ pub unsafe fn vaddl_u16(a: u16x4, b: u16x4) -> u32x4 {
 }
 
 /// Vector long add.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(uaddl))]
 pub unsafe fn vaddl_u32(a: u32x2, b: u32x2) -> u64x2 {
@@ -205,7 +205,7 @@ extern "C" {
 }
 
 /// Reciprocal square-root estimate.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(frsqrte))]
 pub unsafe fn vrsqrte_f32(a: f32x2) -> f32x2 {

--- a/coresimd/src/arm/v6.rs
+++ b/coresimd/src/arm/v6.rs
@@ -10,14 +10,14 @@
 use stdsimd_test::assert_instr;
 
 /// Reverse the order of the bytes.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(rev))]
 pub unsafe fn _rev_u16(x: u16) -> u16 {
     x.swap_bytes() as u16
 }
 
 /// Reverse the order of the bytes.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(rev))]
 pub unsafe fn _rev_u32(x: u32) -> u32 {
     x.swap_bytes() as u32

--- a/coresimd/src/arm/v7.rs
+++ b/coresimd/src/arm/v7.rs
@@ -13,28 +13,28 @@ pub use super::v6::*;
 use stdsimd_test::assert_instr;
 
 /// Count Leading Zeros.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(clz))]
 pub unsafe fn _clz_u8(x: u8) -> u8 {
     x.leading_zeros() as u8
 }
 
 /// Count Leading Zeros.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(clz))]
 pub unsafe fn _clz_u16(x: u16) -> u16 {
     x.leading_zeros() as u16
 }
 
 /// Count Leading Zeros.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(clz))]
 pub unsafe fn _clz_u32(x: u32) -> u32 {
     x.leading_zeros() as u32
 }
 
 /// Reverse the bit order.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(rbit))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "v7"))]
 #[cfg(dont_compile_me)] // FIXME need to add `v7` upstream in rustc

--- a/coresimd/src/lib.rs
+++ b/coresimd/src/lib.rs
@@ -15,7 +15,7 @@
            simd_ffi, target_feature, cfg_target_feature, asm,
            const_atomic_usize_new, stmt_expr_attributes, core_intrinsics,
            crate_in_paths)]
-#![cfg_attr(test, feature(proc_macro, test, repr_align, attr_literals))]
+#![cfg_attr(test, feature(proc_macro, test, attr_literals))]
 #![cfg_attr(feature = "cargo-clippy",
             allow(inline_always, too_many_arguments, cast_sign_loss,
                   cast_lossless, cast_possible_wrap,

--- a/coresimd/src/lib.rs
+++ b/coresimd/src/lib.rs
@@ -12,7 +12,7 @@
 #![allow(dead_code)]
 #![allow(unused_features)]
 #![feature(const_fn, link_llvm_intrinsics, platform_intrinsics, repr_simd,
-           simd_ffi, target_feature, cfg_target_feature, i128_type, asm,
+           simd_ffi, target_feature, cfg_target_feature, asm,
            const_atomic_usize_new, stmt_expr_attributes, core_intrinsics,
            crate_in_paths)]
 #![cfg_attr(test, feature(proc_macro, test, repr_align, attr_literals))]

--- a/coresimd/src/macros.rs
+++ b/coresimd/src/macros.rs
@@ -25,17 +25,17 @@ macro_rules! define_impl {
         $($elname:ident),+
     ) => {
         impl $name {
-            #[inline(always)]
+            #[inline]
             pub const fn new($($elname: $elemty),*) -> $name {
                 $name($($elname),*)
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn len() -> i32 {
                 $nelems
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn splat(value: $elemty) -> $name {
                 $name($({
                     #[allow(non_camel_case_types, dead_code)]
@@ -44,24 +44,24 @@ macro_rules! define_impl {
                 }),*)
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn extract(self, idx: u32) -> $elemty {
                 assert!(idx < $nelems);
                 unsafe { self.extract_unchecked(idx) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub unsafe fn extract_unchecked(self, idx: u32) -> $elemty {
                 simd_extract(self, idx)
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn replace(self, idx: u32, val: $elemty) -> $name {
                 assert!(idx < $nelems);
                 unsafe { self.replace_unchecked(idx, val) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub unsafe fn replace_unchecked(
                 self,
                 idx: u32,
@@ -70,13 +70,13 @@ macro_rules! define_impl {
                 simd_insert(self, idx, val)
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn store(self, slice: &mut [$elemty], offset: usize) {
                 assert!(slice[offset..].len() >= $nelems);
                 unsafe { self.store_unchecked(slice, offset) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub unsafe fn store_unchecked(
                 self,
                 slice: &mut [$elemty],
@@ -91,13 +91,13 @@ macro_rules! define_impl {
                     size_of::<$name>());
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn load(slice: &[$elemty], offset: usize) -> $name {
                 assert!(slice[offset..].len() >= $nelems);
                 unsafe { $name::load_unchecked(slice, offset) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub unsafe fn load_unchecked(
                 slice: &[$elemty],
                 offset: usize,
@@ -113,32 +113,32 @@ macro_rules! define_impl {
                 x
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn eq(self, other: $name) -> $boolname {
                 unsafe { simd_eq(self, other) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn ne(self, other: $name) -> $boolname {
                 unsafe { simd_ne(self, other) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn lt(self, other: $name) -> $boolname {
                 unsafe { simd_lt(self, other) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn le(self, other: $name) -> $boolname {
                 unsafe { simd_le(self, other) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn gt(self, other: $name) -> $boolname {
                 unsafe { simd_gt(self, other) }
             }
 
-            #[inline(always)]
+            #[inline]
             pub fn ge(self, other: $name) -> $boolname {
                 unsafe { simd_ge(self, other) }
             }
@@ -150,7 +150,7 @@ macro_rules! define_from {
     ($to:ident, $($from:ident),+) => {
         $(
             impl From<$from> for $to {
-                #[inline(always)]
+                #[inline]
                 fn from(f: $from) -> $to {
                     unsafe { ::core::mem::transmute(f) }
                 }
@@ -164,7 +164,7 @@ macro_rules! define_common_ops {
         $(
             impl ::core::ops::Add for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn add(self, other: Self) -> Self {
                     unsafe { simd_add(self, other) }
                 }
@@ -172,7 +172,7 @@ macro_rules! define_common_ops {
 
             impl ::core::ops::Sub for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn sub(self, other: Self) -> Self {
                     unsafe { simd_sub(self, other) }
                 }
@@ -180,7 +180,7 @@ macro_rules! define_common_ops {
 
             impl ::core::ops::Mul for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn mul(self, other: Self) -> Self {
                     unsafe { simd_mul(self, other) }
                 }
@@ -188,7 +188,7 @@ macro_rules! define_common_ops {
 
             impl ::core::ops::Div for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn div(self, other: Self) -> Self {
                     unsafe { simd_div(self, other) }
                 }
@@ -196,42 +196,42 @@ macro_rules! define_common_ops {
 
             impl ::core::ops::Rem for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn rem(self, other: Self) -> Self {
                     unsafe { simd_rem(self, other) }
                 }
             }
 
             impl ::core::ops::AddAssign for $ty {
-                #[inline(always)]
+                #[inline]
                 fn add_assign(&mut self, other: Self) {
                     *self = *self + other;
                 }
             }
 
             impl ::core::ops::SubAssign for $ty {
-                #[inline(always)]
+                #[inline]
                 fn sub_assign(&mut self, other: Self) {
                     *self = *self - other;
                 }
             }
 
             impl ::core::ops::MulAssign for $ty {
-                #[inline(always)]
+                #[inline]
                 fn mul_assign(&mut self, other: Self) {
                     *self = *self * other;
                 }
             }
 
             impl ::core::ops::DivAssign for $ty {
-                #[inline(always)]
+                #[inline]
                 fn div_assign(&mut self, other: Self) {
                     *self = *self / other;
                 }
             }
 
             impl ::core::ops::RemAssign for $ty {
-                #[inline(always)]
+                #[inline]
                 fn rem_assign(&mut self, other: Self) {
                     *self = *self % other;
                 }
@@ -246,27 +246,27 @@ macro_rules! define_shifts {
         $(
             impl ::core::ops::Shl<$by> for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn shl(self, other: $by) -> Self {
                     unsafe { simd_shl(self, $ty::splat(other as $elem)) }
                 }
             }
             impl ::core::ops::Shr<$by> for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn shr(self, other: $by) -> Self {
                     unsafe { simd_shr(self, $ty::splat(other as $elem)) }
                 }
             }
 
             impl ::core::ops::ShlAssign<$by> for $ty {
-                #[inline(always)]
+                #[inline]
                 fn shl_assign(&mut self, other: $by) {
                     *self = *self << other;
                 }
             }
             impl ::core::ops::ShrAssign<$by> for $ty {
-                #[inline(always)]
+                #[inline]
                 fn shr_assign(&mut self, other: $by) {
                     *self = *self >> other;
                 }
@@ -281,7 +281,7 @@ macro_rules! define_float_ops {
         $(
             impl ::core::ops::Neg for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn neg(self) -> Self {
                     Self::splat(-1.0) * self
                 }
@@ -295,7 +295,7 @@ macro_rules! define_signed_integer_ops {
         $(
             impl ::core::ops::Neg for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn neg(self) -> Self {
                     Self::splat(-1) * self
                 }
@@ -309,7 +309,7 @@ macro_rules! define_integer_ops {
         $(
             impl ::core::ops::Not for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn not(self) -> Self {
                     $ty::splat(!0) ^ self
                 }
@@ -317,39 +317,39 @@ macro_rules! define_integer_ops {
 
             impl ::core::ops::BitAnd for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn bitand(self, other: Self) -> Self {
                     unsafe { simd_and(self, other) }
                 }
             }
             impl ::core::ops::BitOr for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn bitor(self, other: Self) -> Self {
                     unsafe { simd_or(self, other) }
                 }
             }
             impl ::core::ops::BitXor for $ty {
                 type Output = Self;
-                #[inline(always)]
+                #[inline]
                 fn bitxor(self, other: Self) -> Self {
                     unsafe { simd_xor(self, other) }
                 }
             }
             impl ::core::ops::BitAndAssign for $ty {
-                #[inline(always)]
+                #[inline]
                 fn bitand_assign(&mut self, other: Self) {
                     *self = *self & other;
                 }
             }
             impl ::core::ops::BitOrAssign for $ty {
-                #[inline(always)]
+                #[inline]
                 fn bitor_assign(&mut self, other: Self) {
                     *self = *self | other;
                 }
             }
             impl ::core::ops::BitXorAssign for $ty {
-                #[inline(always)]
+                #[inline]
                 fn bitxor_assign(&mut self, other: Self) {
                     *self = *self ^ other;
                 }
@@ -383,7 +383,7 @@ macro_rules! define_casts {
     ($(($fromty:ident, $toty:ident, $cast:ident)),+) => {
         $(
             impl $fromty {
-                #[inline(always)]
+                #[inline]
                 pub fn $cast(self) -> ::simd::$toty {
                     unsafe { simd_cast(self) }
                 }

--- a/coresimd/src/nvptx/mod.rs
+++ b/coresimd/src/nvptx/mod.rs
@@ -42,79 +42,79 @@ extern "C" {
 }
 
 /// Synchronizes all threads in the block.
-#[inline(always)]
+#[inline]
 pub unsafe fn _syncthreads() -> () {
     syncthreads()
 }
 
 /// x-th thread-block dimension.
-#[inline(always)]
+#[inline]
 pub unsafe fn _block_dim_x() -> i32 {
     block_dim_x()
 }
 
 /// y-th thread-block dimension.
-#[inline(always)]
+#[inline]
 pub unsafe fn _block_dim_y() -> i32 {
     block_dim_y()
 }
 
 /// z-th thread-block dimension.
-#[inline(always)]
+#[inline]
 pub unsafe fn _block_dim_z() -> i32 {
     block_dim_z()
 }
 
 /// x-th thread-block index.
-#[inline(always)]
+#[inline]
 pub unsafe fn _block_idx_x() -> i32 {
     block_idx_x()
 }
 
 /// y-th thread-block index.
-#[inline(always)]
+#[inline]
 pub unsafe fn _block_idx_y() -> i32 {
     block_idx_y()
 }
 
 /// z-th thread-block index.
-#[inline(always)]
+#[inline]
 pub unsafe fn _block_idx_z() -> i32 {
     block_idx_z()
 }
 
 /// x-th block-grid dimension.
-#[inline(always)]
+#[inline]
 pub unsafe fn _grid_dim_x() -> i32 {
     grid_dim_x()
 }
 
 /// y-th block-grid dimension.
-#[inline(always)]
+#[inline]
 pub unsafe fn _grid_dim_y() -> i32 {
     grid_dim_y()
 }
 
 /// z-th block-grid dimension.
-#[inline(always)]
+#[inline]
 pub unsafe fn _grid_dim_z() -> i32 {
     grid_dim_z()
 }
 
 /// x-th thread index.
-#[inline(always)]
+#[inline]
 pub unsafe fn _thread_idx_x() -> i32 {
     thread_idx_x()
 }
 
 /// y-th thread index.
-#[inline(always)]
+#[inline]
 pub unsafe fn _thread_idx_y() -> i32 {
     thread_idx_y()
 }
 
 /// z-th thread index.
-#[inline(always)]
+#[inline]
 pub unsafe fn _thread_idx_z() -> i32 {
     thread_idx_z()
 }

--- a/coresimd/src/runtime/x86.rs
+++ b/coresimd/src/runtime/x86.rs
@@ -111,7 +111,7 @@ macro_rules! __unstable_detect_feature {
         $unstable_detect_feature(
             $crate::__vendor_runtime::__Feature::fma{})
     };
-    ("bmi", $unstable_detect_feature:path) => {
+    ("bmi1", $unstable_detect_feature:path) => {
         $unstable_detect_feature(
             $crate::__vendor_runtime::__Feature::bmi{})
     };
@@ -473,7 +473,7 @@ mod tests {
         );
         println!("fma: {:?}", cfg_feature_enabled!("fma"));
         println!("abm: {:?}", cfg_feature_enabled!("abm"));
-        println!("bmi: {:?}", cfg_feature_enabled!("bmi"));
+        println!("bmi: {:?}", cfg_feature_enabled!("bmi1"));
         println!("bmi2: {:?}", cfg_feature_enabled!("bmi2"));
         println!("tbm: {:?}", cfg_feature_enabled!("tbm"));
         println!("popcnt: {:?}", cfg_feature_enabled!("popcnt"));
@@ -517,7 +517,7 @@ mod tests {
             information.avx512_vpopcntdq()
         );
         assert_eq!(cfg_feature_enabled!("fma"), information.fma());
-        assert_eq!(cfg_feature_enabled!("bmi"), information.bmi1());
+        assert_eq!(cfg_feature_enabled!("bmi1"), information.bmi1());
         assert_eq!(cfg_feature_enabled!("bmi2"), information.bmi2());
         assert_eq!(cfg_feature_enabled!("popcnt"), information.popcnt());
         assert_eq!(cfg_feature_enabled!("abm"), information.lzcnt());

--- a/coresimd/src/x86/i386/eflags.rs
+++ b/coresimd/src/x86/i386/eflags.rs
@@ -2,7 +2,7 @@
 
 /// Reads EFLAGS.
 #[cfg(target_arch = "x86")]
-#[inline(always)]
+#[inline]
 pub unsafe fn __readeflags() -> u32 {
     let eflags: u32;
     asm!("pushfd; popl $0" : "=r"(eflags) : : : "volatile");
@@ -11,7 +11,7 @@ pub unsafe fn __readeflags() -> u32 {
 
 /// Reads EFLAGS.
 #[cfg(target_arch = "x86_64")]
-#[inline(always)]
+#[inline]
 pub unsafe fn __readeflags() -> u64 {
     let eflags: u64;
     asm!("pushfq; popq $0" : "=r"(eflags) : : : "volatile");
@@ -20,14 +20,14 @@ pub unsafe fn __readeflags() -> u64 {
 
 /// Write EFLAGS.
 #[cfg(target_arch = "x86")]
-#[inline(always)]
+#[inline]
 pub unsafe fn __writeeflags(eflags: u32) {
     asm!("pushl $0; popfd" : : "r"(eflags) : "cc", "flags" : "volatile");
 }
 
 /// Write EFLAGS.
 #[cfg(target_arch = "x86_64")]
-#[inline(always)]
+#[inline]
 pub unsafe fn __writeeflags(eflags: u64) {
     asm!("pushq $0; popfq" : : "r"(eflags) : "cc", "flags" : "volatile");
 }

--- a/coresimd/src/x86/i386/fxsr.rs
+++ b/coresimd/src/x86/i386/fxsr.rs
@@ -21,7 +21,7 @@ extern "C" {
 ///
 /// [fxsave]: http://www.felixcloutier.com/x86/FXSAVE.html
 /// [fxrstor]: http://www.felixcloutier.com/x86/FXRSTOR.html
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "fxsr")]
 #[cfg_attr(test, assert_instr(fxsave))]
 pub unsafe fn _fxsave(mem_addr: *mut u8) {
@@ -42,7 +42,7 @@ pub unsafe fn _fxsave(mem_addr: *mut u8) {
 ///
 /// [fxsave]: http://www.felixcloutier.com/x86/FXSAVE.html
 /// [fxrstor]: http://www.felixcloutier.com/x86/FXRSTOR.html
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "fxsr")]
 #[cfg_attr(test, assert_instr(fxrstor))]
 pub unsafe fn _fxrstor(mem_addr: *const u8) {

--- a/coresimd/src/x86/i586/abm.rs
+++ b/coresimd/src/x86/i586/abm.rs
@@ -23,7 +23,7 @@ use stdsimd_test::assert_instr;
 /// Counts the leading most significant zero bits.
 ///
 /// When the operand is zero, it returns its size in bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "lzcnt")]
 #[cfg_attr(test, assert_instr(lzcnt))]
 pub unsafe fn _lzcnt_u32(x: u32) -> u32 {
@@ -33,7 +33,7 @@ pub unsafe fn _lzcnt_u32(x: u32) -> u32 {
 /// Counts the leading most significant zero bits.
 ///
 /// When the operand is zero, it returns its size in bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "lzcnt")]
 #[cfg_attr(test, assert_instr(lzcnt))]
 pub unsafe fn _lzcnt_u64(x: u64) -> u64 {
@@ -41,7 +41,7 @@ pub unsafe fn _lzcnt_u64(x: u64) -> u64 {
 }
 
 /// Counts the bits that are set.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "popcnt")]
 #[cfg_attr(test, assert_instr(popcnt))]
 pub unsafe fn _popcnt32(x: i32) -> i32 {
@@ -49,7 +49,7 @@ pub unsafe fn _popcnt32(x: i32) -> i32 {
 }
 
 /// Counts the bits that are set.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "popcnt")]
 #[cfg_attr(test, assert_instr(popcnt))]
 pub unsafe fn _popcnt64(x: i64) -> i32 {

--- a/coresimd/src/x86/i586/avx.rs
+++ b/coresimd/src/x86/i586/avx.rs
@@ -25,7 +25,7 @@ use v256::*;
 
 /// Add packed double-precision (64-bit) floating-point elements
 /// in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vaddpd))]
 pub unsafe fn _mm256_add_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -34,7 +34,7 @@ pub unsafe fn _mm256_add_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Add packed single-precision (32-bit) floating-point elements in `a` and
 /// `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vaddps))]
 pub unsafe fn _mm256_add_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -44,7 +44,7 @@ pub unsafe fn _mm256_add_ps(a: f32x8, b: f32x8) -> f32x8 {
 /// Compute the bitwise AND of a packed double-precision (64-bit)
 /// floating-point elements
 /// in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // FIXME: Should be 'vandpd' instuction.
 // See https://github.com/rust-lang-nursery/stdsimd/issues/71
@@ -57,7 +57,7 @@ pub unsafe fn _mm256_and_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Compute the bitwise AND of packed single-precision (32-bit) floating-point
 /// elements in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vandps))]
 pub unsafe fn _mm256_and_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -68,7 +68,7 @@ pub unsafe fn _mm256_and_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Compute the bitwise OR packed double-precision (64-bit) floating-point
 /// elements in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // FIXME: Should be 'vorpd' instuction.
 // See https://github.com/rust-lang-nursery/stdsimd/issues/71
@@ -81,7 +81,7 @@ pub unsafe fn _mm256_or_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Compute the bitwise OR packed single-precision (32-bit) floating-point
 /// elements in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vorps))]
 pub unsafe fn _mm256_or_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -92,7 +92,7 @@ pub unsafe fn _mm256_or_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Shuffle double-precision (64-bit) floating-point elements within 128-bit
 /// lanes using the control in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vshufpd, imm8 = 0x1))]
 pub unsafe fn _mm256_shuffle_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
@@ -134,7 +134,7 @@ pub unsafe fn _mm256_shuffle_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
 
 /// Shuffle single-precision (32-bit) floating-point elements in `a` within
 /// 128-bit lanes using the control in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vshufps, imm8 = 0x0))]
 pub unsafe fn _mm256_shuffle_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
@@ -185,7 +185,7 @@ pub unsafe fn _mm256_shuffle_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
 /// Compute the bitwise NOT of packed double-precision (64-bit) floating-point
 /// elements in `a`
 /// and then AND with `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // FIXME: Should be 'vandnpd' instruction.
 #[cfg_attr(test, assert_instr(vandnps))]
@@ -198,7 +198,7 @@ pub unsafe fn _mm256_andnot_pd(a: f64x4, b: f64x4) -> f64x4 {
 /// Compute the bitwise NOT of packed single-precision (32-bit) floating-point
 /// elements in `a`
 /// and then AND with `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vandnps))]
 pub unsafe fn _mm256_andnot_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -209,7 +209,7 @@ pub unsafe fn _mm256_andnot_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Compare packed double-precision (64-bit) floating-point elements
 /// in `a` and `b`, and return packed maximum values
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaxpd))]
 pub unsafe fn _mm256_max_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -218,7 +218,7 @@ pub unsafe fn _mm256_max_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Compare packed single-precision (32-bit) floating-point elements in `a`
 /// and `b`, and return packed maximum values
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaxps))]
 pub unsafe fn _mm256_max_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -227,7 +227,7 @@ pub unsafe fn _mm256_max_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Compare packed double-precision (64-bit) floating-point elements
 /// in `a` and `b`, and return packed minimum values
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vminpd))]
 pub unsafe fn _mm256_min_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -236,7 +236,7 @@ pub unsafe fn _mm256_min_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Compare packed single-precision (32-bit) floating-point elements in `a`
 /// and `b`, and return packed minimum values
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vminps))]
 pub unsafe fn _mm256_min_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -245,7 +245,7 @@ pub unsafe fn _mm256_min_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Add packed double-precision (64-bit) floating-point elements
 /// in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmulpd))]
 pub unsafe fn _mm256_mul_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -254,7 +254,7 @@ pub unsafe fn _mm256_mul_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Add packed single-precision (32-bit) floating-point elements in `a` and
 /// `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmulps))]
 pub unsafe fn _mm256_mul_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -263,7 +263,7 @@ pub unsafe fn _mm256_mul_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Alternatively add and subtract packed double-precision (64-bit)
 /// floating-point elements in `a` to/from packed elements in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vaddsubpd))]
 pub unsafe fn _mm256_addsub_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -272,7 +272,7 @@ pub unsafe fn _mm256_addsub_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Alternatively add and subtract packed single-precision (32-bit)
 /// floating-point elements in `a` to/from packed elements in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vaddsubps))]
 pub unsafe fn _mm256_addsub_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -281,7 +281,7 @@ pub unsafe fn _mm256_addsub_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Subtract packed double-precision (64-bit) floating-point elements in `b`
 /// from packed elements in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vsubpd))]
 pub unsafe fn _mm256_sub_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -290,7 +290,7 @@ pub unsafe fn _mm256_sub_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Subtract packed single-precision (32-bit) floating-point elements in `b`
 /// from packed elements in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vsubps))]
 pub unsafe fn _mm256_sub_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -299,7 +299,7 @@ pub unsafe fn _mm256_sub_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Compute the division of each of the 8 packed 32-bit floating-point elements
 /// in `a` by the corresponding packed elements in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vdivps))]
 pub unsafe fn _mm256_div_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -308,7 +308,7 @@ pub unsafe fn _mm256_div_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Compute the division of each of the 4 packed 64-bit floating-point elements
 /// in `a` by the corresponding packed elements in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vdivpd))]
 pub unsafe fn _mm256_div_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -326,7 +326,7 @@ pub unsafe fn _mm256_div_pd(a: f64x4, b: f64x4) -> f64x4 {
 /// For a complete list of options, check [the LLVM docs][llvm_docs].
 ///
 /// [llvm_docs]: https://github.com/llvm-mirror/clang/blob/dcd8d797b20291f1a6b3e0ddda085aa2bbb382a8/lib/Headers/avxintrin.h#L382
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vroundpd, b = 0x3))]
 pub unsafe fn _mm256_round_pd(a: f64x4, b: i32) -> f64x4 {
@@ -338,7 +338,7 @@ pub unsafe fn _mm256_round_pd(a: f64x4, b: i32) -> f64x4 {
 
 /// Round packed double-precision (64-bit) floating point elements in `a`
 /// toward positive infinity.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vroundpd))]
 pub unsafe fn _mm256_ceil_pd(a: f64x4) -> f64x4 {
@@ -347,7 +347,7 @@ pub unsafe fn _mm256_ceil_pd(a: f64x4) -> f64x4 {
 
 /// Round packed double-precision (64-bit) floating point elements in `a`
 /// toward negative infinity.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vroundpd))]
 pub unsafe fn _mm256_floor_pd(a: f64x4) -> f64x4 {
@@ -365,7 +365,7 @@ pub unsafe fn _mm256_floor_pd(a: f64x4) -> f64x4 {
 /// For a complete list of options, check [the LLVM docs][llvm_docs].
 ///
 /// [llvm_docs]: https://github.com/llvm-mirror/clang/blob/dcd8d797b20291f1a6b3e0ddda085aa2bbb382a8/lib/Headers/avxintrin.h#L382
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vroundps, b = 0x00))]
 pub unsafe fn _mm256_round_ps(a: f32x8, b: i32) -> f32x8 {
@@ -379,7 +379,7 @@ pub unsafe fn _mm256_round_ps(a: f32x8, b: i32) -> f32x8 {
 
 /// Round packed single-precision (32-bit) floating point elements in `a`
 /// toward positive infinity.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vroundps))]
 pub unsafe fn _mm256_ceil_ps(a: f32x8) -> f32x8 {
@@ -388,7 +388,7 @@ pub unsafe fn _mm256_ceil_ps(a: f32x8) -> f32x8 {
 
 /// Round packed single-precision (32-bit) floating point elements in `a`
 /// toward negative infinity.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vroundps))]
 pub unsafe fn _mm256_floor_ps(a: f32x8) -> f32x8 {
@@ -397,7 +397,7 @@ pub unsafe fn _mm256_floor_ps(a: f32x8) -> f32x8 {
 
 /// Return the square root of packed single-precision (32-bit) floating point
 /// elements in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vsqrtps))]
 pub unsafe fn _mm256_sqrt_ps(a: f32x8) -> f32x8 {
@@ -406,7 +406,7 @@ pub unsafe fn _mm256_sqrt_ps(a: f32x8) -> f32x8 {
 
 /// Return the square root of packed double-precision (64-bit) floating point
 /// elements in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vsqrtpd))]
 pub unsafe fn _mm256_sqrt_pd(a: f64x4) -> f64x4 {
@@ -415,7 +415,7 @@ pub unsafe fn _mm256_sqrt_pd(a: f64x4) -> f64x4 {
 
 /// Blend packed double-precision (64-bit) floating-point elements from
 /// `a` and `b` using control mask `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vblendpd, imm8 = 9))]
 pub unsafe fn _mm256_blend_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
@@ -457,7 +457,7 @@ pub unsafe fn _mm256_blend_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
 
 /// Blend packed single-precision (32-bit) floating-point elements from
 /// `a` and `b` using control mask `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vblendps, imm8 = 9))]
 pub unsafe fn _mm256_blend_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
@@ -507,7 +507,7 @@ pub unsafe fn _mm256_blend_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
 
 /// Blend packed double-precision (64-bit) floating-point elements from
 /// `a` and `b` using `c` as a mask.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vblendvpd))]
 pub unsafe fn _mm256_blendv_pd(a: f64x4, b: f64x4, c: f64x4) -> f64x4 {
@@ -516,7 +516,7 @@ pub unsafe fn _mm256_blendv_pd(a: f64x4, b: f64x4, c: f64x4) -> f64x4 {
 
 /// Blend packed single-precision (32-bit) floating-point elements from
 /// `a` and `b` using `c` as a mask.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vblendvps))]
 pub unsafe fn _mm256_blendv_ps(a: f32x8, b: f32x8, c: f32x8) -> f32x8 {
@@ -527,7 +527,7 @@ pub unsafe fn _mm256_blendv_ps(a: f32x8, b: f32x8, c: f32x8) -> f32x8 {
 /// elements in `a` and `b` using the high 4 bits in `imm8`,
 /// sum the four products, and conditionally return the sum
 ///  using the low 4 bits of `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vdpps, imm8 = 0x0))]
 pub unsafe fn _mm256_dp_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
@@ -541,7 +541,7 @@ pub unsafe fn _mm256_dp_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
 /// of 4 64-bit floating points `a` and `b`.
 /// In the result, sums of elements from `a` are returned in even locations,
 /// while sums of elements from `b` are returned in odd locations.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vhaddpd))]
 pub unsafe fn _mm256_hadd_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -553,7 +553,7 @@ pub unsafe fn _mm256_hadd_pd(a: f64x4, b: f64x4) -> f64x4 {
 /// In the result, sums of elements from `a` are returned in locations of
 /// indices 0, 1, 4, 5; while sums of elements from `b` are locations
 /// 2, 3, 6, 7.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vhaddps))]
 pub unsafe fn _mm256_hadd_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -564,7 +564,7 @@ pub unsafe fn _mm256_hadd_ps(a: f32x8, b: f32x8) -> f32x8 {
 /// of 4 64-bit floating points `a` and `b`.
 /// In the result, sums of elements from `a` are returned in even locations,
 /// while sums of elements from `b` are returned in odd locations.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vhsubpd))]
 pub unsafe fn _mm256_hsub_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -576,7 +576,7 @@ pub unsafe fn _mm256_hsub_pd(a: f64x4, b: f64x4) -> f64x4 {
 /// In the result, sums of elements from `a` are returned in locations of
 /// indices 0, 1, 4, 5; while sums of elements from `b` are locations
 /// 2, 3, 6, 7.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vhsubps))]
 pub unsafe fn _mm256_hsub_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -585,7 +585,7 @@ pub unsafe fn _mm256_hsub_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Compute the bitwise XOR of packed double-precision (64-bit) floating-point
 /// elements in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // FIXME Should be 'vxorpd' instruction.
 #[cfg_attr(test, assert_instr(vxorps))]
@@ -597,7 +597,7 @@ pub unsafe fn _mm256_xor_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Compute the bitwise XOR of packed single-precision (32-bit) floating-point
 /// elements in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vxorps))]
 pub unsafe fn _mm256_xor_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -674,7 +674,7 @@ pub const _CMP_TRUE_US: i32 = 0x1f;
 /// Compare packed double-precision (64-bit) floating-point
 /// elements in `a` and `b` based on the comparison operand
 /// specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 #[cfg_attr(test, assert_instr(vcmpeqpd, imm8 = 0))] // TODO Validate vcmppd
 pub unsafe fn _mm_cmp_pd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
@@ -687,7 +687,7 @@ pub unsafe fn _mm_cmp_pd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
 /// Compare packed double-precision (64-bit) floating-point
 /// elements in `a` and `b` based on the comparison operand
 /// specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcmpeqpd, imm8 = 0))] // TODO Validate vcmppd
 pub unsafe fn _mm256_cmp_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
@@ -700,7 +700,7 @@ pub unsafe fn _mm256_cmp_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
 /// Compare packed single-precision (32-bit) floating-point
 /// elements in `a` and `b` based on the comparison operand
 /// specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse")]
 #[cfg_attr(test, assert_instr(vcmpeqps, imm8 = 0))] // TODO Validate vcmpps
 pub unsafe fn _mm_cmp_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
@@ -713,7 +713,7 @@ pub unsafe fn _mm_cmp_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
 /// Compare packed single-precision (32-bit) floating-point
 /// elements in `a` and `b` based on the comparison operand
 /// specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcmpeqps, imm8 = 0))] // TODO Validate vcmpps
 pub unsafe fn _mm256_cmp_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
@@ -728,7 +728,7 @@ pub unsafe fn _mm256_cmp_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
 /// store the result in the lower element of returned vector,
 /// and copy the upper element from `a` to the upper element of returned
 /// vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 #[cfg_attr(test, assert_instr(vcmpeqsd, imm8 = 0))] // TODO Validate vcmpsd
 pub unsafe fn _mm_cmp_sd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
@@ -743,7 +743,7 @@ pub unsafe fn _mm_cmp_sd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
 /// store the result in the lower element of returned vector,
 /// and copy the upper 3 packed elements from `a` to the upper elements of
 /// returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse")]
 #[cfg_attr(test, assert_instr(vcmpeqss, imm8 = 0))] // TODO Validate vcmpss
 pub unsafe fn _mm_cmp_ss(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
@@ -755,7 +755,7 @@ pub unsafe fn _mm_cmp_ss(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
 
 /// Convert packed 32-bit integers in `a` to packed double-precision (64-bit)
 /// floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcvtdq2pd))]
 pub unsafe fn _mm256_cvtepi32_pd(a: i32x4) -> f64x4 {
@@ -764,7 +764,7 @@ pub unsafe fn _mm256_cvtepi32_pd(a: i32x4) -> f64x4 {
 
 /// Convert packed 32-bit integers in `a` to packed single-precision (32-bit)
 /// floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcvtdq2ps))]
 pub unsafe fn _mm256_cvtepi32_ps(a: i32x8) -> f32x8 {
@@ -773,7 +773,7 @@ pub unsafe fn _mm256_cvtepi32_ps(a: i32x8) -> f32x8 {
 
 /// Convert packed double-precision (64-bit) floating-point elements in `a`
 /// to packed single-precision (32-bit) floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcvtpd2ps))]
 pub unsafe fn _mm256_cvtpd_ps(a: f64x4) -> f32x4 {
@@ -782,7 +782,7 @@ pub unsafe fn _mm256_cvtpd_ps(a: f64x4) -> f32x4 {
 
 /// Convert packed single-precision (32-bit) floating-point elements in `a`
 /// to packed 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcvtps2dq))]
 pub unsafe fn _mm256_cvtps_epi32(a: f32x8) -> i32x8 {
@@ -791,7 +791,7 @@ pub unsafe fn _mm256_cvtps_epi32(a: f32x8) -> i32x8 {
 
 /// Convert packed single-precision (32-bit) floating-point elements in `a`
 /// to packed double-precision (64-bit) floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcvtps2pd))]
 pub unsafe fn _mm256_cvtps_pd(a: f32x4) -> f64x4 {
@@ -800,7 +800,7 @@ pub unsafe fn _mm256_cvtps_pd(a: f32x4) -> f64x4 {
 
 /// Convert packed double-precision (64-bit) floating-point elements in `a`
 /// to packed 32-bit integers with truncation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcvttpd2dq))]
 pub unsafe fn _mm256_cvttpd_epi32(a: f64x4) -> i32x4 {
@@ -809,7 +809,7 @@ pub unsafe fn _mm256_cvttpd_epi32(a: f64x4) -> i32x4 {
 
 /// Convert packed double-precision (64-bit) floating-point elements in `a`
 /// to packed 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcvtpd2dq))]
 pub unsafe fn _mm256_cvtpd_epi32(a: f64x4) -> i32x4 {
@@ -818,7 +818,7 @@ pub unsafe fn _mm256_cvtpd_epi32(a: f64x4) -> i32x4 {
 
 /// Convert packed single-precision (32-bit) floating-point elements in `a`
 /// to packed 32-bit integers with truncation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vcvttps2dq))]
 pub unsafe fn _mm256_cvttps_epi32(a: f32x8) -> i32x8 {
@@ -827,7 +827,7 @@ pub unsafe fn _mm256_cvttps_epi32(a: f32x8) -> i32x8 {
 
 /// Extract 128 bits (composed of 4 packed single-precision (32-bit)
 /// floating-point elements) from `a`, selected with `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vextractf128))]
 pub unsafe fn _mm256_extractf128_ps(a: f32x8, imm8: i32) -> f32x4 {
@@ -839,7 +839,7 @@ pub unsafe fn _mm256_extractf128_ps(a: f32x8, imm8: i32) -> f32x4 {
 
 /// Extract 128 bits (composed of 2 packed double-precision (64-bit)
 /// floating-point elements) from `a`, selected with `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vextractf128))]
 pub unsafe fn _mm256_extractf128_pd(a: f64x4, imm8: i32) -> f64x2 {
@@ -850,7 +850,7 @@ pub unsafe fn _mm256_extractf128_pd(a: f64x4, imm8: i32) -> f64x2 {
 }
 
 /// Extract 128 bits (composed of integer data) from `a`, selected with `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vextractf128))]
 pub unsafe fn _mm256_extractf128_si256(a: __m256i, imm8: i32) -> __m128i {
@@ -863,7 +863,7 @@ pub unsafe fn _mm256_extractf128_si256(a: __m256i, imm8: i32) -> __m128i {
 }
 
 /// Zero the contents of all XMM or YMM registers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vzeroall))]
 pub unsafe fn _mm256_zeroall() {
@@ -872,7 +872,7 @@ pub unsafe fn _mm256_zeroall() {
 
 /// Zero the upper 128 bits of all YMM registers;
 /// the lower 128-bits of the registers are unmodified.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vzeroupper))]
 pub unsafe fn _mm256_zeroupper() {
@@ -881,7 +881,7 @@ pub unsafe fn _mm256_zeroupper() {
 
 /// Shuffle single-precision (32-bit) floating-point elements in `a`
 /// within 128-bit lanes using the control in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vpermilps))]
 pub unsafe fn _mm256_permutevar_ps(a: f32x8, b: i32x8) -> f32x8 {
@@ -890,7 +890,7 @@ pub unsafe fn _mm256_permutevar_ps(a: f32x8, b: i32x8) -> f32x8 {
 
 /// Shuffle single-precision (32-bit) floating-point elements in `a`
 /// using the control in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vpermilps))]
 pub unsafe fn _mm_permutevar_ps(a: f32x4, b: i32x4) -> f32x4 {
@@ -899,7 +899,7 @@ pub unsafe fn _mm_permutevar_ps(a: f32x4, b: i32x4) -> f32x4 {
 
 /// Shuffle single-precision (32-bit) floating-point elements in `a`
 /// within 128-bit lanes using the control in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vpermilps, imm8 = 9))]
 pub unsafe fn _mm256_permute_ps(a: f32x8, imm8: i32) -> f32x8 {
@@ -951,7 +951,7 @@ pub unsafe fn _mm256_permute_ps(a: f32x8, imm8: i32) -> f32x8 {
 
 /// Shuffle single-precision (32-bit) floating-point elements in `a`
 /// using the control in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse")]
 #[cfg_attr(test, assert_instr(vpermilps, imm8 = 9))]
 pub unsafe fn _mm_permute_ps(a: f32x4, imm8: i32) -> f32x4 {
@@ -1005,7 +1005,7 @@ pub unsafe fn _mm_permute_ps(a: f32x4, imm8: i32) -> f32x4 {
 
 /// Shuffle double-precision (64-bit) floating-point elements in `a`
 /// within 256-bit lanes using the control in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vpermilpd))]
 pub unsafe fn _mm256_permutevar_pd(a: f64x4, b: i64x4) -> f64x4 {
@@ -1014,7 +1014,7 @@ pub unsafe fn _mm256_permutevar_pd(a: f64x4, b: i64x4) -> f64x4 {
 
 /// Shuffle double-precision (64-bit) floating-point elements in `a`
 /// using the control in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vpermilpd))]
 pub unsafe fn _mm_permutevar_pd(a: f64x2, b: i64x2) -> f64x2 {
@@ -1023,7 +1023,7 @@ pub unsafe fn _mm_permutevar_pd(a: f64x2, b: i64x2) -> f64x2 {
 
 /// Shuffle double-precision (64-bit) floating-point elements in `a`
 /// within 128-bit lanes using the control in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vpermilpd, imm8 = 0x1))]
 pub unsafe fn _mm256_permute_pd(a: f64x4, imm8: i32) -> f64x4 {
@@ -1065,7 +1065,7 @@ pub unsafe fn _mm256_permute_pd(a: f64x4, imm8: i32) -> f64x4 {
 
 /// Shuffle double-precision (64-bit) floating-point elements in `a`
 /// using the control in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 #[cfg_attr(test, assert_instr(vpermilpd, imm8 = 0x1))]
 pub unsafe fn _mm_permute_pd(a: f64x2, imm8: i32) -> f64x2 {
@@ -1093,7 +1093,7 @@ pub unsafe fn _mm_permute_pd(a: f64x2, imm8: i32) -> f64x2 {
 
 /// Shuffle 256-bits (composed of 8 packed single-precision (32-bit)
 /// floating-point elements) selected by `imm8` from `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x5))]
 pub unsafe fn _mm256_permute2f128_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
@@ -1105,7 +1105,7 @@ pub unsafe fn _mm256_permute2f128_ps(a: f32x8, b: f32x8, imm8: i32) -> f32x8 {
 
 /// Shuffle 256-bits (composed of 4 packed double-precision (64-bit)
 /// floating-point elements) selected by `imm8` from `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x31))]
 pub unsafe fn _mm256_permute2f128_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
@@ -1117,7 +1117,7 @@ pub unsafe fn _mm256_permute2f128_pd(a: f64x4, b: f64x4, imm8: i32) -> f64x4 {
 
 /// Shuffle 258-bits (composed of integer data) selected by `imm8`
 /// from `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x31))]
 pub unsafe fn _mm256_permute2f128_si256(
@@ -1131,7 +1131,7 @@ pub unsafe fn _mm256_permute2f128_si256(
 
 /// Broadcast a single-precision (32-bit) floating-point element from memory
 /// to all elements of the returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 pub unsafe fn _mm256_broadcast_ss(f: &f32) -> f32x8 {
@@ -1140,7 +1140,7 @@ pub unsafe fn _mm256_broadcast_ss(f: &f32) -> f32x8 {
 
 /// Broadcast a single-precision (32-bit) floating-point element from memory
 /// to all elements of the returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 pub unsafe fn _mm_broadcast_ss(f: &f32) -> f32x4 {
@@ -1149,7 +1149,7 @@ pub unsafe fn _mm_broadcast_ss(f: &f32) -> f32x4 {
 
 /// Broadcast a double-precision (64-bit) floating-point element from memory
 /// to all elements of the returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vbroadcastsd))]
 pub unsafe fn _mm256_broadcast_sd(f: &f64) -> f64x4 {
@@ -1158,7 +1158,7 @@ pub unsafe fn _mm256_broadcast_sd(f: &f64) -> f64x4 {
 
 /// Broadcast 128 bits from memory (composed of 4 packed single-precision
 /// (32-bit) floating-point elements) to all elements of the returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vbroadcastf128))]
 pub unsafe fn _mm256_broadcast_ps(a: &f32x4) -> f32x8 {
@@ -1167,7 +1167,7 @@ pub unsafe fn _mm256_broadcast_ps(a: &f32x4) -> f32x8 {
 
 /// Broadcast 128 bits from memory (composed of 2 packed double-precision
 /// (64-bit) floating-point elements) to all elements of the returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vbroadcastf128))]
 pub unsafe fn _mm256_broadcast_pd(a: &f64x2) -> f64x4 {
@@ -1177,7 +1177,7 @@ pub unsafe fn _mm256_broadcast_pd(a: &f64x2) -> f64x4 {
 /// Copy `a` to result, then insert 128 bits (composed of 4 packed
 /// single-precision (32-bit) floating-point elements) from `b` into result
 /// at the location specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128, imm8 = 1))]
 pub unsafe fn _mm256_insertf128_ps(a: f32x8, b: f32x4, imm8: i32) -> f32x8 {
@@ -1191,7 +1191,7 @@ pub unsafe fn _mm256_insertf128_ps(a: f32x8, b: f32x4, imm8: i32) -> f32x8 {
 /// Copy `a` to result, then insert 128 bits (composed of 2 packed
 /// double-precision (64-bit) floating-point elements) from `b` into result
 /// at the location specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128, imm8 = 1))]
 pub unsafe fn _mm256_insertf128_pd(a: f64x4, b: f64x2, imm8: i32) -> f64x4 {
@@ -1203,7 +1203,7 @@ pub unsafe fn _mm256_insertf128_pd(a: f64x4, b: f64x2, imm8: i32) -> f64x4 {
 
 /// Copy `a` to result, then insert 128 bits from `b` into result
 /// at the location specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128, imm8 = 1))]
 pub unsafe fn _mm256_insertf128_si256(
@@ -1219,7 +1219,7 @@ pub unsafe fn _mm256_insertf128_si256(
 
 /// Copy `a` to result, and insert the 8-bit integer `i` into result
 /// at the location specified by `index`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_insert_epi8(a: i8x32, i: i8, index: i32) -> i8x32 {
@@ -1229,7 +1229,7 @@ pub unsafe fn _mm256_insert_epi8(a: i8x32, i: i8, index: i32) -> i8x32 {
 
 /// Copy `a` to result, and insert the 16-bit integer `i` into result
 /// at the location specified by `index`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_insert_epi16(a: i16x16, i: i16, index: i32) -> i16x16 {
@@ -1239,7 +1239,7 @@ pub unsafe fn _mm256_insert_epi16(a: i16x16, i: i16, index: i32) -> i16x16 {
 
 /// Copy `a` to result, and insert the 32-bit integer `i` into result
 /// at the location specified by `index`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_insert_epi32(a: i32x8, i: i32, index: i32) -> i32x8 {
@@ -1249,7 +1249,7 @@ pub unsafe fn _mm256_insert_epi32(a: i32x8, i: i32, index: i32) -> i32x8 {
 
 /// Copy `a` to result, and insert the 64-bit integer `i` into result
 /// at the location specified by `index`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_insert_epi64(a: i64x4, i: i64, index: i32) -> i64x4 {
@@ -1261,7 +1261,7 @@ pub unsafe fn _mm256_insert_epi64(a: i64x4, i: i64, index: i32) -> i64x4 {
 /// floating-point elements) from memory into result.
 /// `mem_addr` must be aligned on a 32-byte boundary or a
 /// general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovaps))] // FIXME vmovapd expected
 pub unsafe fn _mm256_load_pd(mem_addr: *const f64) -> f64x4 {
@@ -1272,7 +1272,7 @@ pub unsafe fn _mm256_load_pd(mem_addr: *const f64) -> f64x4 {
 /// floating-point elements) from `a` into memory.
 /// `mem_addr` must be aligned on a 32-byte boundary or a
 /// general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovaps))] // FIXME vmovapd expected
 pub unsafe fn _mm256_store_pd(mem_addr: *const f64, a: f64x4) {
@@ -1283,7 +1283,7 @@ pub unsafe fn _mm256_store_pd(mem_addr: *const f64, a: f64x4) {
 /// floating-point elements) from memory into result.
 /// `mem_addr` must be aligned on a 32-byte boundary or a
 /// general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovaps))]
 pub unsafe fn _mm256_load_ps(mem_addr: *const f32) -> f32x8 {
@@ -1294,7 +1294,7 @@ pub unsafe fn _mm256_load_ps(mem_addr: *const f32) -> f32x8 {
 /// floating-point elements) from `a` into memory.
 /// `mem_addr` must be aligned on a 32-byte boundary or a
 /// general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovaps))]
 pub unsafe fn _mm256_store_ps(mem_addr: *const f32, a: f32x8) {
@@ -1304,7 +1304,7 @@ pub unsafe fn _mm256_store_ps(mem_addr: *const f32, a: f32x8) {
 /// Load 256-bits (composed of 4 packed double-precision (64-bit)
 /// floating-point elements) from memory into result.
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovups))] // FIXME vmovupd expected
 pub unsafe fn _mm256_loadu_pd(mem_addr: *const f64) -> f64x4 {
@@ -1320,7 +1320,7 @@ pub unsafe fn _mm256_loadu_pd(mem_addr: *const f64) -> f64x4 {
 /// Store 256-bits (composed of 4 packed double-precision (64-bit)
 /// floating-point elements) from `a` into memory.
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovups))] // FIXME vmovupd expected
 pub unsafe fn _mm256_storeu_pd(mem_addr: *mut f64, a: f64x4) {
@@ -1330,7 +1330,7 @@ pub unsafe fn _mm256_storeu_pd(mem_addr: *mut f64, a: f64x4) {
 /// Load 256-bits (composed of 8 packed single-precision (32-bit)
 /// floating-point elements) from memory into result.
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovups))]
 pub unsafe fn _mm256_loadu_ps(mem_addr: *const f32) -> f32x8 {
@@ -1346,7 +1346,7 @@ pub unsafe fn _mm256_loadu_ps(mem_addr: *const f32) -> f32x8 {
 /// Store 256-bits (composed of 8 packed single-precision (32-bit)
 /// floating-point elements) from `a` into memory.
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovups))]
 pub unsafe fn _mm256_storeu_ps(mem_addr: *mut f32, a: f32x8) {
@@ -1356,7 +1356,7 @@ pub unsafe fn _mm256_storeu_ps(mem_addr: *mut f32, a: f32x8) {
 /// Load 256-bits of integer data from memory into result.
 /// `mem_addr` must be aligned on a 32-byte boundary or a
 /// general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovaps))] // FIXME vmovdqa expected
 pub unsafe fn _mm256_load_si256(mem_addr: *const __m256i) -> __m256i {
@@ -1366,7 +1366,7 @@ pub unsafe fn _mm256_load_si256(mem_addr: *const __m256i) -> __m256i {
 /// Store 256-bits of integer data from `a` into memory.
 /// `mem_addr` must be aligned on a 32-byte boundary or a
 /// general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovaps))] // FIXME vmovdqa expected
 pub unsafe fn _mm256_store_si256(mem_addr: *mut __m256i, a: __m256i) {
@@ -1375,7 +1375,7 @@ pub unsafe fn _mm256_store_si256(mem_addr: *mut __m256i, a: __m256i) {
 
 /// Load 256-bits of integer data from memory into result.
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovups))] // FIXME vmovdqu expected
 pub unsafe fn _mm256_loadu_si256(mem_addr: *const __m256i) -> __m256i {
@@ -1390,7 +1390,7 @@ pub unsafe fn _mm256_loadu_si256(mem_addr: *const __m256i) -> __m256i {
 
 /// Store 256-bits of integer data from `a` into memory.
 ///     `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovups))] // FIXME vmovdqu expected
 pub unsafe fn _mm256_storeu_si256(mem_addr: *mut __m256i, a: __m256i) {
@@ -1400,7 +1400,7 @@ pub unsafe fn _mm256_storeu_si256(mem_addr: *mut __m256i, a: __m256i) {
 /// Load packed double-precision (64-bit) floating-point elements from memory
 /// into result using `mask` (elements are zeroed out when the high bit of the
 /// corresponding element is not set).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovpd))]
 pub unsafe fn _mm256_maskload_pd(mem_addr: *const f64, mask: i64x4) -> f64x4 {
@@ -1409,7 +1409,7 @@ pub unsafe fn _mm256_maskload_pd(mem_addr: *const f64, mask: i64x4) -> f64x4 {
 
 /// Store packed double-precision (64-bit) floating-point elements from `a`
 /// into memory using `mask`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovpd))]
 pub unsafe fn _mm256_maskstore_pd(mem_addr: *mut f64, mask: i64x4, a: f64x4) {
@@ -1419,7 +1419,7 @@ pub unsafe fn _mm256_maskstore_pd(mem_addr: *mut f64, mask: i64x4, a: f64x4) {
 /// Load packed double-precision (64-bit) floating-point elements from memory
 /// into result using `mask` (elements are zeroed out when the high bit of the
 /// corresponding element is not set).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovpd))]
 pub unsafe fn _mm_maskload_pd(mem_addr: *const f64, mask: i64x2) -> f64x2 {
@@ -1428,7 +1428,7 @@ pub unsafe fn _mm_maskload_pd(mem_addr: *const f64, mask: i64x2) -> f64x2 {
 
 /// Store packed double-precision (64-bit) floating-point elements from `a`
 /// into memory using `mask`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovpd))]
 pub unsafe fn _mm_maskstore_pd(mem_addr: *mut f64, mask: i64x2, a: f64x2) {
@@ -1438,7 +1438,7 @@ pub unsafe fn _mm_maskstore_pd(mem_addr: *mut f64, mask: i64x2, a: f64x2) {
 /// Load packed single-precision (32-bit) floating-point elements from memory
 /// into result using `mask` (elements are zeroed out when the high bit of the
 /// corresponding element is not set).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovps))]
 pub unsafe fn _mm256_maskload_ps(mem_addr: *const f32, mask: i32x8) -> f32x8 {
@@ -1447,7 +1447,7 @@ pub unsafe fn _mm256_maskload_ps(mem_addr: *const f32, mask: i32x8) -> f32x8 {
 
 /// Store packed single-precision (32-bit) floating-point elements from `a`
 /// into memory using `mask`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovps))]
 pub unsafe fn _mm256_maskstore_ps(mem_addr: *mut f32, mask: i32x8, a: f32x8) {
@@ -1457,7 +1457,7 @@ pub unsafe fn _mm256_maskstore_ps(mem_addr: *mut f32, mask: i32x8, a: f32x8) {
 /// Load packed single-precision (32-bit) floating-point elements from memory
 /// into result using `mask` (elements are zeroed out when the high bit of the
 /// corresponding element is not set).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovps))]
 pub unsafe fn _mm_maskload_ps(mem_addr: *const f32, mask: i32x4) -> f32x4 {
@@ -1466,7 +1466,7 @@ pub unsafe fn _mm_maskload_ps(mem_addr: *const f32, mask: i32x4) -> f32x4 {
 
 /// Store packed single-precision (32-bit) floating-point elements from `a`
 /// into memory using `mask`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovps))]
 pub unsafe fn _mm_maskstore_ps(mem_addr: *mut f32, mask: i32x4, a: f32x4) {
@@ -1475,7 +1475,7 @@ pub unsafe fn _mm_maskstore_ps(mem_addr: *mut f32, mask: i32x4, a: f32x4) {
 
 /// Duplicate odd-indexed single-precision (32-bit) floating-point elements
 /// from `a`, and return the results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovshdup))]
 pub unsafe fn _mm256_movehdup_ps(a: f32x8) -> f32x8 {
@@ -1484,7 +1484,7 @@ pub unsafe fn _mm256_movehdup_ps(a: f32x8) -> f32x8 {
 
 /// Duplicate even-indexed single-precision (32-bit) floating-point elements
 /// from `a`, and return the results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovsldup))]
 pub unsafe fn _mm256_moveldup_ps(a: f32x8) -> f32x8 {
@@ -1493,7 +1493,7 @@ pub unsafe fn _mm256_moveldup_ps(a: f32x8) -> f32x8 {
 
 /// Duplicate even-indexed double-precision (64-bit) floating-point elements
 /// from "a", and return the results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovddup))]
 pub unsafe fn _mm256_movedup_pd(a: f64x4) -> f64x4 {
@@ -1503,7 +1503,7 @@ pub unsafe fn _mm256_movedup_pd(a: f64x4) -> f64x4 {
 /// Load 256-bits of integer data from unaligned memory into result.
 /// This intrinsic may perform better than `_mm256_loadu_si256` when the
 /// data crosses a cache line boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vlddqu))]
 pub unsafe fn _mm256_lddqu_si256(mem_addr: *const i8x32) -> i8x32 {
@@ -1513,7 +1513,7 @@ pub unsafe fn _mm256_lddqu_si256(mem_addr: *const i8x32) -> i8x32 {
 /// Moves integer data from a 256-bit integer vector to a 32-byte
 /// aligned memory location. To minimize caching, the data is flagged as
 /// non-temporal (unlikely to be used again soon)
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovntps))] // FIXME vmovntdq
 pub unsafe fn _mm256_stream_si256(mem_addr: *const __m256i, a: __m256i) {
@@ -1523,7 +1523,7 @@ pub unsafe fn _mm256_stream_si256(mem_addr: *const __m256i, a: __m256i) {
 /// Moves double-precision values from a 256-bit vector of [4 x double]
 /// to a 32-byte aligned memory location. To minimize caching, the data is
 /// flagged as non-temporal (unlikely to be used again soon).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovntps))] // FIXME vmovntpd
 pub unsafe fn _mm256_stream_pd(mem_addr: *const f64, a: f64x4) {
@@ -1534,7 +1534,7 @@ pub unsafe fn _mm256_stream_pd(mem_addr: *const f64, a: f64x4) {
 /// of [8 x float] to a 32-byte aligned memory location. To minimize
 /// caching, the data is flagged as non-temporal (unlikely to be used again
 /// soon).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovntps))]
 pub unsafe fn _mm256_stream_ps(mem_addr: *const f32, a: f32x8) {
@@ -1544,7 +1544,7 @@ pub unsafe fn _mm256_stream_ps(mem_addr: *const f32, a: f32x8) {
 /// Compute the approximate reciprocal of packed single-precision (32-bit)
 /// floating-point elements in `a`, and return the results. The maximum
 /// relative error for this approximation is less than 1.5*2^-12.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vrcpps))]
 pub unsafe fn _mm256_rcp_ps(a: f32x8) -> f32x8 {
@@ -1554,7 +1554,7 @@ pub unsafe fn _mm256_rcp_ps(a: f32x8) -> f32x8 {
 /// Compute the approximate reciprocal square root of packed single-precision
 /// (32-bit) floating-point elements in `a`, and return the results.
 /// The maximum relative error for this approximation is less than 1.5*2^-12.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vrsqrtps))]
 pub unsafe fn _mm256_rsqrt_ps(a: f32x8) -> f32x8 {
@@ -1563,7 +1563,7 @@ pub unsafe fn _mm256_rsqrt_ps(a: f32x8) -> f32x8 {
 
 /// Unpack and interleave double-precision (64-bit) floating-point elements
 /// from the high half of each 128-bit lane in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vunpckhpd))]
 pub unsafe fn _mm256_unpackhi_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -1572,7 +1572,7 @@ pub unsafe fn _mm256_unpackhi_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Unpack and interleave single-precision (32-bit) floating-point elements
 /// from the high half of each 128-bit lane in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vunpckhps))]
 pub unsafe fn _mm256_unpackhi_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -1581,7 +1581,7 @@ pub unsafe fn _mm256_unpackhi_ps(a: f32x8, b: f32x8) -> f32x8 {
 
 /// Unpack and interleave double-precision (64-bit) floating-point elements
 /// from the low half of each 128-bit lane in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vunpcklpd))]
 pub unsafe fn _mm256_unpacklo_pd(a: f64x4, b: f64x4) -> f64x4 {
@@ -1590,7 +1590,7 @@ pub unsafe fn _mm256_unpacklo_pd(a: f64x4, b: f64x4) -> f64x4 {
 
 /// Unpack and interleave single-precision (32-bit) floating-point elements
 /// from the low half of each 128-bit lane in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vunpcklps))]
 pub unsafe fn _mm256_unpacklo_ps(a: f32x8, b: f32x8) -> f32x8 {
@@ -1601,7 +1601,7 @@ pub unsafe fn _mm256_unpacklo_ps(a: f32x8, b: f32x8) -> f32x8 {
 /// `b`, and set `ZF` to 1 if the result is zero, otherwise set `ZF` to 0.
 /// Compute the bitwise NOT of `a` and then AND with `b`, and set `CF` to 1 if
 /// the result is zero, otherwise set `CF` to 0. Return the `ZF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vptest))]
 pub unsafe fn _mm256_testz_si256(a: i64x4, b: i64x4) -> i32 {
@@ -1612,7 +1612,7 @@ pub unsafe fn _mm256_testz_si256(a: i64x4, b: i64x4) -> i32 {
 /// `b`, and set `ZF` to 1 if the result is zero, otherwise set `ZF` to 0.
 /// Compute the bitwise NOT of `a` and then AND with `b`, and set `CF` to 1 if
 /// the result is zero, otherwise set `CF` to 0. Return the `CF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vptest))]
 pub unsafe fn _mm256_testc_si256(a: i64x4, b: i64x4) -> i32 {
@@ -1624,7 +1624,7 @@ pub unsafe fn _mm256_testc_si256(a: i64x4, b: i64x4) -> i32 {
 /// Compute the bitwise NOT of `a` and then AND with `b`, and set `CF` to 1 if
 /// the result is zero, otherwise set `CF` to 0. Return 1 if both the `ZF` and
 /// `CF` values are zero, otherwise return 0.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vptest))]
 pub unsafe fn _mm256_testnzc_si256(a: i64x4, b: i64x4) -> i32 {
@@ -1638,7 +1638,7 @@ pub unsafe fn _mm256_testnzc_si256(a: i64x4, b: i64x4) -> i32 {
 /// NOT of `a` and then AND with `b`, producing an intermediate value, and set
 /// `CF` to 1 if the sign bit of each 64-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return the `ZF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestpd))]
 pub unsafe fn _mm256_testz_pd(a: f64x4, b: f64x4) -> i32 {
@@ -1652,7 +1652,7 @@ pub unsafe fn _mm256_testz_pd(a: f64x4, b: f64x4) -> i32 {
 /// NOT of `a` and then AND with `b`, producing an intermediate value, and set
 /// `CF` to 1 if the sign bit of each 64-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return the `CF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestpd))]
 pub unsafe fn _mm256_testc_pd(a: f64x4, b: f64x4) -> i32 {
@@ -1667,7 +1667,7 @@ pub unsafe fn _mm256_testc_pd(a: f64x4, b: f64x4) -> i32 {
 /// `CF` to 1 if the sign bit of each 64-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return 1 if both the `ZF` and `CF` values
 /// are zero, otherwise return 0.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestpd))]
 pub unsafe fn _mm256_testnzc_pd(a: f64x4, b: f64x4) -> i32 {
@@ -1681,7 +1681,7 @@ pub unsafe fn _mm256_testnzc_pd(a: f64x4, b: f64x4) -> i32 {
 /// NOT of `a` and then AND with `b`, producing an intermediate value, and set
 /// `CF` to 1 if the sign bit of each 64-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return the `ZF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestpd))]
 pub unsafe fn _mm_testz_pd(a: f64x2, b: f64x2) -> i32 {
@@ -1695,7 +1695,7 @@ pub unsafe fn _mm_testz_pd(a: f64x2, b: f64x2) -> i32 {
 /// NOT of `a` and then AND with `b`, producing an intermediate value, and set
 /// `CF` to 1 if the sign bit of each 64-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return the `CF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestpd))]
 pub unsafe fn _mm_testc_pd(a: f64x2, b: f64x2) -> i32 {
@@ -1710,7 +1710,7 @@ pub unsafe fn _mm_testc_pd(a: f64x2, b: f64x2) -> i32 {
 /// `CF` to 1 if the sign bit of each 64-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return 1 if both the `ZF` and `CF` values
 /// are zero, otherwise return 0.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestpd))]
 pub unsafe fn _mm_testnzc_pd(a: f64x2, b: f64x2) -> i32 {
@@ -1724,7 +1724,7 @@ pub unsafe fn _mm_testnzc_pd(a: f64x2, b: f64x2) -> i32 {
 /// NOT of `a` and then AND with `b`, producing an intermediate value, and set
 /// `CF` to 1 if the sign bit of each 32-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return the `ZF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestps))]
 pub unsafe fn _mm256_testz_ps(a: f32x8, b: f32x8) -> i32 {
@@ -1738,7 +1738,7 @@ pub unsafe fn _mm256_testz_ps(a: f32x8, b: f32x8) -> i32 {
 /// NOT of `a` and then AND with `b`, producing an intermediate value, and set
 /// `CF` to 1 if the sign bit of each 32-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return the `CF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestps))]
 pub unsafe fn _mm256_testc_ps(a: f32x8, b: f32x8) -> i32 {
@@ -1753,7 +1753,7 @@ pub unsafe fn _mm256_testc_ps(a: f32x8, b: f32x8) -> i32 {
 /// `CF` to 1 if the sign bit of each 32-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return 1 if both the `ZF` and `CF` values
 /// are zero, otherwise return 0.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestps))]
 pub unsafe fn _mm256_testnzc_ps(a: f32x8, b: f32x8) -> i32 {
@@ -1767,7 +1767,7 @@ pub unsafe fn _mm256_testnzc_ps(a: f32x8, b: f32x8) -> i32 {
 /// NOT of `a` and then AND with `b`, producing an intermediate value, and set
 /// `CF` to 1 if the sign bit of each 32-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return the `ZF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestps))]
 pub unsafe fn _mm_testz_ps(a: f32x4, b: f32x4) -> i32 {
@@ -1781,7 +1781,7 @@ pub unsafe fn _mm_testz_ps(a: f32x4, b: f32x4) -> i32 {
 /// NOT of `a` and then AND with `b`, producing an intermediate value, and set
 /// `CF` to 1 if the sign bit of each 32-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return the `CF` value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestps))]
 pub unsafe fn _mm_testc_ps(a: f32x4, b: f32x4) -> i32 {
@@ -1796,7 +1796,7 @@ pub unsafe fn _mm_testc_ps(a: f32x4, b: f32x4) -> i32 {
 /// `CF` to 1 if the sign bit of each 32-bit element in the intermediate value
 /// is zero, otherwise set `CF` to 0. Return 1 if both the `ZF` and `CF` values
 /// are zero, otherwise return 0.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vtestps))]
 pub unsafe fn _mm_testnzc_ps(a: f32x4, b: f32x4) -> i32 {
@@ -1806,7 +1806,7 @@ pub unsafe fn _mm_testnzc_ps(a: f32x4, b: f32x4) -> i32 {
 /// Set each bit of the returned mask based on the most significant bit of the
 /// corresponding packed double-precision (64-bit) floating-point element in
 /// `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovmskpd))]
 pub unsafe fn _mm256_movemask_pd(a: f64x4) -> i32 {
@@ -1816,7 +1816,7 @@ pub unsafe fn _mm256_movemask_pd(a: f64x4) -> i32 {
 /// Set each bit of the returned mask based on the most significant bit of the
 /// corresponding packed single-precision (32-bit) floating-point element in
 /// `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmovmskps))]
 pub unsafe fn _mm256_movemask_ps(a: f32x8) -> i32 {
@@ -1824,7 +1824,7 @@ pub unsafe fn _mm256_movemask_ps(a: f32x8) -> i32 {
 }
 
 /// Return vector of type __m256d with all elements set to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vxorps))] // FIXME vxorpd expected
 pub unsafe fn _mm256_setzero_pd() -> f64x4 {
@@ -1832,7 +1832,7 @@ pub unsafe fn _mm256_setzero_pd() -> f64x4 {
 }
 
 /// Return vector of type __m256 with all elements set to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vxorps))]
 pub unsafe fn _mm256_setzero_ps() -> f32x8 {
@@ -1840,7 +1840,7 @@ pub unsafe fn _mm256_setzero_ps() -> f32x8 {
 }
 
 /// Return vector of type __m256i with all elements set to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vxor))]
 pub unsafe fn _mm256_setzero_si256() -> __m256i {
@@ -1849,7 +1849,7 @@ pub unsafe fn _mm256_setzero_si256() -> __m256i {
 
 /// Set packed double-precision (64-bit) floating-point elements in returned
 /// vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 #[cfg_attr(test, assert_instr(vinsertf128))]
@@ -1859,7 +1859,7 @@ pub unsafe fn _mm256_set_pd(a: f64, b: f64, c: f64, d: f64) -> f64x4 {
 
 /// Set packed single-precision (32-bit) floating-point elements in returned
 /// vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_set_ps(
@@ -1870,7 +1870,7 @@ pub unsafe fn _mm256_set_ps(
 
 /// Set packed 8-bit integers in returned vector with the supplied values in
 /// reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_set_epi8(
@@ -1889,7 +1889,7 @@ pub unsafe fn _mm256_set_epi8(
 }
 
 /// Set packed 16-bit integers in returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_set_epi16(
@@ -1907,7 +1907,7 @@ pub unsafe fn _mm256_set_epi16(
 }
 
 /// Set packed 32-bit integers in returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_set_epi32(
@@ -1917,7 +1917,7 @@ pub unsafe fn _mm256_set_epi32(
 }
 
 /// Set packed 64-bit integers in returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 #[cfg_attr(test, assert_instr(vinsertf128))]
@@ -1927,7 +1927,7 @@ pub unsafe fn _mm256_set_epi64x(a: i64, b: i64, c: i64, d: i64) -> i64x4 {
 
 /// Set packed double-precision (64-bit) floating-point elements in returned
 /// vector with the supplied values in reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_setr_pd(a: f64, b: f64, c: f64, d: f64) -> f64x4 {
@@ -1936,7 +1936,7 @@ pub unsafe fn _mm256_setr_pd(a: f64, b: f64, c: f64, d: f64) -> f64x4 {
 
 /// Set packed single-precision (32-bit) floating-point elements in returned
 /// vector with the supplied values in reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_setr_ps(
@@ -1947,7 +1947,7 @@ pub unsafe fn _mm256_setr_ps(
 
 /// Set packed 8-bit integers in returned vector with the supplied values in
 /// reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_setr_epi8(
@@ -1967,7 +1967,7 @@ pub unsafe fn _mm256_setr_epi8(
 
 /// Set packed 16-bit integers in returned vector with the supplied values in
 /// reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_setr_epi16(
@@ -1986,7 +1986,7 @@ pub unsafe fn _mm256_setr_epi16(
 
 /// Set packed 32-bit integers in returned vector with the supplied values in
 /// reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_setr_epi32(
@@ -1997,7 +1997,7 @@ pub unsafe fn _mm256_setr_epi32(
 
 /// Set packed 64-bit integers in returned vector with the supplied values in
 /// reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 #[cfg_attr(test, assert_instr(vinsertf128))]
@@ -2007,7 +2007,7 @@ pub unsafe fn _mm256_setr_epi64x(a: i64, b: i64, c: i64, d: i64) -> i64x4 {
 
 /// Broadcast double-precision (64-bit) floating-point value `a` to all
 /// elements of returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_set1_pd(a: f64) -> f64x4 {
@@ -2016,7 +2016,7 @@ pub unsafe fn _mm256_set1_pd(a: f64) -> f64x4 {
 
 /// Broadcast single-precision (32-bit) floating-point value `a` to all
 /// elements of returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_set1_ps(a: f32) -> f32x8 {
@@ -2025,7 +2025,7 @@ pub unsafe fn _mm256_set1_ps(a: f32) -> f32x8 {
 
 /// Broadcast 8-bit integer `a` to all elements of returned vector.
 /// This intrinsic may generate the `vpbroadcastb`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vpshufb))]
 #[cfg_attr(test, assert_instr(vinsertf128))]
@@ -2042,7 +2042,7 @@ pub unsafe fn _mm256_set1_epi8(a: i8) -> i8x32 {
 
 /// Broadcast 16-bit integer `a` to all all elements of returned vector.
 /// This intrinsic may generate the `vpbroadcastw`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 //#[cfg_attr(test, assert_instr(vpshufb))]
 #[cfg_attr(test, assert_instr(vinsertf128))]
@@ -2053,7 +2053,7 @@ pub unsafe fn _mm256_set1_epi16(a: i16) -> i16x16 {
 
 /// Broadcast 32-bit integer `a` to all elements of returned vector.
 /// This intrinsic may generate the `vpbroadcastd`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_set1_epi32(a: i32) -> i32x8 {
@@ -2062,7 +2062,7 @@ pub unsafe fn _mm256_set1_epi32(a: i32) -> i32x8 {
 
 /// Broadcast 64-bit integer `a` to all elements of returned vector.
 /// This intrinsic may generate the `vpbroadcastq`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 //#[cfg_attr(test, assert_instr(vmovddup))]
 #[cfg_attr(test, assert_instr(vinsertf128))]
@@ -2072,7 +2072,7 @@ pub unsafe fn _mm256_set1_epi64x(a: i64) -> i64x4 {
 }
 
 /// Cast vector of type __m256d to type __m256.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2081,7 +2081,7 @@ pub unsafe fn _mm256_castpd_ps(a: f64x4) -> f32x8 {
 }
 
 /// Cast vector of type __m256 to type __m256d.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2090,7 +2090,7 @@ pub unsafe fn _mm256_castps_pd(a: f32x8) -> f64x4 {
 }
 
 /// Casts vector of type __m256 to type __m256i.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2099,7 +2099,7 @@ pub unsafe fn _mm256_castps_si256(a: f32x8) -> __m256i {
 }
 
 /// Casts vector of type __m256i to type __m256.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2108,7 +2108,7 @@ pub unsafe fn _mm256_castsi256_ps(a: __m256i) -> f32x8 {
 }
 
 /// Casts vector of type __m256d to type __m256i.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2117,7 +2117,7 @@ pub unsafe fn _mm256_castpd_si256(a: f64x4) -> __m256i {
 }
 
 /// Casts vector of type __m256i to type __m256d.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2126,7 +2126,7 @@ pub unsafe fn _mm256_castsi256_pd(a: __m256i) -> f64x4 {
 }
 
 /// Casts vector of type __m256 to type __m128.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2135,7 +2135,7 @@ pub unsafe fn _mm256_castps256_ps128(a: f32x8) -> f32x4 {
 }
 
 /// Casts vector of type __m256d to type __m128d.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2144,7 +2144,7 @@ pub unsafe fn _mm256_castpd256_pd128(a: f64x4) -> f64x2 {
 }
 
 /// Casts vector of type __m256i to type __m128i.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2156,7 +2156,7 @@ pub unsafe fn _mm256_castsi256_si128(a: __m256i) -> __m128i {
 
 /// Casts vector of type __m128 to type __m256;
 /// the upper 128 bits of the result are undefined.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2167,7 +2167,7 @@ pub unsafe fn _mm256_castps128_ps256(a: f32x4) -> f32x8 {
 
 /// Casts vector of type __m128d to type __m256d;
 /// the upper 128 bits of the result are undefined.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2178,7 +2178,7 @@ pub unsafe fn _mm256_castpd128_pd256(a: f64x2) -> f64x4 {
 
 /// Casts vector of type __m128i to type __m256i;
 /// the upper 128 bits of the result are undefined.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2192,7 +2192,7 @@ pub unsafe fn _mm256_castsi128_si256(a: __m128i) -> __m256i {
 /// Constructs a 256-bit floating-point vector of [8 x float] from a
 /// 128-bit floating-point vector of [4 x float]. The lower 128 bits contain
 /// the value of the source vector. The upper 128 bits are set to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2204,7 +2204,7 @@ pub unsafe fn _mm256_zextps128_ps256(a: f32x4) -> f32x8 {
 /// Constructs a 256-bit integer vector from a 128-bit integer vector.
 /// The lower 128 bits contain the value of the source vector. The upper
 /// 128 bits are set to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2219,7 +2219,7 @@ pub unsafe fn _mm256_zextsi128_si256(a: __m128i) -> __m256i {
 /// 128-bit floating-point vector of [2 x double]. The lower 128 bits
 /// contain the value of the source vector. The upper 128 bits are set
 /// to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic is only used for compilation and does not generate any
 // instructions, thus it has zero latency.
@@ -2229,7 +2229,7 @@ pub unsafe fn _mm256_zextpd128_pd256(a: f64x2) -> f64x4 {
 }
 
 /// Return vector of type `f32x8` with undefined elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_undefined_ps() -> f32x8 {
@@ -2237,7 +2237,7 @@ pub unsafe fn _mm256_undefined_ps() -> f32x8 {
 }
 
 /// Return vector of type `f64x4` with undefined elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_undefined_pd() -> f64x4 {
@@ -2245,7 +2245,7 @@ pub unsafe fn _mm256_undefined_pd() -> f64x4 {
 }
 
 /// Return vector of type __m256i with undefined elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_undefined_si256() -> __m256i {
@@ -2253,7 +2253,7 @@ pub unsafe fn _mm256_undefined_si256() -> __m256i {
 }
 
 /// Set packed __m256 returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128))]
 pub unsafe fn _mm256_set_m128(hi: f32x4, lo: f32x4) -> f32x8 {
@@ -2261,7 +2261,7 @@ pub unsafe fn _mm256_set_m128(hi: f32x4, lo: f32x4) -> f32x8 {
 }
 
 /// Set packed __m256d returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128))]
 pub unsafe fn _mm256_set_m128d(hi: f64x2, lo: f64x2) -> f64x4 {
@@ -2271,7 +2271,7 @@ pub unsafe fn _mm256_set_m128d(hi: f64x2, lo: f64x2) -> f64x4 {
 }
 
 /// Set packed __m256i returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128))]
 pub unsafe fn _mm256_set_m128i(hi: __m128i, lo: __m128i) -> __m256i {
@@ -2281,7 +2281,7 @@ pub unsafe fn _mm256_set_m128i(hi: __m128i, lo: __m128i) -> __m256i {
 }
 
 /// Set packed __m256 returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128))]
 pub unsafe fn _mm256_setr_m128(lo: f32x4, hi: f32x4) -> f32x8 {
@@ -2289,7 +2289,7 @@ pub unsafe fn _mm256_setr_m128(lo: f32x4, hi: f32x4) -> f32x8 {
 }
 
 /// Set packed __m256d returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128))]
 pub unsafe fn _mm256_setr_m128d(lo: f64x2, hi: f64x2) -> f64x4 {
@@ -2297,7 +2297,7 @@ pub unsafe fn _mm256_setr_m128d(lo: f64x2, hi: f64x2) -> f64x4 {
 }
 
 /// Set packed __m256i returned vector with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vinsertf128))]
 pub unsafe fn _mm256_setr_m128i(lo: __m128i, hi: __m128i) -> __m256i {
@@ -2308,7 +2308,7 @@ pub unsafe fn _mm256_setr_m128i(lo: __m128i, hi: __m128i) -> __m256i {
 /// floating-point elements) from memory, and combine them into a 256-bit
 /// value.
 /// `hiaddr` and `loaddr` do not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_loadu2_m128(
@@ -2323,7 +2323,7 @@ pub unsafe fn _mm256_loadu2_m128(
 /// floating-point elements) from memory, and combine them into a 256-bit
 /// value.
 /// `hiaddr` and `loaddr` do not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_loadu2_m128d(
@@ -2337,7 +2337,7 @@ pub unsafe fn _mm256_loadu2_m128d(
 /// Load two 128-bit values (composed of integer data) from memory, and combine
 /// them into a 256-bit value.
 /// `hiaddr` and `loaddr` do not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_loadu2_m128i(
@@ -2352,7 +2352,7 @@ pub unsafe fn _mm256_loadu2_m128i(
 /// single-precision (32-bit) floating-point elements) from `a` into memory two
 /// different 128-bit locations.
 /// `hiaddr` and `loaddr` do not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_storeu2_m128(
@@ -2369,7 +2369,7 @@ pub unsafe fn _mm256_storeu2_m128(
 /// double-precision (64-bit) floating-point elements) from `a` into memory two
 /// different 128-bit locations.
 /// `hiaddr` and `loaddr` do not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_storeu2_m128d(
@@ -2385,7 +2385,7 @@ pub unsafe fn _mm256_storeu2_m128d(
 /// Store the high and low 128-bit halves (each composed of integer data) from
 /// `a` into memory two different 128-bit locations.
 /// `hiaddr` and `loaddr` do not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_storeu2_m128i(
@@ -2399,7 +2399,7 @@ pub unsafe fn _mm256_storeu2_m128i(
 }
 
 /// Returns the first element of the input vector of [8 x float].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx")]
 //#[cfg_attr(test, assert_instr(movss))] FIXME
 pub unsafe fn _mm256_cvtss_f32(a: f32x8) -> f32 {

--- a/coresimd/src/x86/i586/avx2.rs
+++ b/coresimd/src/x86/i586/avx2.rs
@@ -29,7 +29,7 @@ use v128::*;
 use stdsimd_test::assert_instr;
 
 /// Computes the absolute values of packed 32-bit integers in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpabsd))]
 pub unsafe fn _mm256_abs_epi32(a: i32x8) -> u32x8 {
@@ -37,7 +37,7 @@ pub unsafe fn _mm256_abs_epi32(a: i32x8) -> u32x8 {
 }
 
 /// Computes the absolute values of packed 16-bit integers in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpabsw))]
 pub unsafe fn _mm256_abs_epi16(a: i16x16) -> u16x16 {
@@ -45,7 +45,7 @@ pub unsafe fn _mm256_abs_epi16(a: i16x16) -> u16x16 {
 }
 
 /// Computes the absolute values of packed 8-bit integers in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpabsb))]
 pub unsafe fn _mm256_abs_epi8(a: i8x32) -> u8x32 {
@@ -53,7 +53,7 @@ pub unsafe fn _mm256_abs_epi8(a: i8x32) -> u8x32 {
 }
 
 /// Add packed 64-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpaddq))]
 pub unsafe fn _mm256_add_epi64(a: i64x4, b: i64x4) -> i64x4 {
@@ -61,7 +61,7 @@ pub unsafe fn _mm256_add_epi64(a: i64x4, b: i64x4) -> i64x4 {
 }
 
 /// Add packed 32-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpaddd))]
 pub unsafe fn _mm256_add_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -69,7 +69,7 @@ pub unsafe fn _mm256_add_epi32(a: i32x8, b: i32x8) -> i32x8 {
 }
 
 /// Add packed 16-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpaddw))]
 pub unsafe fn _mm256_add_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -77,7 +77,7 @@ pub unsafe fn _mm256_add_epi16(a: i16x16, b: i16x16) -> i16x16 {
 }
 
 /// Add packed 8-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpaddb))]
 pub unsafe fn _mm256_add_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -85,7 +85,7 @@ pub unsafe fn _mm256_add_epi8(a: i8x32, b: i8x32) -> i8x32 {
 }
 
 /// Add packed 8-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpaddsb))]
 pub unsafe fn _mm256_adds_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -93,7 +93,7 @@ pub unsafe fn _mm256_adds_epi8(a: i8x32, b: i8x32) -> i8x32 {
 }
 
 /// Add packed 16-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpaddsw))]
 pub unsafe fn _mm256_adds_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -101,7 +101,7 @@ pub unsafe fn _mm256_adds_epi16(a: i16x16, b: i16x16) -> i16x16 {
 }
 
 /// Add packed unsigned 8-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpaddusb))]
 pub unsafe fn _mm256_adds_epu8(a: u8x32, b: u8x32) -> u8x32 {
@@ -109,7 +109,7 @@ pub unsafe fn _mm256_adds_epu8(a: u8x32, b: u8x32) -> u8x32 {
 }
 
 /// Add packed unsigned 16-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpaddusw))]
 pub unsafe fn _mm256_adds_epu16(a: u16x16, b: u16x16) -> u16x16 {
@@ -118,7 +118,7 @@ pub unsafe fn _mm256_adds_epu16(a: u16x16, b: u16x16) -> u16x16 {
 
 /// Concatenate pairs of 16-byte blocks in `a` and `b` into a 32-byte temporary
 /// result, shift the result right by `n` bytes, and return the low 16 bytes.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpalignr, n = 15))]
 pub unsafe fn _mm256_alignr_epi8(a: i8x32, b: i8x32, n: i32) -> i8x32 {
@@ -181,7 +181,7 @@ pub unsafe fn _mm256_alignr_epi8(a: i8x32, b: i8x32, n: i32) -> i8x32 {
 
 /// Compute the bitwise AND of 256 bits (representing integer data)
 /// in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vandps))]
 pub unsafe fn _mm256_and_si256(a: __m256i, b: __m256i) -> __m256i {
@@ -190,7 +190,7 @@ pub unsafe fn _mm256_and_si256(a: __m256i, b: __m256i) -> __m256i {
 
 /// Compute the bitwise NOT of 256 bits (representing integer data)
 /// in `a` and then AND with `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vandnps))]
 pub unsafe fn _mm256_andnot_si256(a: __m256i, b: __m256i) -> __m256i {
@@ -198,7 +198,7 @@ pub unsafe fn _mm256_andnot_si256(a: __m256i, b: __m256i) -> __m256i {
 }
 
 /// Average packed unsigned 16-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpavgw))]
 pub unsafe fn _mm256_avg_epu16(a: u16x16, b: u16x16) -> u16x16 {
@@ -206,7 +206,7 @@ pub unsafe fn _mm256_avg_epu16(a: u16x16, b: u16x16) -> u16x16 {
 }
 
 /// Average packed unsigned 8-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpavgb))]
 pub unsafe fn _mm256_avg_epu8(a: u8x32, b: u8x32) -> u8x32 {
@@ -214,7 +214,7 @@ pub unsafe fn _mm256_avg_epu8(a: u8x32, b: u8x32) -> u8x32 {
 }
 
 /// Blend packed 32-bit integers from `a` and `b` using control mask `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpblendd, imm8 = 9))]
 pub unsafe fn _mm_blend_epi32(a: i32x4, b: i32x4, imm8: i32) -> i32x4 {
@@ -243,7 +243,7 @@ pub unsafe fn _mm_blend_epi32(a: i32x4, b: i32x4, imm8: i32) -> i32x4 {
 }
 
 /// Blend packed 32-bit integers from `a` and `b` using control mask `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpblendd, imm8 = 9))]
 pub unsafe fn _mm256_blend_epi32(a: i32x8, b: i32x8, imm8: i32) -> i32x8 {
@@ -292,7 +292,7 @@ pub unsafe fn _mm256_blend_epi32(a: i32x8, b: i32x8, imm8: i32) -> i32x8 {
 }
 
 /// Blend packed 16-bit integers from `a` and `b` using control mask `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpblendw, imm8 = 9))]
 pub unsafe fn _mm256_blend_epi16(a: i16x16, b: i16x16, imm8: i32) -> i16x16 {
@@ -343,7 +343,7 @@ pub unsafe fn _mm256_blend_epi16(a: i16x16, b: i16x16, imm8: i32) -> i16x16 {
 }
 
 /// Blend packed 8-bit integers from `a` and `b` using `mask`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpblendvb))]
 pub unsafe fn _mm256_blendv_epi8(a: i8x32, b: i8x32, mask: __m256i) -> i8x32 {
@@ -352,7 +352,7 @@ pub unsafe fn _mm256_blendv_epi8(a: i8x32, b: i8x32, mask: __m256i) -> i8x32 {
 
 /// Broadcast the low packed 8-bit integer from `a` to all elements of
 /// the 128-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpbroadcastb))]
 pub unsafe fn _mm_broadcastb_epi8(a: i8x16) -> i8x16 {
@@ -361,7 +361,7 @@ pub unsafe fn _mm_broadcastb_epi8(a: i8x16) -> i8x16 {
 
 /// Broadcast the low packed 8-bit integer from `a` to all elements of
 /// the 256-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpbroadcastb))]
 pub unsafe fn _mm256_broadcastb_epi8(a: i8x16) -> i8x32 {
@@ -372,7 +372,7 @@ pub unsafe fn _mm256_broadcastb_epi8(a: i8x16) -> i8x32 {
 // often compiled to vbroadcastss.
 /// Broadcast the low packed 32-bit integer from `a` to all elements of
 /// the 128-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 pub unsafe fn _mm_broadcastd_epi32(a: i32x4) -> i32x4 {
@@ -383,7 +383,7 @@ pub unsafe fn _mm_broadcastd_epi32(a: i32x4) -> i32x4 {
 // often compiled to vbroadcastss.
 /// Broadcast the low packed 32-bit integer from `a` to all elements of
 /// the 256-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 pub unsafe fn _mm256_broadcastd_epi32(a: i32x4) -> i32x8 {
@@ -392,7 +392,7 @@ pub unsafe fn _mm256_broadcastd_epi32(a: i32x4) -> i32x8 {
 
 /// Broadcast the low packed 64-bit integer from `a` to all elements of
 /// the 128-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpbroadcastq))]
 pub unsafe fn _mm_broadcastq_epi64(a: i64x2) -> i64x2 {
@@ -403,7 +403,7 @@ pub unsafe fn _mm_broadcastq_epi64(a: i64x2) -> i64x2 {
 // often compiled to vbroadcastsd.
 /// Broadcast the low packed 64-bit integer from `a` to all elements of
 /// the 256-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vbroadcastsd))]
 pub unsafe fn _mm256_broadcastq_epi64(a: i64x2) -> i64x4 {
@@ -412,7 +412,7 @@ pub unsafe fn _mm256_broadcastq_epi64(a: i64x2) -> i64x4 {
 
 /// Broadcast the low double-precision (64-bit) floating-point element
 /// from `a` to all elements of the 128-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vmovddup))]
 pub unsafe fn _mm_broadcastsd_pd(a: f64x2) -> f64x2 {
@@ -421,7 +421,7 @@ pub unsafe fn _mm_broadcastsd_pd(a: f64x2) -> f64x2 {
 
 /// Broadcast the low double-precision (64-bit) floating-point element
 /// from `a` to all elements of the 256-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vbroadcastsd))]
 pub unsafe fn _mm256_broadcastsd_pd(a: f64x2) -> f64x4 {
@@ -432,7 +432,7 @@ pub unsafe fn _mm256_broadcastsd_pd(a: f64x2) -> f64x4 {
 // vbroadcastf128.
 /// Broadcast 128 bits of integer data from a to all 128-bit lanes in
 /// the 256-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 pub unsafe fn _mm256_broadcastsi128_si256(a: i64x2) -> i64x4 {
     simd_shuffle4(a, i64x2::splat(0_i64), [0, 1, 0, 1])
@@ -440,7 +440,7 @@ pub unsafe fn _mm256_broadcastsi128_si256(a: i64x2) -> i64x4 {
 
 /// Broadcast the low single-precision (32-bit) floating-point element
 /// from `a` to all elements of the 128-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 pub unsafe fn _mm_broadcastss_ps(a: f32x4) -> f32x4 {
@@ -449,7 +449,7 @@ pub unsafe fn _mm_broadcastss_ps(a: f32x4) -> f32x4 {
 
 /// Broadcast the low single-precision (32-bit) floating-point element
 /// from `a` to all elements of the 256-bit returned value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 pub unsafe fn _mm256_broadcastss_ps(a: f32x4) -> f32x8 {
@@ -458,7 +458,7 @@ pub unsafe fn _mm256_broadcastss_ps(a: f32x4) -> f32x8 {
 
 /// Broadcast the low packed 16-bit integer from a to all elements of
 /// the 128-bit returned value
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpbroadcastw))]
 pub unsafe fn _mm_broadcastw_epi16(a: i16x8) -> i16x8 {
@@ -467,7 +467,7 @@ pub unsafe fn _mm_broadcastw_epi16(a: i16x8) -> i16x8 {
 
 /// Broadcast the low packed 16-bit integer from a to all elements of
 /// the 256-bit returned value
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpbroadcastw))]
 pub unsafe fn _mm256_broadcastw_epi16(a: i16x8) -> i16x16 {
@@ -475,7 +475,7 @@ pub unsafe fn _mm256_broadcastw_epi16(a: i16x8) -> i16x16 {
 }
 
 /// Compare packed 64-bit integers in `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpcmpeqq))]
 pub unsafe fn _mm256_cmpeq_epi64(a: i64x4, b: i64x4) -> i64x4 {
@@ -483,7 +483,7 @@ pub unsafe fn _mm256_cmpeq_epi64(a: i64x4, b: i64x4) -> i64x4 {
 }
 
 /// Compare packed 32-bit integers in `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpcmpeqd))]
 pub unsafe fn _mm256_cmpeq_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -491,7 +491,7 @@ pub unsafe fn _mm256_cmpeq_epi32(a: i32x8, b: i32x8) -> i32x8 {
 }
 
 /// Compare packed 16-bit integers in `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpcmpeqw))]
 pub unsafe fn _mm256_cmpeq_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -499,7 +499,7 @@ pub unsafe fn _mm256_cmpeq_epi16(a: i16x16, b: i16x16) -> i16x16 {
 }
 
 /// Compare packed 8-bit integers in `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpcmpeqb))]
 pub unsafe fn _mm256_cmpeq_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -507,7 +507,7 @@ pub unsafe fn _mm256_cmpeq_epi8(a: i8x32, b: i8x32) -> i8x32 {
 }
 
 /// Compare packed 64-bit integers in `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpcmpgtq))]
 pub unsafe fn _mm256_cmpgt_epi64(a: i64x4, b: i64x4) -> i64x4 {
@@ -515,7 +515,7 @@ pub unsafe fn _mm256_cmpgt_epi64(a: i64x4, b: i64x4) -> i64x4 {
 }
 
 /// Compare packed 32-bit integers in `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpcmpgtd))]
 pub unsafe fn _mm256_cmpgt_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -523,7 +523,7 @@ pub unsafe fn _mm256_cmpgt_epi32(a: i32x8, b: i32x8) -> i32x8 {
 }
 
 /// Compare packed 16-bit integers in `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpcmpgtw))]
 pub unsafe fn _mm256_cmpgt_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -531,7 +531,7 @@ pub unsafe fn _mm256_cmpgt_epi16(a: i16x16, b: i16x16) -> i16x16 {
 }
 
 /// Compare packed 8-bit integers in `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpcmpgtb))]
 pub unsafe fn _mm256_cmpgt_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -539,7 +539,7 @@ pub unsafe fn _mm256_cmpgt_epi8(a: i8x32, b: i8x32) -> i8x32 {
 }
 
 /// Sign-extend 16-bit integers to 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovsxwd))]
 pub unsafe fn _mm256_cvtepi16_epi32(a: i16x8) -> i32x8 {
@@ -547,7 +547,7 @@ pub unsafe fn _mm256_cvtepi16_epi32(a: i16x8) -> i32x8 {
 }
 
 /// Sign-extend 16-bit integers to 64-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovsxwq))]
 pub unsafe fn _mm256_cvtepi16_epi64(a: i16x8) -> i64x4 {
@@ -555,7 +555,7 @@ pub unsafe fn _mm256_cvtepi16_epi64(a: i16x8) -> i64x4 {
 }
 
 /// Sign-extend 32-bit integers to 64-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovsxdq))]
 pub unsafe fn _mm256_cvtepi32_epi64(a: i32x4) -> i64x4 {
@@ -563,7 +563,7 @@ pub unsafe fn _mm256_cvtepi32_epi64(a: i32x4) -> i64x4 {
 }
 
 /// Sign-extend 8-bit integers to 16-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovsxbw))]
 pub unsafe fn _mm256_cvtepi8_epi16(a: i8x16) -> i16x16 {
@@ -571,7 +571,7 @@ pub unsafe fn _mm256_cvtepi8_epi16(a: i8x16) -> i16x16 {
 }
 
 /// Sign-extend 8-bit integers to 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovsxbd))]
 pub unsafe fn _mm256_cvtepi8_epi32(a: i8x16) -> i32x8 {
@@ -579,7 +579,7 @@ pub unsafe fn _mm256_cvtepi8_epi32(a: i8x16) -> i32x8 {
 }
 
 /// Sign-extend 8-bit integers to 64-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovsxbq))]
 pub unsafe fn _mm256_cvtepi8_epi64(a: i8x16) -> i64x4 {
@@ -588,7 +588,7 @@ pub unsafe fn _mm256_cvtepi8_epi64(a: i8x16) -> i64x4 {
 
 /// Zero-extend the lower four unsigned 16-bit integers in `a` to 32-bit
 /// integers. The upper four elements of `a` are unused.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovzxwd))]
 pub unsafe fn _mm256_cvtepu16_epi32(a: u16x8) -> i32x8 {
@@ -597,7 +597,7 @@ pub unsafe fn _mm256_cvtepu16_epi32(a: u16x8) -> i32x8 {
 
 /// Zero-extend the lower four unsigned 16-bit integers in `a` to 64-bit
 /// integers. The upper four elements of `a` are unused.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovzxwq))]
 pub unsafe fn _mm256_cvtepu16_epi64(a: u16x8) -> i64x4 {
@@ -605,7 +605,7 @@ pub unsafe fn _mm256_cvtepu16_epi64(a: u16x8) -> i64x4 {
 }
 
 /// Zero-extend unsigned 32-bit integers in `a` to 64-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovzxdq))]
 pub unsafe fn _mm256_cvtepu32_epi64(a: u32x4) -> i64x4 {
@@ -613,7 +613,7 @@ pub unsafe fn _mm256_cvtepu32_epi64(a: u32x4) -> i64x4 {
 }
 
 /// Zero-extend unsigned 8-bit integers in `a` to 16-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovzxbw))]
 pub unsafe fn _mm256_cvtepu8_epi16(a: u8x16) -> i16x16 {
@@ -622,7 +622,7 @@ pub unsafe fn _mm256_cvtepu8_epi16(a: u8x16) -> i16x16 {
 
 /// Zero-extend the lower eight unsigned 8-bit integers in `a` to 32-bit
 /// integers. The upper eight elements of `a` are unused.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovzxbd))]
 pub unsafe fn _mm256_cvtepu8_epi32(a: u8x16) -> i32x8 {
@@ -631,7 +631,7 @@ pub unsafe fn _mm256_cvtepu8_epi32(a: u8x16) -> i32x8 {
 
 /// Zero-extend the lower four unsigned 8-bit integers in `a` to 64-bit
 /// integers. The upper twelve elements of `a` are unused.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovzxbq))]
 pub unsafe fn _mm256_cvtepu8_epi64(a: u8x16) -> i64x4 {
@@ -639,7 +639,7 @@ pub unsafe fn _mm256_cvtepu8_epi64(a: u8x16) -> i64x4 {
 }
 
 /// Extract 128 bits (of integer data) from `a` selected with `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vextractf128, imm8 = 1))]
 pub unsafe fn _mm256_extracti128_si256(a: __m256i, imm8: i32) -> __m128i {
@@ -654,7 +654,7 @@ pub unsafe fn _mm256_extracti128_si256(a: __m256i, imm8: i32) -> __m128i {
 }
 
 /// Horizontally add adjacent pairs of 16-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vphaddw))]
 pub unsafe fn _mm256_hadd_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -662,7 +662,7 @@ pub unsafe fn _mm256_hadd_epi16(a: i16x16, b: i16x16) -> i16x16 {
 }
 
 /// Horizontally add adjacent pairs of 32-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vphaddd))]
 pub unsafe fn _mm256_hadd_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -671,7 +671,7 @@ pub unsafe fn _mm256_hadd_epi32(a: i32x8, b: i32x8) -> i32x8 {
 
 /// Horizontally add adjacent pairs of 16-bit integers in `a` and `b`
 /// using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vphaddsw))]
 pub unsafe fn _mm256_hadds_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -679,7 +679,7 @@ pub unsafe fn _mm256_hadds_epi16(a: i16x16, b: i16x16) -> i16x16 {
 }
 
 /// Horizontally substract adjacent pairs of 16-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vphsubw))]
 pub unsafe fn _mm256_hsub_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -687,7 +687,7 @@ pub unsafe fn _mm256_hsub_epi16(a: i16x16, b: i16x16) -> i16x16 {
 }
 
 /// Horizontally substract adjacent pairs of 32-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vphsubd))]
 pub unsafe fn _mm256_hsub_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -696,7 +696,7 @@ pub unsafe fn _mm256_hsub_epi32(a: i32x8, b: i32x8) -> i32x8 {
 
 /// Horizontally subtract adjacent pairs of 16-bit integers in `a` and `b`
 /// using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vphsubsw))]
 pub unsafe fn _mm256_hsubs_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -706,7 +706,7 @@ pub unsafe fn _mm256_hsubs_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 pub unsafe fn _mm_i32gather_epi32(
@@ -722,7 +722,7 @@ pub unsafe fn _mm_i32gather_epi32(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 pub unsafe fn _mm_mask_i32gather_epi32(
@@ -737,7 +737,7 @@ pub unsafe fn _mm_mask_i32gather_epi32(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 pub unsafe fn _mm256_i32gather_epi32(
@@ -753,7 +753,7 @@ pub unsafe fn _mm256_i32gather_epi32(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 pub unsafe fn _mm256_mask_i32gather_epi32(
@@ -768,7 +768,7 @@ pub unsafe fn _mm256_mask_i32gather_epi32(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 pub unsafe fn _mm_i32gather_ps(
@@ -784,7 +784,7 @@ pub unsafe fn _mm_i32gather_ps(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 pub unsafe fn _mm_mask_i32gather_ps(
@@ -799,7 +799,7 @@ pub unsafe fn _mm_mask_i32gather_ps(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 pub unsafe fn _mm256_i32gather_ps(
@@ -815,7 +815,7 @@ pub unsafe fn _mm256_i32gather_ps(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 pub unsafe fn _mm256_mask_i32gather_ps(
@@ -830,7 +830,7 @@ pub unsafe fn _mm256_mask_i32gather_ps(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 pub unsafe fn _mm_i32gather_epi64(
@@ -846,7 +846,7 @@ pub unsafe fn _mm_i32gather_epi64(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 pub unsafe fn _mm_mask_i32gather_epi64(
@@ -861,7 +861,7 @@ pub unsafe fn _mm_mask_i32gather_epi64(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 pub unsafe fn _mm256_i32gather_epi64(
@@ -877,7 +877,7 @@ pub unsafe fn _mm256_i32gather_epi64(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 pub unsafe fn _mm256_mask_i32gather_epi64(
@@ -892,7 +892,7 @@ pub unsafe fn _mm256_mask_i32gather_epi64(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 pub unsafe fn _mm_i32gather_pd(
@@ -908,7 +908,7 @@ pub unsafe fn _mm_i32gather_pd(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 pub unsafe fn _mm_mask_i32gather_pd(
@@ -923,7 +923,7 @@ pub unsafe fn _mm_mask_i32gather_pd(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 pub unsafe fn _mm256_i32gather_pd(
@@ -939,7 +939,7 @@ pub unsafe fn _mm256_i32gather_pd(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 pub unsafe fn _mm256_mask_i32gather_pd(
@@ -954,7 +954,7 @@ pub unsafe fn _mm256_mask_i32gather_pd(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 pub unsafe fn _mm_i64gather_epi32(
@@ -970,7 +970,7 @@ pub unsafe fn _mm_i64gather_epi32(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 pub unsafe fn _mm_mask_i64gather_epi32(
@@ -985,7 +985,7 @@ pub unsafe fn _mm_mask_i64gather_epi32(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 pub unsafe fn _mm256_i64gather_epi32(
@@ -1001,7 +1001,7 @@ pub unsafe fn _mm256_i64gather_epi32(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 pub unsafe fn _mm256_mask_i64gather_epi32(
@@ -1016,7 +1016,7 @@ pub unsafe fn _mm256_mask_i64gather_epi32(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 pub unsafe fn _mm_i64gather_ps(
@@ -1032,7 +1032,7 @@ pub unsafe fn _mm_i64gather_ps(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 pub unsafe fn _mm_mask_i64gather_ps(
@@ -1047,7 +1047,7 @@ pub unsafe fn _mm_mask_i64gather_ps(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 pub unsafe fn _mm256_i64gather_ps(
@@ -1063,7 +1063,7 @@ pub unsafe fn _mm256_i64gather_ps(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 pub unsafe fn _mm256_mask_i64gather_ps(
@@ -1078,7 +1078,7 @@ pub unsafe fn _mm256_mask_i64gather_ps(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 pub unsafe fn _mm_i64gather_epi64(
@@ -1094,7 +1094,7 @@ pub unsafe fn _mm_i64gather_epi64(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 pub unsafe fn _mm_mask_i64gather_epi64(
@@ -1109,7 +1109,7 @@ pub unsafe fn _mm_mask_i64gather_epi64(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 pub unsafe fn _mm256_i64gather_epi64(
@@ -1125,7 +1125,7 @@ pub unsafe fn _mm256_i64gather_epi64(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 pub unsafe fn _mm256_mask_i64gather_epi64(
@@ -1140,7 +1140,7 @@ pub unsafe fn _mm256_mask_i64gather_epi64(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 pub unsafe fn _mm_i64gather_pd(
@@ -1156,7 +1156,7 @@ pub unsafe fn _mm_i64gather_pd(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 pub unsafe fn _mm_mask_i64gather_pd(
@@ -1171,7 +1171,7 @@ pub unsafe fn _mm_mask_i64gather_pd(
 /// Return values from `slice` at offsets determined by `offsets * scale`,
 /// where
 /// `scale` is between 1 and 8.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 pub unsafe fn _mm256_i64gather_pd(
@@ -1187,7 +1187,7 @@ pub unsafe fn _mm256_i64gather_pd(
 /// where
 /// `scale` is between 1 and 8. If mask is set, load the value from `src` in
 /// that position instead.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 pub unsafe fn _mm256_mask_i64gather_pd(
@@ -1201,7 +1201,7 @@ pub unsafe fn _mm256_mask_i64gather_pd(
 
 /// Copy `a` to `dst`, then insert 128 bits (of integer data) from `b` at the
 /// location specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vinsertf128, imm8 = 1))]
 pub unsafe fn _mm256_inserti128_si256(
@@ -1220,7 +1220,7 @@ pub unsafe fn _mm256_inserti128_si256(
 /// Multiply packed signed 16-bit integers in `a` and `b`, producing
 /// intermediate signed 32-bit integers. Horizontally add adjacent pairs
 /// of intermediate 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaddwd))]
 pub unsafe fn _mm256_madd_epi16(a: i16x16, b: i16x16) -> i32x8 {
@@ -1231,7 +1231,7 @@ pub unsafe fn _mm256_madd_epi16(a: i16x16, b: i16x16) -> i32x8 {
 /// corresponding signed 8-bit integer from `b`, producing intermediate
 /// signed 16-bit integers. Horizontally add adjacent pairs of intermediate
 /// signed 16-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaddubsw))]
 pub unsafe fn _mm256_maddubs_epi16(a: u8x32, b: u8x32) -> i16x16 {
@@ -1241,7 +1241,7 @@ pub unsafe fn _mm256_maddubs_epi16(a: u8x32, b: u8x32) -> i16x16 {
 /// Load packed 32-bit integers from memory pointed by `mem_addr` using `mask`
 /// (elements are zeroed out when the highest bit is not set in the
 /// corresponding element).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovd))]
 pub unsafe fn _mm_maskload_epi32(mem_addr: *const i32, mask: i32x4) -> i32x4 {
@@ -1251,7 +1251,7 @@ pub unsafe fn _mm_maskload_epi32(mem_addr: *const i32, mask: i32x4) -> i32x4 {
 /// Load packed 32-bit integers from memory pointed by `mem_addr` using `mask`
 /// (elements are zeroed out when the highest bit is not set in the
 /// corresponding element).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovd))]
 pub unsafe fn _mm256_maskload_epi32(
@@ -1263,7 +1263,7 @@ pub unsafe fn _mm256_maskload_epi32(
 /// Load packed 64-bit integers from memory pointed by `mem_addr` using `mask`
 /// (elements are zeroed out when the highest bit is not set in the
 /// corresponding element).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovq))]
 pub unsafe fn _mm_maskload_epi64(mem_addr: *const i64, mask: i64x2) -> i64x2 {
@@ -1273,7 +1273,7 @@ pub unsafe fn _mm_maskload_epi64(mem_addr: *const i64, mask: i64x2) -> i64x2 {
 /// Load packed 64-bit integers from memory pointed by `mem_addr` using `mask`
 /// (elements are zeroed out when the highest bit is not set in the
 /// corresponding element).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovq))]
 pub unsafe fn _mm256_maskload_epi64(
@@ -1285,7 +1285,7 @@ pub unsafe fn _mm256_maskload_epi64(
 /// Store packed 32-bit integers from `a` into memory pointed by `mem_addr`
 /// using `mask` (elements are not stored when the highest bit is not set
 /// in the corresponding element).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovd))]
 pub unsafe fn _mm_maskstore_epi32(mem_addr: *mut i32, mask: i32x4, a: i32x4) {
@@ -1295,7 +1295,7 @@ pub unsafe fn _mm_maskstore_epi32(mem_addr: *mut i32, mask: i32x4, a: i32x4) {
 /// Store packed 32-bit integers from `a` into memory pointed by `mem_addr`
 /// using `mask` (elements are not stored when the highest bit is not set
 /// in the corresponding element).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovd))]
 pub unsafe fn _mm256_maskstore_epi32(
@@ -1307,7 +1307,7 @@ pub unsafe fn _mm256_maskstore_epi32(
 /// Store packed 64-bit integers from `a` into memory pointed by `mem_addr`
 /// using `mask` (elements are not stored when the highest bit is not set
 /// in the corresponding element).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovq))]
 pub unsafe fn _mm_maskstore_epi64(mem_addr: *mut i64, mask: i64x2, a: i64x2) {
@@ -1317,7 +1317,7 @@ pub unsafe fn _mm_maskstore_epi64(mem_addr: *mut i64, mask: i64x2, a: i64x2) {
 /// Store packed 64-bit integers from `a` into memory pointed by `mem_addr`
 /// using `mask` (elements are not stored when the highest bit is not set
 /// in the corresponding element).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovq))]
 pub unsafe fn _mm256_maskstore_epi64(
@@ -1328,7 +1328,7 @@ pub unsafe fn _mm256_maskstore_epi64(
 
 /// Compare packed 16-bit integers in `a` and `b`, and return the packed
 /// maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaxsw))]
 pub unsafe fn _mm256_max_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -1337,7 +1337,7 @@ pub unsafe fn _mm256_max_epi16(a: i16x16, b: i16x16) -> i16x16 {
 
 /// Compare packed 32-bit integers in `a` and `b`, and return the packed
 /// maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaxsd))]
 pub unsafe fn _mm256_max_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -1346,7 +1346,7 @@ pub unsafe fn _mm256_max_epi32(a: i32x8, b: i32x8) -> i32x8 {
 
 /// Compare packed 8-bit integers in `a` and `b`, and return the packed
 /// maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaxsb))]
 pub unsafe fn _mm256_max_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -1355,7 +1355,7 @@ pub unsafe fn _mm256_max_epi8(a: i8x32, b: i8x32) -> i8x32 {
 
 /// Compare packed unsigned 16-bit integers in `a` and `b`, and return
 /// the packed maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaxuw))]
 pub unsafe fn _mm256_max_epu16(a: u16x16, b: u16x16) -> u16x16 {
@@ -1364,7 +1364,7 @@ pub unsafe fn _mm256_max_epu16(a: u16x16, b: u16x16) -> u16x16 {
 
 /// Compare packed unsigned 32-bit integers in `a` and `b`, and return
 /// the packed maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaxud))]
 pub unsafe fn _mm256_max_epu32(a: u32x8, b: u32x8) -> u32x8 {
@@ -1373,7 +1373,7 @@ pub unsafe fn _mm256_max_epu32(a: u32x8, b: u32x8) -> u32x8 {
 
 /// Compare packed unsigned 8-bit integers in `a` and `b`, and return
 /// the packed maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaxub))]
 pub unsafe fn _mm256_max_epu8(a: u8x32, b: u8x32) -> u8x32 {
@@ -1382,7 +1382,7 @@ pub unsafe fn _mm256_max_epu8(a: u8x32, b: u8x32) -> u8x32 {
 
 /// Compare packed 16-bit integers in `a` and `b`, and return the packed
 /// minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpminsw))]
 pub unsafe fn _mm256_min_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -1391,7 +1391,7 @@ pub unsafe fn _mm256_min_epi16(a: i16x16, b: i16x16) -> i16x16 {
 
 /// Compare packed 32-bit integers in `a` and `b`, and return the packed
 /// minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpminsd))]
 pub unsafe fn _mm256_min_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -1400,7 +1400,7 @@ pub unsafe fn _mm256_min_epi32(a: i32x8, b: i32x8) -> i32x8 {
 
 /// Compare packed 8-bit integers in `a` and `b`, and return the packed
 /// minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpminsb))]
 pub unsafe fn _mm256_min_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -1409,7 +1409,7 @@ pub unsafe fn _mm256_min_epi8(a: i8x32, b: i8x32) -> i8x32 {
 
 /// Compare packed unsigned 16-bit integers in `a` and `b`, and return
 /// the packed minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpminuw))]
 pub unsafe fn _mm256_min_epu16(a: u16x16, b: u16x16) -> u16x16 {
@@ -1418,7 +1418,7 @@ pub unsafe fn _mm256_min_epu16(a: u16x16, b: u16x16) -> u16x16 {
 
 /// Compare packed unsigned 32-bit integers in `a` and `b`, and return
 /// the packed minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpminud))]
 pub unsafe fn _mm256_min_epu32(a: u32x8, b: u32x8) -> u32x8 {
@@ -1427,7 +1427,7 @@ pub unsafe fn _mm256_min_epu32(a: u32x8, b: u32x8) -> u32x8 {
 
 /// Compare packed unsigned 8-bit integers in `a` and `b`, and return
 /// the packed minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpminub))]
 pub unsafe fn _mm256_min_epu8(a: u8x32, b: u8x32) -> u8x32 {
@@ -1436,7 +1436,7 @@ pub unsafe fn _mm256_min_epu8(a: u8x32, b: u8x32) -> u8x32 {
 
 /// Create mask from the most significant bit of each 8-bit element in `a`,
 /// return the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmovmskb))]
 pub unsafe fn _mm256_movemask_epi8(a: i8x32) -> i32 {
@@ -1450,7 +1450,7 @@ pub unsafe fn _mm256_movemask_epi8(a: i8x32) -> i32 {
 /// selected from `b` starting at on the offset specified in `imm8`. Eight
 /// quadruplets are formed from sequential 8-bit integers selected from `a`
 /// starting at the offset specified in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vmpsadbw, imm8 = 0))]
 pub unsafe fn _mm256_mpsadbw_epu8(a: u8x32, b: u8x32, imm8: i32) -> u16x16 {
@@ -1464,7 +1464,7 @@ pub unsafe fn _mm256_mpsadbw_epu8(a: u8x32, b: u8x32, imm8: i32) -> u16x16 {
 /// `a` and `b`
 ///
 /// Return the 64-bit results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmuldq))]
 pub unsafe fn _mm256_mul_epi32(a: i32x8, b: i32x8) -> i64x4 {
@@ -1475,7 +1475,7 @@ pub unsafe fn _mm256_mul_epi32(a: i32x8, b: i32x8) -> i64x4 {
 /// element in `a` and `b`
 ///
 /// Return the unsigned 64-bit results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmuludq))]
 pub unsafe fn _mm256_mul_epu32(a: u32x8, b: u32x8) -> u64x4 {
@@ -1485,7 +1485,7 @@ pub unsafe fn _mm256_mul_epu32(a: u32x8, b: u32x8) -> u64x4 {
 /// Multiply the packed 16-bit integers in `a` and `b`, producing
 /// intermediate 32-bit integers and returning the high 16 bits of the
 /// intermediate integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmulhw))]
 pub unsafe fn _mm256_mulhi_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -1495,7 +1495,7 @@ pub unsafe fn _mm256_mulhi_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// Multiply the packed unsigned 16-bit integers in `a` and `b`, producing
 /// intermediate 32-bit integers and returning the high 16 bits of the
 /// intermediate integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmulhuw))]
 pub unsafe fn _mm256_mulhi_epu16(a: u16x16, b: u16x16) -> u16x16 {
@@ -1505,7 +1505,7 @@ pub unsafe fn _mm256_mulhi_epu16(a: u16x16, b: u16x16) -> u16x16 {
 /// Multiply the packed 16-bit integers in `a` and `b`, producing
 /// intermediate 32-bit integers, and return the low 16 bits of the
 /// intermediate integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmullw))]
 pub unsafe fn _mm256_mullo_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -1515,7 +1515,7 @@ pub unsafe fn _mm256_mullo_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// Multiply the packed 32-bit integers in `a` and `b`, producing
 /// intermediate 64-bit integers, and return the low 16 bits of the
 /// intermediate integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmulld))]
 pub unsafe fn _mm256_mullo_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -1526,7 +1526,7 @@ pub unsafe fn _mm256_mullo_epi32(a: i32x8, b: i32x8) -> i32x8 {
 /// intermediate signed 32-bit integers. Truncate each intermediate
 /// integer to the 18 most significant bits, round by adding 1, and
 /// return bits [16:1]
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmulhrsw))]
 pub unsafe fn _mm256_mulhrs_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -1535,7 +1535,7 @@ pub unsafe fn _mm256_mulhrs_epi16(a: i16x16, b: i16x16) -> i16x16 {
 
 /// Compute the bitwise OR of 256 bits (representing integer data) in `a`
 /// and `b`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vorps))]
 pub unsafe fn _mm256_or_si256(a: __m256i, b: __m256i) -> __m256i {
@@ -1544,7 +1544,7 @@ pub unsafe fn _mm256_or_si256(a: __m256i, b: __m256i) -> __m256i {
 
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpacksswb))]
 pub unsafe fn _mm256_packs_epi16(a: i16x16, b: i16x16) -> i8x32 {
@@ -1553,7 +1553,7 @@ pub unsafe fn _mm256_packs_epi16(a: i16x16, b: i16x16) -> i8x32 {
 
 /// Convert packed 32-bit integers from `a` and `b` to packed 16-bit integers
 /// using signed saturation
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpackssdw))]
 pub unsafe fn _mm256_packs_epi32(a: i32x8, b: i32x8) -> i16x16 {
@@ -1562,7 +1562,7 @@ pub unsafe fn _mm256_packs_epi32(a: i32x8, b: i32x8) -> i16x16 {
 
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using unsigned saturation
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpackuswb))]
 pub unsafe fn _mm256_packus_epi16(a: i16x16, b: i16x16) -> u8x32 {
@@ -1571,7 +1571,7 @@ pub unsafe fn _mm256_packus_epi16(a: i16x16, b: i16x16) -> u8x32 {
 
 /// Convert packed 32-bit integers from `a` and `b` to packed 16-bit integers
 /// using unsigned saturation
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpackusdw))]
 pub unsafe fn _mm256_packus_epi32(a: i32x8, b: i32x8) -> u16x16 {
@@ -1582,7 +1582,7 @@ pub unsafe fn _mm256_packus_epi32(a: i32x8, b: i32x8) -> u16x16 {
 ///
 /// The last 3 bits of each integer of `b` are used as addresses into the 8
 /// integers of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpermd))]
 pub unsafe fn _mm256_permutevar8x32_epi32(a: u32x8, b: u32x8) -> u32x8 {
@@ -1590,7 +1590,7 @@ pub unsafe fn _mm256_permutevar8x32_epi32(a: u32x8, b: u32x8) -> u32x8 {
 }
 
 /// Permutes 64-bit integers from `a` using control mask `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpermq, imm8 = 9))]
 pub unsafe fn _mm256_permute4x64_epi64(a: i64x4, imm8: i32) -> i64x4 {
@@ -1639,7 +1639,7 @@ pub unsafe fn _mm256_permute4x64_epi64(a: i64x4, imm8: i32) -> i64x4 {
 }
 
 /// Shuffle 128-bits of integer data selected by `imm8` from `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 9))]
 pub unsafe fn _mm256_permute2x128_si256(
@@ -1655,7 +1655,7 @@ pub unsafe fn _mm256_permute2x128_si256(
 
 /// Shuffle 64-bit floating-point elements in `a` across lanes using the
 /// control in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpermpd, imm8 = 1))]
 pub unsafe fn _mm256_permute4x64_pd(a: f64x4, imm8: i32) -> f64x4 {
@@ -1706,7 +1706,7 @@ pub unsafe fn _mm256_permute4x64_pd(a: f64x4, imm8: i32) -> f64x4 {
 
 /// Shuffle eight 32-bit foating-point elements in `a` across lanes using
 /// the corresponding 32-bit integer index in `idx`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpermps))]
 pub unsafe fn _mm256_permutevar8x32_ps(a: f32x8, idx: i32x8) -> f32x8 {
@@ -1717,7 +1717,7 @@ pub unsafe fn _mm256_permutevar8x32_ps(a: f32x8, idx: i32x8) -> f32x8 {
 /// and `b`, then horizontally sum each consecutive 8 differences to
 /// produce four unsigned 16-bit integers, and pack these unsigned 16-bit
 /// integers in the low 16 bits of the 64-bit return value
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsadbw))]
 pub unsafe fn _mm256_sad_epu8(a: u8x32, b: u8x32) -> u64x4 {
@@ -1753,7 +1753,7 @@ pub unsafe fn _mm256_sad_epu8(a: u8x32, b: u8x32) -> u64x4 {
 ///     r
 /// }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpshufb))]
 pub unsafe fn _mm256_shuffle_epi8(a: u8x32, b: u8x32) -> u8x32 {
@@ -1797,7 +1797,7 @@ pub unsafe fn _mm256_shuffle_epi8(a: u8x32, b: u8x32) -> u8x32 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpshufd, imm8 = 9))]
 pub unsafe fn _mm256_shuffle_epi32(a: i32x8, imm8: i32) -> i32x8 {
@@ -1856,7 +1856,7 @@ pub unsafe fn _mm256_shuffle_epi32(a: i32x8, imm8: i32) -> i32x8 {
 /// Shuffle 16-bit integers in the high 64 bits of 128-bit lanes of `a` using
 /// the control in `imm8`. The low 64 bits of 128-bit lanes of `a` are copied
 /// to the output.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpshufhw, imm8 = 9))]
 pub unsafe fn _mm256_shufflehi_epi16(a: i16x16, imm8: i32) -> i16x16 {
@@ -1911,7 +1911,7 @@ pub unsafe fn _mm256_shufflehi_epi16(a: i16x16, imm8: i32) -> i16x16 {
 /// Shuffle 16-bit integers in the low 64 bits of 128-bit lanes of `a` using
 /// the control in `imm8`. The high 64 bits of 128-bit lanes of `a` are copied
 /// to the output.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpshuflw, imm8 = 9))]
 pub unsafe fn _mm256_shufflelo_epi16(a: i16x16, imm8: i32) -> i16x16 {
@@ -1966,7 +1966,7 @@ pub unsafe fn _mm256_shufflelo_epi16(a: i16x16, imm8: i32) -> i16x16 {
 /// Negate packed 16-bit integers in `a` when the corresponding signed
 /// 16-bit integer in `b` is negative, and return the results.
 /// Results are zeroed out when the corresponding element in `b` is zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsignw))]
 pub unsafe fn _mm256_sign_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -1976,7 +1976,7 @@ pub unsafe fn _mm256_sign_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// Negate packed 32-bit integers in `a` when the corresponding signed
 /// 32-bit integer in `b` is negative, and return the results.
 /// Results are zeroed out when the corresponding element in `b` is zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsignd))]
 pub unsafe fn _mm256_sign_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -1986,7 +1986,7 @@ pub unsafe fn _mm256_sign_epi32(a: i32x8, b: i32x8) -> i32x8 {
 /// Negate packed 8-bit integers in `a` when the corresponding signed
 /// 8-bit integer in `b` is negative, and return the results.
 /// Results are zeroed out when the corresponding element in `b` is zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsignb))]
 pub unsafe fn _mm256_sign_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -1995,7 +1995,7 @@ pub unsafe fn _mm256_sign_epi8(a: i8x32, b: i8x32) -> i8x32 {
 
 /// Shift packed 16-bit integers in `a` left by `count` while
 /// shifting in zeros, and return the result
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsllw))]
 pub unsafe fn _mm256_sll_epi16(a: i16x16, count: i16x8) -> i16x16 {
@@ -2004,7 +2004,7 @@ pub unsafe fn _mm256_sll_epi16(a: i16x16, count: i16x8) -> i16x16 {
 
 /// Shift packed 32-bit integers in `a` left by `count` while
 /// shifting in zeros, and return the result
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpslld))]
 pub unsafe fn _mm256_sll_epi32(a: i32x8, count: i32x4) -> i32x8 {
@@ -2013,7 +2013,7 @@ pub unsafe fn _mm256_sll_epi32(a: i32x8, count: i32x4) -> i32x8 {
 
 /// Shift packed 64-bit integers in `a` left by `count` while
 /// shifting in zeros, and return the result
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsllq))]
 pub unsafe fn _mm256_sll_epi64(a: i64x4, count: i64x2) -> i64x4 {
@@ -2022,7 +2022,7 @@ pub unsafe fn _mm256_sll_epi64(a: i64x4, count: i64x2) -> i64x4 {
 
 /// Shift packed 16-bit integers in `a` left by `imm8` while
 /// shifting in zeros, return the results;
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsllw))]
 pub unsafe fn _mm256_slli_epi16(a: i16x16, imm8: i32) -> i16x16 {
@@ -2031,7 +2031,7 @@ pub unsafe fn _mm256_slli_epi16(a: i16x16, imm8: i32) -> i16x16 {
 
 /// Shift packed 32-bit integers in `a` left by `imm8` while
 /// shifting in zeros, return the results;
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpslld))]
 pub unsafe fn _mm256_slli_epi32(a: i32x8, imm8: i32) -> i32x8 {
@@ -2040,7 +2040,7 @@ pub unsafe fn _mm256_slli_epi32(a: i32x8, imm8: i32) -> i32x8 {
 
 /// Shift packed 64-bit integers in `a` left by `imm8` while
 /// shifting in zeros, return the results;
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsllq))]
 pub unsafe fn _mm256_slli_epi64(a: i64x4, imm8: i32) -> i64x4 {
@@ -2048,7 +2048,7 @@ pub unsafe fn _mm256_slli_epi64(a: i64x4, imm8: i32) -> i64x4 {
 }
 
 /// Shift 128-bit lanes in `a` left by `imm8` bytes while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpslldq, imm8 = 3))]
 pub unsafe fn _mm256_slli_si256(a: __m256i, imm8: i32) -> __m256i {
@@ -2061,7 +2061,7 @@ pub unsafe fn _mm256_slli_si256(a: __m256i, imm8: i32) -> __m256i {
 }
 
 /// Shift 128-bit lanes in `a` left by `imm8` bytes while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpslldq, imm8 = 3))]
 pub unsafe fn _mm256_bslli_epi128(a: __m256i, imm8: i32) -> __m256i {
@@ -2071,7 +2071,7 @@ pub unsafe fn _mm256_bslli_epi128(a: __m256i, imm8: i32) -> __m256i {
 /// Shift packed 32-bit integers in `a` left by the amount
 /// specified by the corresponding element in `count` while
 /// shifting in zeros, and return the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsllvd))]
 pub unsafe fn _mm_sllv_epi32(a: i32x4, count: i32x4) -> i32x4 {
@@ -2081,7 +2081,7 @@ pub unsafe fn _mm_sllv_epi32(a: i32x4, count: i32x4) -> i32x4 {
 /// Shift packed 32-bit integers in `a` left by the amount
 /// specified by the corresponding element in `count` while
 /// shifting in zeros, and return the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsllvd))]
 pub unsafe fn _mm256_sllv_epi32(a: i32x8, count: i32x8) -> i32x8 {
@@ -2091,7 +2091,7 @@ pub unsafe fn _mm256_sllv_epi32(a: i32x8, count: i32x8) -> i32x8 {
 /// Shift packed 64-bit integers in `a` left by the amount
 /// specified by the corresponding element in `count` while
 /// shifting in zeros, and return the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsllvq))]
 pub unsafe fn _mm_sllv_epi64(a: i64x2, count: i64x2) -> i64x2 {
@@ -2101,7 +2101,7 @@ pub unsafe fn _mm_sllv_epi64(a: i64x2, count: i64x2) -> i64x2 {
 /// Shift packed 64-bit integers in `a` left by the amount
 /// specified by the corresponding element in `count` while
 /// shifting in zeros, and return the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsllvq))]
 pub unsafe fn _mm256_sllv_epi64(a: i64x4, count: i64x4) -> i64x4 {
@@ -2110,7 +2110,7 @@ pub unsafe fn _mm256_sllv_epi64(a: i64x4, count: i64x4) -> i64x4 {
 
 /// Shift packed 16-bit integers in `a` right by `count` while
 /// shifting in sign bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsraw))]
 pub unsafe fn _mm256_sra_epi16(a: i16x16, count: i16x8) -> i16x16 {
@@ -2119,7 +2119,7 @@ pub unsafe fn _mm256_sra_epi16(a: i16x16, count: i16x8) -> i16x16 {
 
 /// Shift packed 32-bit integers in `a` right by `count` while
 /// shifting in sign bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrad))]
 pub unsafe fn _mm256_sra_epi32(a: i32x8, count: i32x4) -> i32x8 {
@@ -2128,7 +2128,7 @@ pub unsafe fn _mm256_sra_epi32(a: i32x8, count: i32x4) -> i32x8 {
 
 /// Shift packed 16-bit integers in `a` right by `imm8` while
 /// shifting in sign bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsraw))]
 pub unsafe fn _mm256_srai_epi16(a: i16x16, imm8: i32) -> i16x16 {
@@ -2137,7 +2137,7 @@ pub unsafe fn _mm256_srai_epi16(a: i16x16, imm8: i32) -> i16x16 {
 
 /// Shift packed 32-bit integers in `a` right by `imm8` while
 /// shifting in sign bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrad))]
 pub unsafe fn _mm256_srai_epi32(a: i32x8, imm8: i32) -> i32x8 {
@@ -2146,7 +2146,7 @@ pub unsafe fn _mm256_srai_epi32(a: i32x8, imm8: i32) -> i32x8 {
 
 /// Shift packed 32-bit integers in `a` right by the amount specified by the
 /// corresponding element in `count` while shifting in sign bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsravd))]
 pub unsafe fn _mm_srav_epi32(a: i32x4, count: i32x4) -> i32x4 {
@@ -2155,7 +2155,7 @@ pub unsafe fn _mm_srav_epi32(a: i32x4, count: i32x4) -> i32x4 {
 
 /// Shift packed 32-bit integers in `a` right by the amount specified by the
 /// corresponding element in `count` while shifting in sign bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsravd))]
 pub unsafe fn _mm256_srav_epi32(a: i32x8, count: i32x8) -> i32x8 {
@@ -2163,7 +2163,7 @@ pub unsafe fn _mm256_srav_epi32(a: i32x8, count: i32x8) -> i32x8 {
 }
 
 /// Shift 128-bit lanes in `a` right by `imm8` bytes while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrldq, imm8 = 3))]
 pub unsafe fn _mm256_srli_si256(a: __m256i, imm8: i32) -> __m256i {
@@ -2176,7 +2176,7 @@ pub unsafe fn _mm256_srli_si256(a: __m256i, imm8: i32) -> __m256i {
 }
 
 /// Shift 128-bit lanes in `a` right by `imm8` bytes while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrldq, imm8 = 3))]
 pub unsafe fn _mm256_bsrli_epi128(a: __m256i, imm8: i32) -> __m256i {
@@ -2185,7 +2185,7 @@ pub unsafe fn _mm256_bsrli_epi128(a: __m256i, imm8: i32) -> __m256i {
 
 /// Shift packed 16-bit integers in `a` right by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrlw))]
 pub unsafe fn _mm256_srl_epi16(a: i16x16, count: i16x8) -> i16x16 {
@@ -2194,7 +2194,7 @@ pub unsafe fn _mm256_srl_epi16(a: i16x16, count: i16x8) -> i16x16 {
 
 /// Shift packed 32-bit integers in `a` right by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrld))]
 pub unsafe fn _mm256_srl_epi32(a: i32x8, count: i32x4) -> i32x8 {
@@ -2203,7 +2203,7 @@ pub unsafe fn _mm256_srl_epi32(a: i32x8, count: i32x4) -> i32x8 {
 
 /// Shift packed 64-bit integers in `a` right by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrlq))]
 pub unsafe fn _mm256_srl_epi64(a: i64x4, count: i64x2) -> i64x4 {
@@ -2212,7 +2212,7 @@ pub unsafe fn _mm256_srl_epi64(a: i64x4, count: i64x2) -> i64x4 {
 
 /// Shift packed 16-bit integers in `a` right by `imm8` while shifting in
 /// zeros
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrlw))]
 pub unsafe fn _mm256_srli_epi16(a: i16x16, imm8: i32) -> i16x16 {
@@ -2221,7 +2221,7 @@ pub unsafe fn _mm256_srli_epi16(a: i16x16, imm8: i32) -> i16x16 {
 
 /// Shift packed 32-bit integers in `a` right by `imm8` while shifting in
 /// zeros
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrld))]
 pub unsafe fn _mm256_srli_epi32(a: i32x8, imm8: i32) -> i32x8 {
@@ -2230,7 +2230,7 @@ pub unsafe fn _mm256_srli_epi32(a: i32x8, imm8: i32) -> i32x8 {
 
 /// Shift packed 64-bit integers in `a` right by `imm8` while shifting in
 /// zeros
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrlq))]
 pub unsafe fn _mm256_srli_epi64(a: i64x4, imm8: i32) -> i64x4 {
@@ -2239,7 +2239,7 @@ pub unsafe fn _mm256_srli_epi64(a: i64x4, imm8: i32) -> i64x4 {
 
 /// Shift packed 32-bit integers in `a` right by the amount specified by
 /// the corresponding element in `count` while shifting in zeros,
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrlvd))]
 pub unsafe fn _mm_srlv_epi32(a: i32x4, count: i32x4) -> i32x4 {
@@ -2248,7 +2248,7 @@ pub unsafe fn _mm_srlv_epi32(a: i32x4, count: i32x4) -> i32x4 {
 
 /// Shift packed 32-bit integers in `a` right by the amount specified by
 /// the corresponding element in `count` while shifting in zeros,
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrlvd))]
 pub unsafe fn _mm256_srlv_epi32(a: i32x8, count: i32x8) -> i32x8 {
@@ -2257,7 +2257,7 @@ pub unsafe fn _mm256_srlv_epi32(a: i32x8, count: i32x8) -> i32x8 {
 
 /// Shift packed 64-bit integers in `a` right by the amount specified by
 /// the corresponding element in `count` while shifting in zeros,
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrlvq))]
 pub unsafe fn _mm_srlv_epi64(a: i64x2, count: i64x2) -> i64x2 {
@@ -2266,7 +2266,7 @@ pub unsafe fn _mm_srlv_epi64(a: i64x2, count: i64x2) -> i64x2 {
 
 /// Shift packed 64-bit integers in `a` right by the amount specified by
 /// the corresponding element in `count` while shifting in zeros,
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsrlvq))]
 pub unsafe fn _mm256_srlv_epi64(a: i64x4, count: i64x4) -> i64x4 {
@@ -2276,7 +2276,7 @@ pub unsafe fn _mm256_srlv_epi64(a: i64x4, count: i64x4) -> i64x4 {
 // TODO _mm256_stream_load_si256 (__m256i const* mem_addr)
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsubw))]
 pub unsafe fn _mm256_sub_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -2284,7 +2284,7 @@ pub unsafe fn _mm256_sub_epi16(a: i16x16, b: i16x16) -> i16x16 {
 }
 
 /// Subtract packed 32-bit integers in `b` from packed 16-bit integers in `a`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsubd))]
 pub unsafe fn _mm256_sub_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -2292,7 +2292,7 @@ pub unsafe fn _mm256_sub_epi32(a: i32x8, b: i32x8) -> i32x8 {
 }
 
 /// Subtract packed 64-bit integers in `b` from packed 16-bit integers in `a`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsubq))]
 pub unsafe fn _mm256_sub_epi64(a: i64x4, b: i64x4) -> i64x4 {
@@ -2300,7 +2300,7 @@ pub unsafe fn _mm256_sub_epi64(a: i64x4, b: i64x4) -> i64x4 {
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 16-bit integers in `a`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsubb))]
 pub unsafe fn _mm256_sub_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -2309,7 +2309,7 @@ pub unsafe fn _mm256_sub_epi8(a: i8x32, b: i8x32) -> i8x32 {
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in
 /// `a` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsubsw))]
 pub unsafe fn _mm256_subs_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -2318,7 +2318,7 @@ pub unsafe fn _mm256_subs_epi16(a: i16x16, b: i16x16) -> i16x16 {
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in
 /// `a` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsubsb))]
 pub unsafe fn _mm256_subs_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -2327,7 +2327,7 @@ pub unsafe fn _mm256_subs_epi8(a: i8x32, b: i8x32) -> i8x32 {
 
 /// Subtract packed unsigned 16-bit integers in `b` from packed 16-bit
 /// integers in `a` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsubusw))]
 pub unsafe fn _mm256_subs_epu16(a: u16x16, b: u16x16) -> u16x16 {
@@ -2336,7 +2336,7 @@ pub unsafe fn _mm256_subs_epu16(a: u16x16, b: u16x16) -> u16x16 {
 
 /// Subtract packed unsigned 8-bit integers in `b` from packed 8-bit
 /// integers in `a` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpsubusb))]
 pub unsafe fn _mm256_subs_epu8(a: u8x32, b: u8x32) -> u8x32 {
@@ -2379,7 +2379,7 @@ pub unsafe fn _mm256_subs_epu8(a: u8x32, b: u8x32) -> u8x32 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpunpckhbw))]
 pub unsafe fn _mm256_unpackhi_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -2427,7 +2427,7 @@ pub unsafe fn _mm256_unpackhi_epi8(a: i8x32, b: i8x32) -> i8x32 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpunpcklbw))]
 pub unsafe fn _mm256_unpacklo_epi8(a: i8x32, b: i8x32) -> i8x32 {
@@ -2473,7 +2473,7 @@ pub unsafe fn _mm256_unpacklo_epi8(a: i8x32, b: i8x32) -> i8x32 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpunpckhwd))]
 pub unsafe fn _mm256_unpackhi_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -2517,7 +2517,7 @@ pub unsafe fn _mm256_unpackhi_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpunpcklwd))]
 pub unsafe fn _mm256_unpacklo_epi16(a: i16x16, b: i16x16) -> i16x16 {
@@ -2560,7 +2560,7 @@ pub unsafe fn _mm256_unpacklo_epi16(a: i16x16, b: i16x16) -> i16x16 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpunpckhdq))]
 pub unsafe fn _mm256_unpackhi_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -2599,7 +2599,7 @@ pub unsafe fn _mm256_unpackhi_epi32(a: i32x8, b: i32x8) -> i32x8 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpunpckldq))]
 pub unsafe fn _mm256_unpacklo_epi32(a: i32x8, b: i32x8) -> i32x8 {
@@ -2638,7 +2638,7 @@ pub unsafe fn _mm256_unpacklo_epi32(a: i32x8, b: i32x8) -> i32x8 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpunpckhqdq))]
 pub unsafe fn _mm256_unpackhi_epi64(a: i64x4, b: i64x4) -> i64x4 {
@@ -2677,7 +2677,7 @@ pub unsafe fn _mm256_unpackhi_epi64(a: i64x4, b: i64x4) -> i64x4 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpunpcklqdq))]
 pub unsafe fn _mm256_unpacklo_epi64(a: i64x4, b: i64x4) -> i64x4 {
@@ -2686,7 +2686,7 @@ pub unsafe fn _mm256_unpacklo_epi64(a: i64x4, b: i64x4) -> i64x4 {
 
 /// Compute the bitwise XOR of 256 bits (representing integer data)
 /// in `a` and `b`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vxorps))]
 pub unsafe fn _mm256_xor_si256(a: __m256i, b: __m256i) -> __m256i {
@@ -2697,7 +2697,7 @@ pub unsafe fn _mm256_xor_si256(a: __m256i, b: __m256i) -> __m256i {
 /// integer containing the zero-extended integer data.
 ///
 /// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_extract_epi8(a: i8x32, imm8: i32) -> i8 {
@@ -2709,7 +2709,7 @@ pub unsafe fn _mm256_extract_epi8(a: i8x32, imm8: i32) -> i8 {
 /// integer containing the zero-extended integer data.
 ///
 /// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_extract_epi16(a: i16x16, imm8: i32) -> i16 {
@@ -2718,7 +2718,7 @@ pub unsafe fn _mm256_extract_epi16(a: i16x16, imm8: i32) -> i16 {
 }
 
 /// Extract a 32-bit integer from `a`, selected with `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_extract_epi32(a: i32x8, imm8: i32) -> i32 {
@@ -2727,7 +2727,7 @@ pub unsafe fn _mm256_extract_epi32(a: i32x8, imm8: i32) -> i32 {
 }
 
 /// Extract a 64-bit integer from `a`, selected with `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 // This intrinsic has no corresponding instruction.
 pub unsafe fn _mm256_extract_epi64(a: i64x4, imm8: i32) -> i64 {
@@ -2736,7 +2736,7 @@ pub unsafe fn _mm256_extract_epi64(a: i64x4, imm8: i32) -> i64 {
 }
 
 /// Returns the first element of the input vector of [4 x double].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 //#[cfg_attr(test, assert_instr(movsd))] FIXME
 pub unsafe fn _mm256_cvtsd_f64(a: f64x4) -> f64 {
@@ -2744,7 +2744,7 @@ pub unsafe fn _mm256_cvtsd_f64(a: f64x4) -> f64 {
 }
 
 /// Returns the first element of the input vector of [8 x i32].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 //#[cfg_attr(test, assert_instr(movd))] FIXME
 pub unsafe fn _mm256_cvtsi256_si32(a: i32x8) -> i32 {

--- a/coresimd/src/x86/i586/bmi.rs
+++ b/coresimd/src/x86/i586/bmi.rs
@@ -14,8 +14,8 @@ use stdsimd_test::assert_instr;
 
 /// Extracts bits in range [`start`, `start` + `length`) from `a` into
 /// the least significant bits of the result.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(bextr))]
 pub unsafe fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
     _bextr2_u32(a, (start & 0xff_u32) | ((len & 0xff_u32) << 8_u32))
@@ -23,8 +23,8 @@ pub unsafe fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
 
 /// Extracts bits in range [`start`, `start` + `length`) from `a` into
 /// the least significant bits of the result.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(bextr))]
 #[cfg(not(target_arch = "x86"))]
 pub unsafe fn _bextr_u64(a: u64, start: u32, len: u32) -> u64 {
@@ -36,8 +36,8 @@ pub unsafe fn _bextr_u64(a: u64, start: u32, len: u32) -> u64 {
 ///
 /// Bits [7,0] of `control` specify the index to the first bit in the range to
 /// be extracted, and bits [15,8] specify the length of the range.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(bextr))]
 pub unsafe fn _bextr2_u32(a: u32, control: u32) -> u32 {
     x86_bmi_bextr_32(a, control)
@@ -48,8 +48,8 @@ pub unsafe fn _bextr2_u32(a: u32, control: u32) -> u32 {
 ///
 /// Bits [7,0] of `control` specify the index to the first bit in the range to
 /// be extracted, and bits [15,8] specify the length of the range.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(bextr))]
 #[cfg(not(target_arch = "x86"))]
 pub unsafe fn _bextr2_u64(a: u64, control: u64) -> u64 {
@@ -57,32 +57,32 @@ pub unsafe fn _bextr2_u64(a: u64, control: u64) -> u64 {
 }
 
 /// Bitwise logical `AND` of inverted `a` with `b`.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(andn))]
 pub unsafe fn _andn_u32(a: u32, b: u32) -> u32 {
     !a & b
 }
 
 /// Bitwise logical `AND` of inverted `a` with `b`.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(andn))]
 pub unsafe fn _andn_u64(a: u64, b: u64) -> u64 {
     !a & b
 }
 
 /// Extract lowest set isolated bit.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(blsi))]
 pub unsafe fn _blsi_u32(x: u32) -> u32 {
     x & x.wrapping_neg()
 }
 
 /// Extract lowest set isolated bit.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(blsi))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
 pub unsafe fn _blsi_u64(x: u64) -> u64 {
@@ -90,16 +90,16 @@ pub unsafe fn _blsi_u64(x: u64) -> u64 {
 }
 
 /// Get mask up to lowest set bit.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(blsmsk))]
 pub unsafe fn _blsmsk_u32(x: u32) -> u32 {
     x ^ (x.wrapping_sub(1_u32))
 }
 
 /// Get mask up to lowest set bit.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(blsmsk))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
 pub unsafe fn _blsmsk_u64(x: u64) -> u64 {
@@ -109,8 +109,8 @@ pub unsafe fn _blsmsk_u64(x: u64) -> u64 {
 /// Resets the lowest set bit of `x`.
 ///
 /// If `x` is sets CF.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(blsr))]
 pub unsafe fn _blsr_u32(x: u32) -> u32 {
     x & (x.wrapping_sub(1))
@@ -119,8 +119,8 @@ pub unsafe fn _blsr_u32(x: u32) -> u32 {
 /// Resets the lowest set bit of `x`.
 ///
 /// If `x` is sets CF.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(blsr))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
 pub unsafe fn _blsr_u64(x: u64) -> u64 {
@@ -130,8 +130,8 @@ pub unsafe fn _blsr_u64(x: u64) -> u64 {
 /// Counts the number of trailing least significant zero bits.
 ///
 /// When the source operand is 0, it returns its size in bits.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _tzcnt_u32(x: u32) -> u32 {
     x.trailing_zeros()
@@ -140,8 +140,8 @@ pub unsafe fn _tzcnt_u32(x: u32) -> u32 {
 /// Counts the number of trailing least significant zero bits.
 ///
 /// When the source operand is 0, it returns its size in bits.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _tzcnt_u64(x: u64) -> u64 {
     x.trailing_zeros() as u64
@@ -150,8 +150,8 @@ pub unsafe fn _tzcnt_u64(x: u64) -> u64 {
 /// Counts the number of trailing least significant zero bits.
 ///
 /// When the source operand is 0, it returns its size in bits.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _mm_tzcnt_32(x: u32) -> i32 {
     x.trailing_zeros() as i32
@@ -160,8 +160,8 @@ pub unsafe fn _mm_tzcnt_32(x: u32) -> i32 {
 /// Counts the number of trailing least significant zero bits.
 ///
 /// When the source operand is 0, it returns its size in bits.
-#[inline(always)]
 #[target_feature(enable = "bmi")]
+#[inline]
 #[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _mm_tzcnt_64(x: u64) -> i64 {
     x.trailing_zeros() as i64

--- a/coresimd/src/x86/i586/bmi.rs
+++ b/coresimd/src/x86/i586/bmi.rs
@@ -14,8 +14,8 @@ use stdsimd_test::assert_instr;
 
 /// Extracts bits in range [`start`, `start` + `length`) from `a` into
 /// the least significant bits of the result.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(bextr))]
 pub unsafe fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
     _bextr2_u32(a, (start & 0xff_u32) | ((len & 0xff_u32) << 8_u32))
@@ -23,8 +23,8 @@ pub unsafe fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
 
 /// Extracts bits in range [`start`, `start` + `length`) from `a` into
 /// the least significant bits of the result.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(bextr))]
 #[cfg(not(target_arch = "x86"))]
 pub unsafe fn _bextr_u64(a: u64, start: u32, len: u32) -> u64 {
@@ -36,8 +36,8 @@ pub unsafe fn _bextr_u64(a: u64, start: u32, len: u32) -> u64 {
 ///
 /// Bits [7,0] of `control` specify the index to the first bit in the range to
 /// be extracted, and bits [15,8] specify the length of the range.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(bextr))]
 pub unsafe fn _bextr2_u32(a: u32, control: u32) -> u32 {
     x86_bmi_bextr_32(a, control)
@@ -48,8 +48,8 @@ pub unsafe fn _bextr2_u32(a: u32, control: u32) -> u32 {
 ///
 /// Bits [7,0] of `control` specify the index to the first bit in the range to
 /// be extracted, and bits [15,8] specify the length of the range.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(bextr))]
 #[cfg(not(target_arch = "x86"))]
 pub unsafe fn _bextr2_u64(a: u64, control: u64) -> u64 {
@@ -57,32 +57,32 @@ pub unsafe fn _bextr2_u64(a: u64, control: u64) -> u64 {
 }
 
 /// Bitwise logical `AND` of inverted `a` with `b`.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(andn))]
 pub unsafe fn _andn_u32(a: u32, b: u32) -> u32 {
     !a & b
 }
 
 /// Bitwise logical `AND` of inverted `a` with `b`.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(andn))]
 pub unsafe fn _andn_u64(a: u64, b: u64) -> u64 {
     !a & b
 }
 
 /// Extract lowest set isolated bit.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(blsi))]
 pub unsafe fn _blsi_u32(x: u32) -> u32 {
     x & x.wrapping_neg()
 }
 
 /// Extract lowest set isolated bit.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(blsi))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
 pub unsafe fn _blsi_u64(x: u64) -> u64 {
@@ -90,16 +90,16 @@ pub unsafe fn _blsi_u64(x: u64) -> u64 {
 }
 
 /// Get mask up to lowest set bit.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(blsmsk))]
 pub unsafe fn _blsmsk_u32(x: u32) -> u32 {
     x ^ (x.wrapping_sub(1_u32))
 }
 
 /// Get mask up to lowest set bit.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(blsmsk))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
 pub unsafe fn _blsmsk_u64(x: u64) -> u64 {
@@ -109,8 +109,8 @@ pub unsafe fn _blsmsk_u64(x: u64) -> u64 {
 /// Resets the lowest set bit of `x`.
 ///
 /// If `x` is sets CF.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(blsr))]
 pub unsafe fn _blsr_u32(x: u32) -> u32 {
     x & (x.wrapping_sub(1))
@@ -119,8 +119,8 @@ pub unsafe fn _blsr_u32(x: u32) -> u32 {
 /// Resets the lowest set bit of `x`.
 ///
 /// If `x` is sets CF.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(blsr))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
 pub unsafe fn _blsr_u64(x: u64) -> u64 {
@@ -130,8 +130,8 @@ pub unsafe fn _blsr_u64(x: u64) -> u64 {
 /// Counts the number of trailing least significant zero bits.
 ///
 /// When the source operand is 0, it returns its size in bits.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _tzcnt_u32(x: u32) -> u32 {
     x.trailing_zeros()
@@ -140,8 +140,8 @@ pub unsafe fn _tzcnt_u32(x: u32) -> u32 {
 /// Counts the number of trailing least significant zero bits.
 ///
 /// When the source operand is 0, it returns its size in bits.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _tzcnt_u64(x: u64) -> u64 {
     x.trailing_zeros() as u64
@@ -150,8 +150,8 @@ pub unsafe fn _tzcnt_u64(x: u64) -> u64 {
 /// Counts the number of trailing least significant zero bits.
 ///
 /// When the source operand is 0, it returns its size in bits.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _mm_tzcnt_32(x: u32) -> i32 {
     x.trailing_zeros() as i32
@@ -160,8 +160,8 @@ pub unsafe fn _mm_tzcnt_32(x: u32) -> i32 {
 /// Counts the number of trailing least significant zero bits.
 ///
 /// When the source operand is 0, it returns its size in bits.
-#[target_feature(enable = "bmi")]
 #[inline]
+#[target_feature(enable = "bmi1")]
 #[cfg_attr(test, assert_instr(tzcnt))]
 pub unsafe fn _mm_tzcnt_64(x: u64) -> i64 {
     x.trailing_zeros() as i64
@@ -181,20 +181,20 @@ mod tests {
 
     use x86::i586::bmi;
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     unsafe fn _bextr_u32() {
         let r = bmi::_bextr_u32(0b0101_0000u32, 4, 4);
         assert_eq!(r, 0b0000_0101u32);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     #[cfg(not(target_arch = "x86"))]
     unsafe fn _bextr_u64() {
         let r = bmi::_bextr_u64(0b0101_0000u64, 4, 4);
         assert_eq!(r, 0b0000_0101u64);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     unsafe fn _andn_u32() {
         assert_eq!(bmi::_andn_u32(0, 0), 0);
         assert_eq!(bmi::_andn_u32(0, 1), 1);
@@ -217,7 +217,7 @@ mod tests {
         assert_eq!(r, 0b0001_1101u32);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     #[cfg(not(target_arch = "x86"))]
     unsafe fn _andn_u64() {
         assert_eq!(bmi::_andn_u64(0, 0), 0);
@@ -241,38 +241,38 @@ mod tests {
         assert_eq!(r, 0b0001_1101u64);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     unsafe fn _blsi_u32() {
         assert_eq!(bmi::_blsi_u32(0b1101_0000u32), 0b0001_0000u32);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     #[cfg(not(target_arch = "x86"))]
     unsafe fn _blsi_u64() {
         assert_eq!(bmi::_blsi_u64(0b1101_0000u64), 0b0001_0000u64);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     unsafe fn _blsmsk_u32() {
         let r = bmi::_blsmsk_u32(0b0011_0000u32);
         assert_eq!(r, 0b0001_1111u32);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     #[cfg(not(target_arch = "x86"))]
     unsafe fn _blsmsk_u64() {
         let r = bmi::_blsmsk_u64(0b0011_0000u64);
         assert_eq!(r, 0b0001_1111u64);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     unsafe fn _blsr_u32() {
         // TODO: test the behavior when the input is 0
         let r = bmi::_blsr_u32(0b0011_0000u32);
         assert_eq!(r, 0b0010_0000u32);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     #[cfg(not(target_arch = "x86"))]
     unsafe fn _blsr_u64() {
         // TODO: test the behavior when the input is 0
@@ -280,14 +280,14 @@ mod tests {
         assert_eq!(r, 0b0010_0000u64);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     unsafe fn _tzcnt_u32() {
         assert_eq!(bmi::_tzcnt_u32(0b0000_0001u32), 0u32);
         assert_eq!(bmi::_tzcnt_u32(0b0000_0000u32), 32u32);
         assert_eq!(bmi::_tzcnt_u32(0b1001_0000u32), 4u32);
     }
 
-    #[simd_test = "bmi"]
+    #[simd_test = "bmi1"]
     #[cfg(not(target_arch = "x86"))]
     unsafe fn _tzcnt_u64() {
         assert_eq!(bmi::_tzcnt_u64(0b0000_0001u64), 0u64);

--- a/coresimd/src/x86/i586/bmi2.rs
+++ b/coresimd/src/x86/i586/bmi2.rs
@@ -17,7 +17,7 @@ use stdsimd_test::assert_instr;
 ///
 /// Unsigned multiplication of `a` with `b` returning a pair `(lo, hi)` with
 /// the low half and the high half of the result.
-#[inline(always)]
+#[inline]
 // LLVM BUG (should be mulxl): https://bugs.llvm.org/show_bug.cgi?id=34232
 #[cfg_attr(all(test, target_arch = "x86_64"), assert_instr(imul))]
 #[cfg_attr(all(test, target_arch = "x86"), assert_instr(mulx))]
@@ -32,7 +32,7 @@ pub unsafe fn _mulx_u32(a: u32, b: u32, hi: &mut u32) -> u32 {
 ///
 /// Unsigned multiplication of `a` with `b` returning a pair `(lo, hi)` with
 /// the low half and the high half of the result.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(mulx))]
 #[target_feature(enable = "bmi2")]
 #[cfg(not(target_arch = "x86"))] // calls an intrinsic
@@ -43,7 +43,7 @@ pub unsafe fn _mulx_u64(a: u64, b: u64, hi: &mut u64) -> u64 {
 }
 
 /// Zero higher bits of `a` >= `index`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "bmi2")]
 #[cfg_attr(test, assert_instr(bzhi))]
 pub unsafe fn _bzhi_u32(a: u32, index: u32) -> u32 {
@@ -51,7 +51,7 @@ pub unsafe fn _bzhi_u32(a: u32, index: u32) -> u32 {
 }
 
 /// Zero higher bits of `a` >= `index`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "bmi2")]
 #[cfg_attr(test, assert_instr(bzhi))]
 #[cfg(not(target_arch = "x86"))]
@@ -61,7 +61,7 @@ pub unsafe fn _bzhi_u64(a: u64, index: u32) -> u64 {
 
 /// Scatter contiguous low order bits of `a` to the result at the positions
 /// specified by the `mask`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "bmi2")]
 #[cfg_attr(test, assert_instr(pdep))]
 pub unsafe fn _pdep_u32(a: u32, mask: u32) -> u32 {
@@ -70,7 +70,7 @@ pub unsafe fn _pdep_u32(a: u32, mask: u32) -> u32 {
 
 /// Scatter contiguous low order bits of `a` to the result at the positions
 /// specified by the `mask`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "bmi2")]
 #[cfg_attr(test, assert_instr(pdep))]
 #[cfg(not(target_arch = "x86"))]
@@ -80,7 +80,7 @@ pub unsafe fn _pdep_u64(a: u64, mask: u64) -> u64 {
 
 /// Gathers the bits of `x` specified by the `mask` into the contiguous low
 /// order bit positions of the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "bmi2")]
 #[cfg_attr(test, assert_instr(pext))]
 pub unsafe fn _pext_u32(a: u32, mask: u32) -> u32 {
@@ -89,7 +89,7 @@ pub unsafe fn _pext_u32(a: u32, mask: u32) -> u32 {
 
 /// Gathers the bits of `x` specified by the `mask` into the contiguous low
 /// order bit positions of the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "bmi2")]
 #[cfg_attr(test, assert_instr(pext))]
 #[cfg(not(target_arch = "x86"))]

--- a/coresimd/src/x86/i586/bswap.rs
+++ b/coresimd/src/x86/i586/bswap.rs
@@ -6,14 +6,14 @@
 use stdsimd_test::assert_instr;
 
 /// Return an integer with the reversed byte order of x
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(bswap))]
 pub unsafe fn _bswap(x: i32) -> i32 {
     bswap_i32(x)
 }
 
 /// Return an integer with the reversed byte order of x
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(bswap))]
 pub unsafe fn _bswap64(x: i64) -> i64 {
     bswap_i64(x)

--- a/coresimd/src/x86/i586/cpuid.rs
+++ b/coresimd/src/x86/i586/cpuid.rs
@@ -42,7 +42,7 @@ pub struct CpuidResult {
 /// [wiki_cpuid]: https://en.wikipedia.org/wiki/CPUID
 /// [intel64_ref]: http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
 /// [amd64_ref]: http://support.amd.com/TechDocs/24594.pdf
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(cpuid))]
 pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
     let mut r = ::core::mem::uninitialized::<CpuidResult>();
@@ -62,14 +62,14 @@ pub unsafe fn __cpuid_count(leaf: u32, sub_leaf: u32) -> CpuidResult {
 }
 
 /// See [`__cpuid_count`](fn.__cpuid_count.html).
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(cpuid))]
 pub unsafe fn __cpuid(leaf: u32) -> CpuidResult {
     __cpuid_count(leaf, 0)
 }
 
 /// Does the host support the `cpuid` instruction?
-#[inline(always)]
+#[inline]
 pub fn has_cpuid() -> bool {
     #[cfg(target_arch = "x86_64")]
     {
@@ -111,7 +111,7 @@ pub fn has_cpuid() -> bool {
 ///
 /// See also [`__cpuid`](fn.__cpuid.html) and
 /// [`__cpuid_count`](fn.__cpuid_count.html).
-#[inline(always)]
+#[inline]
 pub unsafe fn __get_cpuid_max(leaf: u32) -> (u32, u32) {
     let CpuidResult { eax, ebx, .. } = __cpuid(leaf);
     (eax, ebx)

--- a/coresimd/src/x86/i586/rdtsc.rs
+++ b/coresimd/src/x86/i586/rdtsc.rs
@@ -15,7 +15,7 @@ use stdsimd_test::assert_instr;
 ///
 /// On processors that support the Intel 64 architecture, the
 /// high-order 32 bits of each of RAX and RDX are cleared.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(rdtsc))]
 pub unsafe fn _rdtsc() -> u64 {
     rdtsc()
@@ -35,7 +35,7 @@ pub unsafe fn _rdtsc() -> u64 {
 ///
 /// On processors that support the Intel 64 architecture, the
 /// high-order 32 bits of each of RAX, RDX, and RCX are cleared.
-#[inline(always)]
+#[inline]
 #[cfg_attr(test, assert_instr(rdtscp))]
 pub unsafe fn _rdtscp(aux: *mut u32) -> u64 {
     rdtscp(aux as *mut _)

--- a/coresimd/src/x86/i586/sse.rs
+++ b/coresimd/src/x86/i586/sse.rs
@@ -12,7 +12,7 @@ use stdsimd_test::assert_instr;
 
 /// Adds the first component of `a` and `b`, the other components are copied
 /// from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(addss))]
 pub unsafe fn _mm_add_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -20,7 +20,7 @@ pub unsafe fn _mm_add_ss(a: f32x4, b: f32x4) -> f32x4 {
 }
 
 /// Adds f32x4 vectors.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(addps))]
 pub unsafe fn _mm_add_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -29,7 +29,7 @@ pub unsafe fn _mm_add_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Subtracts the first component of `b` from `a`, the other components are
 /// copied from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(subss))]
 pub unsafe fn _mm_sub_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -37,7 +37,7 @@ pub unsafe fn _mm_sub_ss(a: f32x4, b: f32x4) -> f32x4 {
 }
 
 /// Subtracts f32x4 vectors.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(subps))]
 pub unsafe fn _mm_sub_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -46,7 +46,7 @@ pub unsafe fn _mm_sub_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Multiplies the first component of `a` and `b`, the other components are
 /// copied from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(mulss))]
 pub unsafe fn _mm_mul_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -54,7 +54,7 @@ pub unsafe fn _mm_mul_ss(a: f32x4, b: f32x4) -> f32x4 {
 }
 
 /// Multiplies f32x4 vectors.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(mulps))]
 pub unsafe fn _mm_mul_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -63,7 +63,7 @@ pub unsafe fn _mm_mul_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Divides the first component of `b` by `a`, the other components are
 /// copied from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(divss))]
 pub unsafe fn _mm_div_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -71,7 +71,7 @@ pub unsafe fn _mm_div_ss(a: f32x4, b: f32x4) -> f32x4 {
 }
 
 /// Divides f32x4 vectors.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(divps))]
 pub unsafe fn _mm_div_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -80,7 +80,7 @@ pub unsafe fn _mm_div_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Return the square root of the first single-precision (32-bit)
 /// floating-point element in `a`, the other elements are unchanged.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(sqrtss))]
 pub unsafe fn _mm_sqrt_ss(a: f32x4) -> f32x4 {
@@ -89,7 +89,7 @@ pub unsafe fn _mm_sqrt_ss(a: f32x4) -> f32x4 {
 
 /// Return the square root of packed single-precision (32-bit) floating-point
 /// elements in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(sqrtps))]
 pub unsafe fn _mm_sqrt_ps(a: f32x4) -> f32x4 {
@@ -98,7 +98,7 @@ pub unsafe fn _mm_sqrt_ps(a: f32x4) -> f32x4 {
 
 /// Return the approximate reciprocal of the first single-precision
 /// (32-bit) floating-point element in `a`, the other elements are unchanged.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(rcpss))]
 pub unsafe fn _mm_rcp_ss(a: f32x4) -> f32x4 {
@@ -107,7 +107,7 @@ pub unsafe fn _mm_rcp_ss(a: f32x4) -> f32x4 {
 
 /// Return the approximate reciprocal of packed single-precision (32-bit)
 /// floating-point elements in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(rcpps))]
 pub unsafe fn _mm_rcp_ps(a: f32x4) -> f32x4 {
@@ -116,7 +116,7 @@ pub unsafe fn _mm_rcp_ps(a: f32x4) -> f32x4 {
 
 /// Return the approximate reciprocal square root of the fist single-precision
 /// (32-bit) floating-point elements in `a`, the other elements are unchanged.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(rsqrtss))]
 pub unsafe fn _mm_rsqrt_ss(a: f32x4) -> f32x4 {
@@ -125,7 +125,7 @@ pub unsafe fn _mm_rsqrt_ss(a: f32x4) -> f32x4 {
 
 /// Return the approximate reciprocal square root of packed single-precision
 /// (32-bit) floating-point elements in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(rsqrtps))]
 pub unsafe fn _mm_rsqrt_ps(a: f32x4) -> f32x4 {
@@ -135,7 +135,7 @@ pub unsafe fn _mm_rsqrt_ps(a: f32x4) -> f32x4 {
 /// Compare the first single-precision (32-bit) floating-point element of `a`
 /// and `b`, and return the minimum value in the first element of the return
 /// value, the other elements are copied from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(minss))]
 pub unsafe fn _mm_min_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -144,7 +144,7 @@ pub unsafe fn _mm_min_ss(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Compare packed single-precision (32-bit) floating-point elements in `a` and
 /// `b`, and return the corresponding minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(minps))]
 pub unsafe fn _mm_min_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -154,7 +154,7 @@ pub unsafe fn _mm_min_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// Compare the first single-precision (32-bit) floating-point element of `a`
 /// and `b`, and return the maximum value in the first element of the return
 /// value, the other elements are copied from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(maxss))]
 pub unsafe fn _mm_max_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -163,7 +163,7 @@ pub unsafe fn _mm_max_ss(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Compare packed single-precision (32-bit) floating-point elements in `a` and
 /// `b`, and return the corresponding maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(maxps))]
 pub unsafe fn _mm_max_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -171,7 +171,7 @@ pub unsafe fn _mm_max_ps(a: f32x4, b: f32x4) -> f32x4 {
 }
 
 /// Bitwise AND of packed single-precision (32-bit) floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // i586 only seems to generate plain `and` instructions, so ignore it.
 #[cfg_attr(all(test, any(target_arch = "x86_64", target_feature = "sse2")),
@@ -186,7 +186,7 @@ pub unsafe fn _mm_and_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// elements.
 ///
 /// Computes `!a & b` for each bit in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // i586 only seems to generate plain `not` and `and` instructions, so ignore
 // it.
@@ -199,7 +199,7 @@ pub unsafe fn _mm_andnot_ps(a: f32x4, b: f32x4) -> f32x4 {
 }
 
 /// Bitwise OR of packed single-precision (32-bit) floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // i586 only seems to generate plain `or` instructions, so we ignore it.
 #[cfg_attr(all(test, any(target_arch = "x86_64", target_feature = "sse2")),
@@ -212,7 +212,7 @@ pub unsafe fn _mm_or_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Bitwise exclusive OR of packed single-precision (32-bit) floating-point
 /// elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // i586 only seems to generate plain `xor` instructions, so we ignore it.
 #[cfg_attr(all(test, any(target_arch = "x86_64", target_feature = "sse2")),
@@ -226,7 +226,7 @@ pub unsafe fn _mm_xor_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// Compare the lowest `f32` of both inputs for equality. The lowest 32 bits of
 /// the result will be `0xffffffff` if the two inputs are equal, or `0`
 /// otherwise. The upper 96 bits of the result are the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpeqss))]
 pub unsafe fn _mm_cmpeq_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -237,7 +237,7 @@ pub unsafe fn _mm_cmpeq_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// of the result will be `0xffffffff` if `a.extract(0)` is less than
 /// `b.extract(0)`, or `0` otherwise. The upper 96 bits of the result are the
 /// upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpltss))]
 pub unsafe fn _mm_cmplt_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -248,7 +248,7 @@ pub unsafe fn _mm_cmplt_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// 32 bits of the result will be `0xffffffff` if `a.extract(0)` is less than
 /// or equal `b.extract(0)`, or `0` otherwise. The upper 96 bits of the result
 /// are the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpless))]
 pub unsafe fn _mm_cmple_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -259,7 +259,7 @@ pub unsafe fn _mm_cmple_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// bits of the result will be `0xffffffff` if `a.extract(0)` is greater
 /// than `b.extract(0)`, or `0` otherwise. The upper 96 bits of the result
 /// are the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpltss))]
 pub unsafe fn _mm_cmpgt_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -270,7 +270,7 @@ pub unsafe fn _mm_cmpgt_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// lowest 32 bits of the result will be `0xffffffff` if `a.extract(0)` is
 /// greater than or equal `b.extract(0)`, or `0` otherwise. The upper 96 bits
 /// of the result are the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpless))]
 pub unsafe fn _mm_cmpge_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -281,7 +281,7 @@ pub unsafe fn _mm_cmpge_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// of the result will be `0xffffffff` if `a.extract(0)` is not equal to
 /// `b.extract(0)`, or `0` otherwise. The upper 96 bits of the result are the
 /// upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpneqss))]
 pub unsafe fn _mm_cmpneq_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -292,7 +292,7 @@ pub unsafe fn _mm_cmpneq_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// bits of the result will be `0xffffffff` if `a.extract(0)` is not less than
 /// `b.extract(0)`, or `0` otherwise. The upper 96 bits of the result are the
 /// upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpnltss))]
 pub unsafe fn _mm_cmpnlt_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -303,7 +303,7 @@ pub unsafe fn _mm_cmpnlt_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// lowest 32 bits of the result will be `0xffffffff` if `a.extract(0)` is not
 /// less than or equal to `b.extract(0)`, or `0` otherwise. The upper 96 bits
 /// of the result are the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpnless))]
 pub unsafe fn _mm_cmpnle_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -314,7 +314,7 @@ pub unsafe fn _mm_cmpnle_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// bits of the result will be `0xffffffff` if `a.extract(0)` is not greater
 /// than `b.extract(0)`, or `0` otherwise. The upper 96 bits of the result are
 /// the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpnltss))]
 pub unsafe fn _mm_cmpngt_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -325,7 +325,7 @@ pub unsafe fn _mm_cmpngt_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// lowest 32 bits of the result will be `0xffffffff` if `a.extract(0)` is not
 /// greater than or equal to `b.extract(0)`, or `0` otherwise. The upper 96
 /// bits of the result are the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpnless))]
 pub unsafe fn _mm_cmpnge_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -336,7 +336,7 @@ pub unsafe fn _mm_cmpnge_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// the result will be `0xffffffff` if neither of `a.extract(0)` or
 /// `b.extract(0)` is a NaN, or `0` otherwise. The upper 96 bits of the result
 /// are the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpordss))]
 pub unsafe fn _mm_cmpord_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -347,7 +347,7 @@ pub unsafe fn _mm_cmpord_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// of the result will be `0xffffffff` if any of `a.extract(0)` or
 /// `b.extract(0)` is a NaN, or `0` otherwise. The upper 96 bits of the result
 /// are the upper 96 bits of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpunordss))]
 pub unsafe fn _mm_cmpunord_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -357,7 +357,7 @@ pub unsafe fn _mm_cmpunord_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// Compare each of the four floats in `a` to the corresponding element in `b`.
 /// The result in the output vector will be `0xffffffff` if the input elements
 /// were equal, or `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpeqps))]
 pub unsafe fn _mm_cmpeq_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -367,7 +367,7 @@ pub unsafe fn _mm_cmpeq_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// Compare each of the four floats in `a` to the corresponding element in `b`.
 /// The result in the output vector will be `0xffffffff` if the input element
 /// in `a` is less than the corresponding element in `b`, or `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpltps))]
 pub unsafe fn _mm_cmplt_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -378,7 +378,7 @@ pub unsafe fn _mm_cmplt_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// The result in the output vector will be `0xffffffff` if the input element
 /// in `a` is less than or equal to the corresponding element in `b`, or `0`
 /// otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpleps))]
 pub unsafe fn _mm_cmple_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -388,7 +388,7 @@ pub unsafe fn _mm_cmple_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// Compare each of the four floats in `a` to the corresponding element in `b`.
 /// The result in the output vector will be `0xffffffff` if the input element
 /// in `a` is greater than the corresponding element in `b`, or `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpltps))]
 pub unsafe fn _mm_cmpgt_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -399,7 +399,7 @@ pub unsafe fn _mm_cmpgt_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// The result in the output vector will be `0xffffffff` if the input element
 /// in `a` is greater than or equal to the corresponding element in `b`, or `0`
 /// otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpleps))]
 pub unsafe fn _mm_cmpge_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -409,7 +409,7 @@ pub unsafe fn _mm_cmpge_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// Compare each of the four floats in `a` to the corresponding element in `b`.
 /// The result in the output vector will be `0xffffffff` if the input elements
 /// are *not* equal, or `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpneqps))]
 pub unsafe fn _mm_cmpneq_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -420,7 +420,7 @@ pub unsafe fn _mm_cmpneq_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// The result in the output vector will be `0xffffffff` if the input element
 /// in `a` is *not* less than the corresponding element in `b`, or `0`
 /// otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpnltps))]
 pub unsafe fn _mm_cmpnlt_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -431,7 +431,7 @@ pub unsafe fn _mm_cmpnlt_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// The result in the output vector will be `0xffffffff` if the input element
 /// in `a` is *not* less than or equal to the corresponding element in `b`, or
 /// `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpnleps))]
 pub unsafe fn _mm_cmpnle_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -442,7 +442,7 @@ pub unsafe fn _mm_cmpnle_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// The result in the output vector will be `0xffffffff` if the input element
 /// in `a` is *not* greater than the corresponding element in `b`, or `0`
 /// otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpnltps))]
 pub unsafe fn _mm_cmpngt_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -453,7 +453,7 @@ pub unsafe fn _mm_cmpngt_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// The result in the output vector will be `0xffffffff` if the input element
 /// in `a` is *not* greater than or equal to the corresponding element in `b`,
 /// or `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpnleps))]
 pub unsafe fn _mm_cmpnge_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -464,7 +464,7 @@ pub unsafe fn _mm_cmpnge_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// Returns four floats that have one of two possible bit patterns. The element
 /// in the output vector will be `0xffffffff` if the input elements in `a` and
 /// `b` are ordered (i.e., neither of them is a NaN), or 0 otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpordps))]
 pub unsafe fn _mm_cmpord_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -475,7 +475,7 @@ pub unsafe fn _mm_cmpord_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// Returns four floats that have one of two possible bit patterns. The element
 /// in the output vector will be `0xffffffff` if the input elements in `a` and
 /// `b` are unordered (i.e., at least on of them is a NaN), or 0 otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cmpunordps))]
 pub unsafe fn _mm_cmpunord_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -484,7 +484,7 @@ pub unsafe fn _mm_cmpunord_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Compare two 32-bit floats from the low-order bits of `a` and `b`. Returns
 /// `1` if they are equal, or `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(comiss))]
 pub unsafe fn _mm_comieq_ss(a: f32x4, b: f32x4) -> i32 {
@@ -493,7 +493,7 @@ pub unsafe fn _mm_comieq_ss(a: f32x4, b: f32x4) -> i32 {
 
 /// Compare two 32-bit floats from the low-order bits of `a` and `b`. Returns
 /// `1` if the value from `a` is less than the one from `b`, or `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(comiss))]
 pub unsafe fn _mm_comilt_ss(a: f32x4, b: f32x4) -> i32 {
@@ -503,7 +503,7 @@ pub unsafe fn _mm_comilt_ss(a: f32x4, b: f32x4) -> i32 {
 /// Compare two 32-bit floats from the low-order bits of `a` and `b`. Returns
 /// `1` if the value from `a` is less than or equal to the one from `b`, or `0`
 /// otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(comiss))]
 pub unsafe fn _mm_comile_ss(a: f32x4, b: f32x4) -> i32 {
@@ -513,7 +513,7 @@ pub unsafe fn _mm_comile_ss(a: f32x4, b: f32x4) -> i32 {
 /// Compare two 32-bit floats from the low-order bits of `a` and `b`. Returns
 /// `1` if the value from `a` is greater than the one from `b`, or `0`
 /// otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(comiss))]
 pub unsafe fn _mm_comigt_ss(a: f32x4, b: f32x4) -> i32 {
@@ -523,7 +523,7 @@ pub unsafe fn _mm_comigt_ss(a: f32x4, b: f32x4) -> i32 {
 /// Compare two 32-bit floats from the low-order bits of `a` and `b`. Returns
 /// `1` if the value from `a` is greater than or equal to the one from `b`, or
 /// `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(comiss))]
 pub unsafe fn _mm_comige_ss(a: f32x4, b: f32x4) -> i32 {
@@ -532,7 +532,7 @@ pub unsafe fn _mm_comige_ss(a: f32x4, b: f32x4) -> i32 {
 
 /// Compare two 32-bit floats from the low-order bits of `a` and `b`. Returns
 /// `1` if they are *not* equal, or `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(comiss))]
 pub unsafe fn _mm_comineq_ss(a: f32x4, b: f32x4) -> i32 {
@@ -542,7 +542,7 @@ pub unsafe fn _mm_comineq_ss(a: f32x4, b: f32x4) -> i32 {
 /// Compare two 32-bit floats from the low-order bits of `a` and `b`. Returns
 /// `1` if they are equal, or `0` otherwise. This instruction will not signal
 /// an exception if either argument is a quiet NaN.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(ucomiss))]
 pub unsafe fn _mm_ucomieq_ss(a: f32x4, b: f32x4) -> i32 {
@@ -553,7 +553,7 @@ pub unsafe fn _mm_ucomieq_ss(a: f32x4, b: f32x4) -> i32 {
 /// `1` if the value from `a` is less than the one from `b`, or `0` otherwise.
 /// This instruction will not signal an exception if either argument is a quiet
 /// NaN.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(ucomiss))]
 pub unsafe fn _mm_ucomilt_ss(a: f32x4, b: f32x4) -> i32 {
@@ -564,7 +564,7 @@ pub unsafe fn _mm_ucomilt_ss(a: f32x4, b: f32x4) -> i32 {
 /// `1` if the value from `a` is less than or equal to the one from `b`, or `0`
 /// otherwise. This instruction will not signal an exception if either argument
 /// is a quiet NaN.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(ucomiss))]
 pub unsafe fn _mm_ucomile_ss(a: f32x4, b: f32x4) -> i32 {
@@ -575,7 +575,7 @@ pub unsafe fn _mm_ucomile_ss(a: f32x4, b: f32x4) -> i32 {
 /// `1` if the value from `a` is greater than the one from `b`, or `0`
 /// otherwise. This instruction will not signal an exception if either argument
 /// is a quiet NaN.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(ucomiss))]
 pub unsafe fn _mm_ucomigt_ss(a: f32x4, b: f32x4) -> i32 {
@@ -586,7 +586,7 @@ pub unsafe fn _mm_ucomigt_ss(a: f32x4, b: f32x4) -> i32 {
 /// `1` if the value from `a` is greater than or equal to the one from `b`, or
 /// `0` otherwise. This instruction will not signal an exception if either
 /// argument is a quiet NaN.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(ucomiss))]
 pub unsafe fn _mm_ucomige_ss(a: f32x4, b: f32x4) -> i32 {
@@ -596,7 +596,7 @@ pub unsafe fn _mm_ucomige_ss(a: f32x4, b: f32x4) -> i32 {
 /// Compare two 32-bit floats from the low-order bits of `a` and `b`. Returns
 /// `1` if they are *not* equal, or `0` otherwise. This instruction will not
 /// signal an exception if either argument is a quiet NaN.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(ucomiss))]
 pub unsafe fn _mm_ucomineq_ss(a: f32x4, b: f32x4) -> i32 {
@@ -611,7 +611,7 @@ pub unsafe fn _mm_ucomineq_ss(a: f32x4, b: f32x4) -> i32 {
 /// unmasked (see [`_mm_setcsr`](fn._mm_setcsr.html)).
 ///
 /// This corresponds to the `CVTSS2SI` instruction (with 32 bit output).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtss2si))]
 pub unsafe fn _mm_cvtss_si32(a: f32x4) -> i32 {
@@ -619,7 +619,7 @@ pub unsafe fn _mm_cvtss_si32(a: f32x4) -> i32 {
 }
 
 /// Alias for [`_mm_cvtss_si32`](fn._mm_cvtss_si32.html).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtss2si))]
 pub unsafe fn _mm_cvt_ss2si(a: f32x4) -> i32 {
@@ -636,7 +636,7 @@ pub unsafe fn _mm_cvt_ss2si(a: f32x4) -> i32 {
 /// exception if unmasked (see [`_mm_setcsr`](fn._mm_setcsr.html)).
 ///
 /// This corresponds to the `CVTTSS2SI` instruction (with 32 bit output).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvttss2si))]
 pub unsafe fn _mm_cvttss_si32(a: f32x4) -> i32 {
@@ -644,7 +644,7 @@ pub unsafe fn _mm_cvttss_si32(a: f32x4) -> i32 {
 }
 
 /// Alias for [`_mm_cvttss_si32`](fn._mm_cvttss_si32.html).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvttss2si))]
 pub unsafe fn _mm_cvtt_ss2si(a: f32x4) -> i32 {
@@ -652,7 +652,7 @@ pub unsafe fn _mm_cvtt_ss2si(a: f32x4) -> i32 {
 }
 
 /// Extract the lowest 32 bit float from the input vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // No point in using assert_instrs. In Unix x86_64 calling convention this is a
 // no-op, and on Windows it's just a `mov`.
@@ -665,7 +665,7 @@ pub unsafe fn _mm_cvtss_f32(a: f32x4) -> f32 {
 ///
 /// This intrinsic corresponds to the `CVTSI2SS` instruction (with 32 bit
 /// input).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtsi2ss))]
 pub unsafe fn _mm_cvtsi32_ss(a: f32x4, b: i32) -> f32x4 {
@@ -673,7 +673,7 @@ pub unsafe fn _mm_cvtsi32_ss(a: f32x4, b: i32) -> f32x4 {
 }
 
 /// Alias for [`_mm_cvtsi32_ss`](fn._mm_cvtsi32_ss.html).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtsi2ss))]
 pub unsafe fn _mm_cvt_si2ss(a: f32x4, b: i32) -> f32x4 {
@@ -682,7 +682,7 @@ pub unsafe fn _mm_cvt_si2ss(a: f32x4, b: i32) -> f32x4 {
 
 /// Construct a `f32x4` with the lowest element set to `a` and the rest set to
 /// zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movss))]
 pub unsafe fn _mm_set_ss(a: f32) -> f32x4 {
@@ -690,7 +690,7 @@ pub unsafe fn _mm_set_ss(a: f32) -> f32x4 {
 }
 
 /// Construct a `f32x4` with all element set to `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(shufps))]
 pub unsafe fn _mm_set1_ps(a: f32) -> f32x4 {
@@ -698,7 +698,7 @@ pub unsafe fn _mm_set1_ps(a: f32) -> f32x4 {
 }
 
 /// Alias for [`_mm_set1_ps`](fn._mm_set1_ps.html)
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(shufps))]
 pub unsafe fn _mm_set_ps1(a: f32) -> f32x4 {
@@ -722,7 +722,7 @@ pub unsafe fn _mm_set_ps1(a: f32) -> f32x4 {
 /// ```text
 /// assert_eq!(f32x4::new(a, b, c, d), _mm_set_ps(d, c, b, a));
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(unpcklps))]
 pub unsafe fn _mm_set_ps(a: f32, b: f32, c: f32, d: f32) -> f32x4 {
@@ -737,7 +737,7 @@ pub unsafe fn _mm_set_ps(a: f32, b: f32, c: f32, d: f32) -> f32x4 {
 /// ```text
 /// assert_eq!(f32x4::new(a, b, c, d), _mm_setr_ps(a, b, c, d));
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(all(test, target_arch = "x86_64"), assert_instr(unpcklps))]
 // On a 32-bit architecture it just copies the operands from the stack.
@@ -747,7 +747,7 @@ pub unsafe fn _mm_setr_ps(a: f32, b: f32, c: f32, d: f32) -> f32x4 {
 }
 
 /// Construct a `f32x4` with all elements initialized to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(xorps))]
 pub unsafe fn _mm_setzero_ps() -> f32x4 {
@@ -759,7 +759,7 @@ pub unsafe fn _mm_setzero_ps() -> f32x4 {
 ///
 /// The lower half of result takes values from `a` and the higher half from
 /// `b`. Mask is split to 2 control bits each to index the element from inputs.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(shufps, mask = 3))]
 pub unsafe fn _mm_shuffle_ps(a: f32x4, b: f32x4, mask: u32) -> f32x4 {
@@ -810,7 +810,7 @@ pub unsafe fn _mm_shuffle_ps(a: f32x4, b: f32x4, mask: u32) -> f32x4 {
 
 /// Unpack and interleave single-precision (32-bit) floating-point elements
 /// from the higher half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(unpckhps))]
 pub unsafe fn _mm_unpackhi_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -819,7 +819,7 @@ pub unsafe fn _mm_unpackhi_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Unpack and interleave single-precision (32-bit) floating-point elements
 /// from the lower half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(unpcklps))]
 pub unsafe fn _mm_unpacklo_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -828,7 +828,7 @@ pub unsafe fn _mm_unpacklo_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Combine higher half of `a` and `b`. The highwe half of `b` occupies the
 /// lower half of result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movhlps))]
 #[cfg_attr(all(test, windows), assert_instr(unpckhpd))]
@@ -839,7 +839,7 @@ pub unsafe fn _mm_movehl_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Combine lower half of `a` and `b`. The lower half of `b` occupies the
 /// higher half of result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(all(test, target_feature = "sse2"), assert_instr(unpcklpd))]
 #[cfg_attr(all(test, not(target_feature = "sse2")), assert_instr(movlhps))]
@@ -851,7 +851,7 @@ pub unsafe fn _mm_movelh_ps(a: f32x4, b: f32x4) -> f32x4 {
 ///
 /// The mask is stored in the 4 least significant bits of the return value.
 /// All other bits are set to `0`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movmskps))]
 pub unsafe fn _mm_movemask_ps(a: f32x4) -> i32 {
@@ -891,7 +891,7 @@ pub unsafe fn _mm_movemask_ps(a: f32x4) -> i32 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // TODO: generates MOVHPD if the CPU supports SSE2.
 // #[cfg_attr(test, assert_instr(movhps))]
@@ -943,7 +943,7 @@ pub unsafe fn _mm_loadh_pi(a: f32x4, p: *const __m64) -> f32x4 {
 /// #     }
 /// # }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // TODO: generates MOVLPD if the CPU supports SSE2.
 // #[cfg_attr(test, assert_instr(movlps))]
@@ -966,7 +966,7 @@ pub unsafe fn _mm_loadl_pi(a: f32x4, p: *const __m64) -> f32x4 {
 /// elements set to zero.
 ///
 /// This corresponds to instructions `VMOVSS` / `MOVSS`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movss))]
 pub unsafe fn _mm_load_ss(p: *const f32) -> f32x4 {
@@ -978,7 +978,7 @@ pub unsafe fn _mm_load_ss(p: *const f32) -> f32x4 {
 ///
 /// This corresponds to instructions `VMOVSS` / `MOVSS` followed by some
 /// shuffling.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movss))]
 pub unsafe fn _mm_load1_ps(p: *const f32) -> f32x4 {
@@ -987,7 +987,7 @@ pub unsafe fn _mm_load1_ps(p: *const f32) -> f32x4 {
 }
 
 /// Alias for [`_mm_load1_ps`](fn._mm_load1_ps.html)
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movss))]
 pub unsafe fn _mm_load_ps1(p: *const f32) -> f32x4 {
@@ -1002,7 +1002,7 @@ pub unsafe fn _mm_load_ps1(p: *const f32) -> f32x4 {
 /// memory.
 ///
 /// This corresponds to instructions `VMOVAPS` / `MOVAPS`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_load_ps(p: *const f32) -> f32x4 {
@@ -1016,7 +1016,7 @@ pub unsafe fn _mm_load_ps(p: *const f32) -> f32x4 {
 /// may be faster.
 ///
 /// This corresponds to instructions `VMOVUPS` / `MOVUPS`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movups))]
 pub unsafe fn _mm_loadu_ps(p: *const f32) -> f32x4 {
@@ -1049,7 +1049,7 @@ pub unsafe fn _mm_loadu_ps(p: *const f32) -> f32x4 {
 ///
 /// This corresponds to instructions `VMOVAPS` / `MOVAPS` followed by some
 /// shuffling.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_loadr_ps(p: *const f32) -> f32x4 {
@@ -1061,7 +1061,7 @@ pub unsafe fn _mm_loadr_ps(p: *const f32) -> f32x4 {
 ///
 /// This intrinsic corresponds to the `MOVHPS` instruction. The compiler may
 /// choose to generate an equivalent sequence of other instructions.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // On i686 and up LLVM actually generates MOVHPD instead of MOVHPS, that's
 // fine.
@@ -1091,7 +1091,7 @@ pub unsafe fn _mm_storeh_pi(p: *mut __m64, a: f32x4) {
 ///
 /// This intrinsic corresponds to the `MOVQ` instruction. The compiler may
 /// choose to generate an equivalent sequence of other instructions.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 // On i586 the codegen just generates plane MOVs. No need to test for that.
 #[cfg_attr(all(test, any(target_arch = "x86_64", target_feature = "sse2"),
@@ -1121,7 +1121,7 @@ pub unsafe fn _mm_storel_pi(p: *mut __m64, a: f32x4) {
 /// Store the lowest 32 bit float of `a` into memory.
 ///
 /// This intrinsic corresponds to the `MOVSS` instruction.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movss))]
 pub unsafe fn _mm_store_ss(p: *mut f32, a: f32x4) {
@@ -1144,7 +1144,7 @@ pub unsafe fn _mm_store_ss(p: *mut f32, a: f32x4) {
 /// *p.offset(2) = x;
 /// *p.offset(3) = x;
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_store1_ps(p: *mut f32, a: f32x4) {
@@ -1153,7 +1153,7 @@ pub unsafe fn _mm_store1_ps(p: *mut f32, a: f32x4) {
 }
 
 /// Alias for [`_mm_store1_ps`](fn._mm_store1_ps.html)
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_store_ps1(p: *mut f32, a: f32x4) {
@@ -1169,7 +1169,7 @@ pub unsafe fn _mm_store_ps1(p: *mut f32, a: f32x4) {
 /// memory.
 ///
 /// This corresponds to instructions `VMOVAPS` / `MOVAPS`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_store_ps(p: *mut f32, a: f32x4) {
@@ -1181,7 +1181,7 @@ pub unsafe fn _mm_store_ps(p: *mut f32, a: f32x4) {
 /// faster.
 ///
 /// This corresponds to instructions `VMOVUPS` / `MOVUPS`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movups))]
 pub unsafe fn _mm_storeu_ps(p: *mut f32, a: f32x4) {
@@ -1206,7 +1206,7 @@ pub unsafe fn _mm_storeu_ps(p: *mut f32, a: f32x4) {
 /// *p.offset(2) = a.extract(1);
 /// *p.offset(3) = a.extract(0);
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_storer_ps(p: *mut f32, a: f32x4) {
@@ -1221,7 +1221,7 @@ pub unsafe fn _mm_storer_ps(p: *mut f32, a: f32x4) {
 /// ```text
 /// _mm_move_ss(a, b) == a.replace(0, b.extract(0))
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movss))]
 pub unsafe fn _mm_move_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -1234,7 +1234,7 @@ pub unsafe fn _mm_move_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// Guarantees that every store instruction that precedes, in program order, is
 /// globally visible before any store instruction which follows the fence in
 /// program order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(sfence))]
 pub unsafe fn _mm_sfence() {
@@ -1244,7 +1244,7 @@ pub unsafe fn _mm_sfence() {
 /// Get the unsigned 32-bit value of the MXCSR control and status register.
 ///
 /// For more info see [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(stmxcsr))]
 pub unsafe fn _mm_getcsr() -> u32 {
@@ -1378,7 +1378,7 @@ pub unsafe fn _mm_getcsr() -> u32 {
 /// _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);  // turn on
 /// ```
 ///
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(ldmxcsr))]
 pub unsafe fn _mm_setcsr(val: u32) {
@@ -1435,7 +1435,7 @@ pub const _MM_FLUSH_ZERO_ON: u32 = 0x8000;
 pub const _MM_FLUSH_ZERO_OFF: u32 = 0x0000;
 
 /// See [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_GET_EXCEPTION_MASK() -> u32 {
@@ -1443,7 +1443,7 @@ pub unsafe fn _MM_GET_EXCEPTION_MASK() -> u32 {
 }
 
 /// See [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_GET_EXCEPTION_STATE() -> u32 {
@@ -1451,7 +1451,7 @@ pub unsafe fn _MM_GET_EXCEPTION_STATE() -> u32 {
 }
 
 /// See [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_GET_FLUSH_ZERO_MODE() -> u32 {
@@ -1459,7 +1459,7 @@ pub unsafe fn _MM_GET_FLUSH_ZERO_MODE() -> u32 {
 }
 
 /// See [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_GET_ROUNDING_MODE() -> u32 {
@@ -1467,7 +1467,7 @@ pub unsafe fn _MM_GET_ROUNDING_MODE() -> u32 {
 }
 
 /// See [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_SET_EXCEPTION_MASK(x: u32) {
@@ -1475,7 +1475,7 @@ pub unsafe fn _MM_SET_EXCEPTION_MASK(x: u32) {
 }
 
 /// See [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_SET_EXCEPTION_STATE(x: u32) {
@@ -1483,7 +1483,7 @@ pub unsafe fn _MM_SET_EXCEPTION_STATE(x: u32) {
 }
 
 /// See [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_SET_FLUSH_ZERO_MODE(x: u32) {
@@ -1493,7 +1493,7 @@ pub unsafe fn _MM_SET_FLUSH_ZERO_MODE(x: u32) {
 }
 
 /// See [`_mm_setcsr`](fn._mm_setcsr.html)
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_SET_ROUNDING_MODE(x: u32) {
@@ -1548,7 +1548,7 @@ pub const _MM_HINT_NTA: i8 = 0;
 /// * Prefetching may also fail if there are not enough memory-subsystem
 ///   resources (e.g., request buffers).
 ///
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(prefetcht0, strategy = _MM_HINT_T0))]
 #[cfg_attr(test, assert_instr(prefetcht1, strategy = _MM_HINT_T1))]
@@ -1573,14 +1573,14 @@ pub unsafe fn _mm_prefetch(p: *const u8, strategy: i8) {
 }
 
 /// Return vector of type __m128 with undefined elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 pub unsafe fn _mm_undefined_ps() -> f32x4 {
     f32x4::splat(mem::uninitialized())
 }
 
 /// Transpose the 4x4 matrix formed by 4 rows of f32x4 in place.
-#[inline(always)]
+#[inline]
 #[allow(non_snake_case)]
 #[target_feature(enable = "sse")]
 pub unsafe fn _MM_TRANSPOSE4_PS(
@@ -1679,7 +1679,7 @@ extern "C" {
 ///
 /// `mem_addr` must be aligned on a 16-byte boundary or a general-protection
 /// exception _may_ be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(movntps))]
 pub unsafe fn _mm_stream_ps(mem_addr: *mut f32, a: f32x4) {
@@ -1688,7 +1688,7 @@ pub unsafe fn _mm_stream_ps(mem_addr: *mut f32, a: f32x4) {
 
 /// Store 64-bits of integer data from a into memory using a non-temporal
 /// memory hint.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse,mmx")]
 #[cfg_attr(test, assert_instr(movntq))]
 pub unsafe fn _mm_stream_pi(mem_addr: *mut __m64, a: __m64) {

--- a/coresimd/src/x86/i586/sse2.rs
+++ b/coresimd/src/x86/i586/sse2.rs
@@ -15,7 +15,7 @@ use v64::*;
 ///
 /// This can help improve the performance and power consumption of spin-wait
 /// loops.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pause))]
 pub unsafe fn _mm_pause() {
@@ -24,7 +24,7 @@ pub unsafe fn _mm_pause() {
 
 /// Invalidate and flush the cache line that contains `p` from all levels of
 /// the cache hierarchy.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(clflush))]
 pub unsafe fn _mm_clflush(p: *mut u8) {
@@ -37,7 +37,7 @@ pub unsafe fn _mm_clflush(p: *mut u8) {
 /// Guarantees that every load instruction that precedes, in program order, is
 /// globally visible before any load instruction which follows the fence in
 /// program order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(lfence))]
 pub unsafe fn _mm_lfence() {
@@ -50,7 +50,7 @@ pub unsafe fn _mm_lfence() {
 /// Guarantees that every memory access that precedes, in program order, the
 /// memory fence instruction is globally visible before any memory instruction
 /// which follows the fence in program order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(mfence))]
 pub unsafe fn _mm_mfence() {
@@ -58,7 +58,7 @@ pub unsafe fn _mm_mfence() {
 }
 
 /// Add packed 8-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddb))]
 pub unsafe fn _mm_add_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -66,7 +66,7 @@ pub unsafe fn _mm_add_epi8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Add packed 16-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddw))]
 pub unsafe fn _mm_add_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -74,7 +74,7 @@ pub unsafe fn _mm_add_epi16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Add packed 32-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddd))]
 pub unsafe fn _mm_add_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -82,7 +82,7 @@ pub unsafe fn _mm_add_epi32(a: i32x4, b: i32x4) -> i32x4 {
 }
 
 /// Add packed 64-bit integers in `a` and "b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddq))]
 pub unsafe fn _mm_add_epi64(a: i64x2, b: i64x2) -> i64x2 {
@@ -90,7 +90,7 @@ pub unsafe fn _mm_add_epi64(a: i64x2, b: i64x2) -> i64x2 {
 }
 
 /// Add packed 8-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddsb))]
 pub unsafe fn _mm_adds_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -98,7 +98,7 @@ pub unsafe fn _mm_adds_epi8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Add packed 16-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddsw))]
 pub unsafe fn _mm_adds_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -106,7 +106,7 @@ pub unsafe fn _mm_adds_epi16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Add packed unsigned 8-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddusb))]
 pub unsafe fn _mm_adds_epu8(a: u8x16, b: u8x16) -> u8x16 {
@@ -114,7 +114,7 @@ pub unsafe fn _mm_adds_epu8(a: u8x16, b: u8x16) -> u8x16 {
 }
 
 /// Add packed unsigned 16-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddusw))]
 pub unsafe fn _mm_adds_epu16(a: u16x8, b: u16x8) -> u16x8 {
@@ -122,7 +122,7 @@ pub unsafe fn _mm_adds_epu16(a: u16x8, b: u16x8) -> u16x8 {
 }
 
 /// Average packed unsigned 8-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pavgb))]
 pub unsafe fn _mm_avg_epu8(a: u8x16, b: u8x16) -> u8x16 {
@@ -130,7 +130,7 @@ pub unsafe fn _mm_avg_epu8(a: u8x16, b: u8x16) -> u8x16 {
 }
 
 /// Average packed unsigned 16-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pavgw))]
 pub unsafe fn _mm_avg_epu16(a: u16x8, b: u16x8) -> u16x8 {
@@ -142,7 +142,7 @@ pub unsafe fn _mm_avg_epu16(a: u16x8, b: u16x8) -> u16x8 {
 /// Multiply packed signed 16-bit integers in `a` and `b`, producing
 /// intermediate signed 32-bit integers. Horizontally add adjacent pairs of
 /// intermediate 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmaddwd))]
 pub unsafe fn _mm_madd_epi16(a: i16x8, b: i16x8) -> i32x4 {
@@ -151,7 +151,7 @@ pub unsafe fn _mm_madd_epi16(a: i16x8, b: i16x8) -> i32x4 {
 
 /// Compare packed 16-bit integers in `a` and `b`, and return the packed
 /// maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmaxsw))]
 pub unsafe fn _mm_max_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -160,7 +160,7 @@ pub unsafe fn _mm_max_epi16(a: i16x8, b: i16x8) -> i16x8 {
 
 /// Compare packed unsigned 8-bit integers in `a` and `b`, and return the
 /// packed maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmaxub))]
 pub unsafe fn _mm_max_epu8(a: u8x16, b: u8x16) -> u8x16 {
@@ -169,7 +169,7 @@ pub unsafe fn _mm_max_epu8(a: u8x16, b: u8x16) -> u8x16 {
 
 /// Compare packed 16-bit integers in `a` and `b`, and return the packed
 /// minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pminsw))]
 pub unsafe fn _mm_min_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -178,7 +178,7 @@ pub unsafe fn _mm_min_epi16(a: i16x8, b: i16x8) -> i16x8 {
 
 /// Compare packed unsigned 8-bit integers in `a` and `b`, and return the
 /// packed minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pminub))]
 pub unsafe fn _mm_min_epu8(a: u8x16, b: u8x16) -> u8x16 {
@@ -189,7 +189,7 @@ pub unsafe fn _mm_min_epu8(a: u8x16, b: u8x16) -> u8x16 {
 ///
 /// The multiplication produces intermediate 32-bit integers, and returns the
 /// high 16 bits of the intermediate integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmulhw))]
 pub unsafe fn _mm_mulhi_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -200,7 +200,7 @@ pub unsafe fn _mm_mulhi_epi16(a: i16x8, b: i16x8) -> i16x8 {
 ///
 /// The multiplication produces intermediate 32-bit integers, and returns the
 /// high 16 bits of the intermediate integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmulhuw))]
 pub unsafe fn _mm_mulhi_epu16(a: u16x8, b: u16x8) -> u16x8 {
@@ -211,7 +211,7 @@ pub unsafe fn _mm_mulhi_epu16(a: u16x8, b: u16x8) -> u16x8 {
 ///
 /// The multiplication produces intermediate 32-bit integers, and returns the
 /// low 16 bits of the intermediate integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmullw))]
 pub unsafe fn _mm_mullo_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -222,7 +222,7 @@ pub unsafe fn _mm_mullo_epi16(a: i16x8, b: i16x8) -> i16x8 {
 /// in `a` and `b`.
 ///
 /// Return the unsigned 64-bit results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmuludq))]
 pub unsafe fn _mm_mul_epu32(a: u32x4, b: u32x4) -> u64x2 {
@@ -235,7 +235,7 @@ pub unsafe fn _mm_mul_epu32(a: u32x4, b: u32x4) -> u64x2 {
 /// and `b`, then horizontally sum each consecutive 8 differences to produce
 /// two unsigned 16-bit integers, and pack these unsigned 16-bit integers in
 /// the low 16 bits of 64-bit elements returned.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psadbw))]
 pub unsafe fn _mm_sad_epu8(a: u8x16, b: u8x16) -> u64x2 {
@@ -243,7 +243,7 @@ pub unsafe fn _mm_sad_epu8(a: u8x16, b: u8x16) -> u64x2 {
 }
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubb))]
 pub unsafe fn _mm_sub_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -251,7 +251,7 @@ pub unsafe fn _mm_sub_epi8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubw))]
 pub unsafe fn _mm_sub_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -259,7 +259,7 @@ pub unsafe fn _mm_sub_epi16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Subtract packed 32-bit integers in `b` from packed 32-bit integers in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubd))]
 pub unsafe fn _mm_sub_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -267,7 +267,7 @@ pub unsafe fn _mm_sub_epi32(a: i32x4, b: i32x4) -> i32x4 {
 }
 
 /// Subtract packed 64-bit integers in `b` from packed 64-bit integers in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubq))]
 pub unsafe fn _mm_sub_epi64(a: i64x2, b: i64x2) -> i64x2 {
@@ -276,7 +276,7 @@ pub unsafe fn _mm_sub_epi64(a: i64x2, b: i64x2) -> i64x2 {
 
 /// Subtract packed 8-bit integers in `b` from packed 8-bit integers in `a`
 /// using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubsb))]
 pub unsafe fn _mm_subs_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -285,7 +285,7 @@ pub unsafe fn _mm_subs_epi8(a: i8x16, b: i8x16) -> i8x16 {
 
 /// Subtract packed 16-bit integers in `b` from packed 16-bit integers in `a`
 /// using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubsw))]
 pub unsafe fn _mm_subs_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -294,7 +294,7 @@ pub unsafe fn _mm_subs_epi16(a: i16x8, b: i16x8) -> i16x8 {
 
 /// Subtract packed unsigned 8-bit integers in `b` from packed unsigned 8-bit
 /// integers in `a` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubusb))]
 pub unsafe fn _mm_subs_epu8(a: u8x16, b: u8x16) -> u8x16 {
@@ -303,7 +303,7 @@ pub unsafe fn _mm_subs_epu8(a: u8x16, b: u8x16) -> u8x16 {
 
 /// Subtract packed unsigned 16-bit integers in `b` from packed unsigned 16-bit
 /// integers in `a` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubusw))]
 pub unsafe fn _mm_subs_epu16(a: u16x8, b: u16x8) -> u16x8 {
@@ -311,7 +311,7 @@ pub unsafe fn _mm_subs_epu16(a: u16x8, b: u16x8) -> u16x8 {
 }
 
 /// Shift `a` left by `imm8` bytes while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pslldq, imm8 = 1))]
 pub unsafe fn _mm_slli_si128(a: i8x16, imm8: i32) -> i8x16 {
@@ -352,7 +352,7 @@ pub unsafe fn _mm_slli_si128(a: i8x16, imm8: i32) -> i8x16 {
 }
 
 /// Shift `a` left by `imm8` bytes while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pslldq, imm8 = 1))]
 pub unsafe fn _mm_bslli_si128(a: i8x16, imm8: i32) -> i8x16 {
@@ -360,7 +360,7 @@ pub unsafe fn _mm_bslli_si128(a: i8x16, imm8: i32) -> i8x16 {
 }
 
 /// Shift `a` right by `imm8` bytes while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrldq, imm8 = 1))]
 pub unsafe fn _mm_bsrli_si128(a: i8x16, imm8: i32) -> i8x16 {
@@ -368,7 +368,7 @@ pub unsafe fn _mm_bsrli_si128(a: i8x16, imm8: i32) -> i8x16 {
 }
 
 /// Shift packed 16-bit integers in `a` left by `imm8` while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psllw))]
 pub unsafe fn _mm_slli_epi16(a: i16x8, imm8: i32) -> i16x8 {
@@ -377,7 +377,7 @@ pub unsafe fn _mm_slli_epi16(a: i16x8, imm8: i32) -> i16x8 {
 
 /// Shift packed 16-bit integers in `a` left by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psllw))]
 pub unsafe fn _mm_sll_epi16(a: i16x8, count: i16x8) -> i16x8 {
@@ -385,7 +385,7 @@ pub unsafe fn _mm_sll_epi16(a: i16x8, count: i16x8) -> i16x8 {
 }
 
 /// Shift packed 32-bit integers in `a` left by `imm8` while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pslld))]
 pub unsafe fn _mm_slli_epi32(a: i32x4, imm8: i32) -> i32x4 {
@@ -394,7 +394,7 @@ pub unsafe fn _mm_slli_epi32(a: i32x4, imm8: i32) -> i32x4 {
 
 /// Shift packed 32-bit integers in `a` left by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pslld))]
 pub unsafe fn _mm_sll_epi32(a: i32x4, count: i32x4) -> i32x4 {
@@ -402,7 +402,7 @@ pub unsafe fn _mm_sll_epi32(a: i32x4, count: i32x4) -> i32x4 {
 }
 
 /// Shift packed 64-bit integers in `a` left by `imm8` while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psllq))]
 pub unsafe fn _mm_slli_epi64(a: i64x2, imm8: i32) -> i64x2 {
@@ -411,7 +411,7 @@ pub unsafe fn _mm_slli_epi64(a: i64x2, imm8: i32) -> i64x2 {
 
 /// Shift packed 64-bit integers in `a` left by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psllq))]
 pub unsafe fn _mm_sll_epi64(a: i64x2, count: i64x2) -> i64x2 {
@@ -420,7 +420,7 @@ pub unsafe fn _mm_sll_epi64(a: i64x2, count: i64x2) -> i64x2 {
 
 /// Shift packed 16-bit integers in `a` right by `imm8` while shifting in sign
 /// bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psraw))]
 pub unsafe fn _mm_srai_epi16(a: i16x8, imm8: i32) -> i16x8 {
@@ -429,7 +429,7 @@ pub unsafe fn _mm_srai_epi16(a: i16x8, imm8: i32) -> i16x8 {
 
 /// Shift packed 16-bit integers in `a` right by `count` while shifting in sign
 /// bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psraw))]
 pub unsafe fn _mm_sra_epi16(a: i16x8, count: i16x8) -> i16x8 {
@@ -438,7 +438,7 @@ pub unsafe fn _mm_sra_epi16(a: i16x8, count: i16x8) -> i16x8 {
 
 /// Shift packed 32-bit integers in `a` right by `imm8` while shifting in sign
 /// bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrad))]
 pub unsafe fn _mm_srai_epi32(a: i32x4, imm8: i32) -> i32x4 {
@@ -447,7 +447,7 @@ pub unsafe fn _mm_srai_epi32(a: i32x4, imm8: i32) -> i32x4 {
 
 /// Shift packed 32-bit integers in `a` right by `count` while shifting in sign
 /// bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrad))]
 pub unsafe fn _mm_sra_epi32(a: i32x4, count: i32x4) -> i32x4 {
@@ -455,7 +455,7 @@ pub unsafe fn _mm_sra_epi32(a: i32x4, count: i32x4) -> i32x4 {
 }
 
 /// Shift `a` right by `imm8` bytes while shifting in zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrldq, imm8 = 1))]
 pub unsafe fn _mm_srli_si128(a: i8x16, imm8: i32) -> i8x16 {
@@ -497,7 +497,7 @@ pub unsafe fn _mm_srli_si128(a: i8x16, imm8: i32) -> i8x16 {
 
 /// Shift packed 16-bit integers in `a` right by `imm8` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrlw))]
 pub unsafe fn _mm_srli_epi16(a: i16x8, imm8: i32) -> i16x8 {
@@ -506,7 +506,7 @@ pub unsafe fn _mm_srli_epi16(a: i16x8, imm8: i32) -> i16x8 {
 
 /// Shift packed 16-bit integers in `a` right by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrlw))]
 pub unsafe fn _mm_srl_epi16(a: i16x8, count: i16x8) -> i16x8 {
@@ -515,7 +515,7 @@ pub unsafe fn _mm_srl_epi16(a: i16x8, count: i16x8) -> i16x8 {
 
 /// Shift packed 32-bit integers in `a` right by `imm8` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrld))]
 pub unsafe fn _mm_srli_epi32(a: i32x4, imm8: i32) -> i32x4 {
@@ -524,7 +524,7 @@ pub unsafe fn _mm_srli_epi32(a: i32x4, imm8: i32) -> i32x4 {
 
 /// Shift packed 32-bit integers in `a` right by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrld))]
 pub unsafe fn _mm_srl_epi32(a: i32x4, count: i32x4) -> i32x4 {
@@ -533,7 +533,7 @@ pub unsafe fn _mm_srl_epi32(a: i32x4, count: i32x4) -> i32x4 {
 
 /// Shift packed 64-bit integers in `a` right by `imm8` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrlq))]
 pub unsafe fn _mm_srli_epi64(a: i64x2, imm8: i32) -> i64x2 {
@@ -542,7 +542,7 @@ pub unsafe fn _mm_srli_epi64(a: i64x2, imm8: i32) -> i64x2 {
 
 /// Shift packed 64-bit integers in `a` right by `count` while shifting in
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psrlq))]
 pub unsafe fn _mm_srl_epi64(a: i64x2, count: i64x2) -> i64x2 {
@@ -551,7 +551,7 @@ pub unsafe fn _mm_srl_epi64(a: i64x2, count: i64x2) -> i64x2 {
 
 /// Compute the bitwise AND of 128 bits (representing integer data) in `a` and
 /// `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(andps))]
 pub unsafe fn _mm_and_si128(a: __m128i, b: __m128i) -> __m128i {
@@ -560,7 +560,7 @@ pub unsafe fn _mm_and_si128(a: __m128i, b: __m128i) -> __m128i {
 
 /// Compute the bitwise NOT of 128 bits (representing integer data) in `a` and
 /// then AND with `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(andnps))]
 pub unsafe fn _mm_andnot_si128(a: __m128i, b: __m128i) -> __m128i {
@@ -569,7 +569,7 @@ pub unsafe fn _mm_andnot_si128(a: __m128i, b: __m128i) -> __m128i {
 
 /// Compute the bitwise OR of 128 bits (representing integer data) in `a` and
 /// `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(orps))]
 pub unsafe fn _mm_or_si128(a: __m128i, b: __m128i) -> __m128i {
@@ -578,7 +578,7 @@ pub unsafe fn _mm_or_si128(a: __m128i, b: __m128i) -> __m128i {
 
 /// Compute the bitwise XOR of 128 bits (representing integer data) in `a` and
 /// `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(xorps))]
 pub unsafe fn _mm_xor_si128(a: __m128i, b: __m128i) -> __m128i {
@@ -586,7 +586,7 @@ pub unsafe fn _mm_xor_si128(a: __m128i, b: __m128i) -> __m128i {
 }
 
 /// Compare packed 8-bit integers in `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpeqb))]
 pub unsafe fn _mm_cmpeq_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -594,7 +594,7 @@ pub unsafe fn _mm_cmpeq_epi8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Compare packed 16-bit integers in `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpeqw))]
 pub unsafe fn _mm_cmpeq_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -602,7 +602,7 @@ pub unsafe fn _mm_cmpeq_epi16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Compare packed 32-bit integers in `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpeqd))]
 pub unsafe fn _mm_cmpeq_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -610,7 +610,7 @@ pub unsafe fn _mm_cmpeq_epi32(a: i32x4, b: i32x4) -> i32x4 {
 }
 
 /// Compare packed 8-bit integers in `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpgtb))]
 pub unsafe fn _mm_cmpgt_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -618,7 +618,7 @@ pub unsafe fn _mm_cmpgt_epi8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Compare packed 16-bit integers in `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpgtw))]
 pub unsafe fn _mm_cmpgt_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -626,7 +626,7 @@ pub unsafe fn _mm_cmpgt_epi16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Compare packed 32-bit integers in `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpgtd))]
 pub unsafe fn _mm_cmpgt_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -634,7 +634,7 @@ pub unsafe fn _mm_cmpgt_epi32(a: i32x4, b: i32x4) -> i32x4 {
 }
 
 /// Compare packed 8-bit integers in `a` and `b` for less-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpgtb))]
 pub unsafe fn _mm_cmplt_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -642,7 +642,7 @@ pub unsafe fn _mm_cmplt_epi8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Compare packed 16-bit integers in `a` and `b` for less-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpgtw))]
 pub unsafe fn _mm_cmplt_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -650,7 +650,7 @@ pub unsafe fn _mm_cmplt_epi16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Compare packed 32-bit integers in `a` and `b` for less-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pcmpgtd))]
 pub unsafe fn _mm_cmplt_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -659,7 +659,7 @@ pub unsafe fn _mm_cmplt_epi32(a: i32x4, b: i32x4) -> i32x4 {
 
 /// Convert the lower two packed 32-bit integers in `a` to packed
 /// double-precision (64-bit) floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtdq2pd))]
 pub unsafe fn _mm_cvtepi32_pd(a: i32x4) -> f64x2 {
@@ -668,7 +668,7 @@ pub unsafe fn _mm_cvtepi32_pd(a: i32x4) -> f64x2 {
 
 /// Return `a` with its lower element replaced by `b` after converting it to
 /// an `f64`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtsi2sd))]
 pub unsafe fn _mm_cvtsi32_sd(a: f64x2, b: i32) -> f64x2 {
@@ -677,7 +677,7 @@ pub unsafe fn _mm_cvtsi32_sd(a: f64x2, b: i32) -> f64x2 {
 
 /// Convert packed 32-bit integers in `a` to packed single-precision (32-bit)
 /// floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtdq2ps))]
 pub unsafe fn _mm_cvtepi32_ps(a: i32x4) -> f32x4 {
@@ -686,7 +686,7 @@ pub unsafe fn _mm_cvtepi32_ps(a: i32x4) -> f32x4 {
 
 /// Convert packed single-precision (32-bit) floating-point elements in `a`
 /// to packed 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtps2dq))]
 pub unsafe fn _mm_cvtps_epi32(a: f32x4) -> i32x4 {
@@ -695,7 +695,7 @@ pub unsafe fn _mm_cvtps_epi32(a: f32x4) -> i32x4 {
 
 /// Return a vector whose lowest element is `a` and all higher elements are
 /// `0`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, target_arch = "x86_64"), assert_instr(movd))]
 pub unsafe fn _mm_cvtsi32_si128(a: i32) -> i32x4 {
@@ -703,7 +703,7 @@ pub unsafe fn _mm_cvtsi32_si128(a: i32) -> i32x4 {
 }
 
 /// Return the lowest element of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movd))] // FIXME mov on windows
 pub unsafe fn _mm_cvtsi128_si32(a: i32x4) -> i32 {
@@ -712,7 +712,7 @@ pub unsafe fn _mm_cvtsi128_si32(a: i32x4) -> i32 {
 
 /// Set packed 64-bit integers with the supplied values, from highest to
 /// lowest.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set_epi64x(e1: i64, e0: i64) -> i64x2 {
@@ -720,7 +720,7 @@ pub unsafe fn _mm_set_epi64x(e1: i64, e0: i64) -> i64x2 {
 }
 
 /// Set packed 32-bit integers with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set_epi32(e3: i32, e2: i32, e1: i32, e0: i32) -> i32x4 {
@@ -728,7 +728,7 @@ pub unsafe fn _mm_set_epi32(e3: i32, e2: i32, e1: i32, e0: i32) -> i32x4 {
 }
 
 /// Set packed 16-bit integers with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set_epi16(
@@ -738,7 +738,7 @@ pub unsafe fn _mm_set_epi16(
 }
 
 /// Set packed 8-bit integers with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set_epi8(
@@ -752,7 +752,7 @@ pub unsafe fn _mm_set_epi8(
 }
 
 /// Broadcast 64-bit integer `a` to all elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set1_epi64x(a: i64) -> i64x2 {
@@ -760,7 +760,7 @@ pub unsafe fn _mm_set1_epi64x(a: i64) -> i64x2 {
 }
 
 /// Broadcast 32-bit integer `a` to all elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set1_epi32(a: i32) -> i32x4 {
@@ -768,7 +768,7 @@ pub unsafe fn _mm_set1_epi32(a: i32) -> i32x4 {
 }
 
 /// Broadcast 16-bit integer `a` to all elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set1_epi16(a: i16) -> i16x8 {
@@ -776,7 +776,7 @@ pub unsafe fn _mm_set1_epi16(a: i16) -> i16x8 {
 }
 
 /// Broadcast 8-bit integer `a` to all elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set1_epi8(a: i8) -> i8x16 {
@@ -784,7 +784,7 @@ pub unsafe fn _mm_set1_epi8(a: i8) -> i8x16 {
 }
 
 /// Set packed 32-bit integers with the supplied values in reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_setr_epi32(e3: i32, e2: i32, e1: i32, e0: i32) -> i32x4 {
@@ -792,7 +792,7 @@ pub unsafe fn _mm_setr_epi32(e3: i32, e2: i32, e1: i32, e0: i32) -> i32x4 {
 }
 
 /// Set packed 16-bit integers with the supplied values in reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_setr_epi16(
@@ -802,7 +802,7 @@ pub unsafe fn _mm_setr_epi16(
 }
 
 /// Set packed 8-bit integers with the supplied values in reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_setr_epi8(
@@ -816,7 +816,7 @@ pub unsafe fn _mm_setr_epi8(
 }
 
 /// Returns a vector with all elements set to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(xorps))]
 pub unsafe fn _mm_setzero_si128() -> __m128i {
@@ -824,7 +824,7 @@ pub unsafe fn _mm_setzero_si128() -> __m128i {
 }
 
 /// Load 64-bit integer from memory into first element of returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // FIXME movsd on windows
 #[cfg_attr(all(test, not(windows),
@@ -838,7 +838,7 @@ pub unsafe fn _mm_loadl_epi64(mem_addr: *const i64x2) -> i64x2 {
 /// Load 128-bits of integer data from memory into a new vector.
 ///
 /// `mem_addr` must be aligned on a 16-byte boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_load_si128(mem_addr: *const __m128i) -> __m128i {
@@ -848,7 +848,7 @@ pub unsafe fn _mm_load_si128(mem_addr: *const __m128i) -> __m128i {
 /// Load 128-bits of integer data from memory into a new vector.
 ///
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movups))]
 pub unsafe fn _mm_loadu_si128(mem_addr: *const __m128i) -> __m128i {
@@ -869,7 +869,7 @@ pub unsafe fn _mm_loadu_si128(mem_addr: *const __m128i) -> __m128i {
 ///
 /// `mem_addr` should correspond to a 128-bit memory location and does not need
 /// to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(maskmovdqu))]
 pub unsafe fn _mm_maskmoveu_si128(a: i8x16, mask: i8x16, mem_addr: *mut i8) {
@@ -879,7 +879,7 @@ pub unsafe fn _mm_maskmoveu_si128(a: i8x16, mask: i8x16, mem_addr: *mut i8) {
 /// Store 128-bits of integer data from `a` into memory.
 ///
 /// `mem_addr` must be aligned on a 16-byte boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_store_si128(mem_addr: *mut __m128i, a: __m128i) {
@@ -889,7 +889,7 @@ pub unsafe fn _mm_store_si128(mem_addr: *mut __m128i, a: __m128i) {
 /// Store 128-bits of integer data from `a` into memory.
 ///
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movups))] // FIXME movdqu expected
 pub unsafe fn _mm_storeu_si128(mem_addr: *mut __m128i, a: __m128i) {
@@ -899,7 +899,7 @@ pub unsafe fn _mm_storeu_si128(mem_addr: *mut __m128i, a: __m128i) {
 /// Store the lower 64-bit integer `a` to a memory location.
 ///
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // FIXME mov on windows, movlps on i686
 #[cfg_attr(all(test, not(windows),
@@ -917,7 +917,7 @@ pub unsafe fn _mm_storel_epi64(mem_addr: *mut __m128i, a: __m128i) {
 /// Stores a 128-bit integer vector to a 128-bit aligned memory location.
 /// To minimize caching, the data is flagged as non-temporal (unlikely to be
 /// used again soon).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movntps))] // FIXME movntdq
 pub unsafe fn _mm_stream_si128(mem_addr: *mut __m128i, a: __m128i) {
@@ -927,7 +927,7 @@ pub unsafe fn _mm_stream_si128(mem_addr: *mut __m128i, a: __m128i) {
 /// Stores a 32-bit integer value in the specified memory location.
 /// To minimize caching, the data is flagged as non-temporal (unlikely to be
 /// used again soon).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movnti))]
 pub unsafe fn _mm_stream_si32(mem_addr: *mut i32, a: i32) {
@@ -936,7 +936,7 @@ pub unsafe fn _mm_stream_si32(mem_addr: *mut i32, a: i32) {
 
 /// Return a vector where the low element is extracted from `a` and its upper
 /// element is zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // FIXME movd on windows, movd on i686
 #[cfg_attr(all(test, not(windows), target_arch = "x86_64"),
@@ -947,7 +947,7 @@ pub unsafe fn _mm_move_epi64(a: i64x2) -> i64x2 {
 
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using signed saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(packsswb))]
 pub unsafe fn _mm_packs_epi16(a: i16x8, b: i16x8) -> i8x16 {
@@ -956,7 +956,7 @@ pub unsafe fn _mm_packs_epi16(a: i16x8, b: i16x8) -> i8x16 {
 
 /// Convert packed 32-bit integers from `a` and `b` to packed 16-bit integers
 /// using signed saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(packssdw))]
 pub unsafe fn _mm_packs_epi32(a: i32x4, b: i32x4) -> i16x8 {
@@ -965,7 +965,7 @@ pub unsafe fn _mm_packs_epi32(a: i32x4, b: i32x4) -> i16x8 {
 
 /// Convert packed 16-bit integers from `a` and `b` to packed 8-bit integers
 /// using unsigned saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(packuswb))]
 pub unsafe fn _mm_packus_epi16(a: i16x8, b: i16x8) -> u8x16 {
@@ -973,7 +973,7 @@ pub unsafe fn _mm_packus_epi16(a: i16x8, b: i16x8) -> u8x16 {
 }
 
 /// Return the `imm8` element of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pextrw, imm8 = 9))]
 pub unsafe fn _mm_extract_epi16(a: i16x8, imm8: i32) -> i32 {
@@ -982,7 +982,7 @@ pub unsafe fn _mm_extract_epi16(a: i16x8, imm8: i32) -> i32 {
 }
 
 /// Return a new vector where the `imm8` element of `a` is replaced with `i`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pinsrw, imm8 = 9))]
 pub unsafe fn _mm_insert_epi16(a: i16x8, i: i32, imm8: i32) -> i16x8 {
@@ -990,7 +990,7 @@ pub unsafe fn _mm_insert_epi16(a: i16x8, i: i32, imm8: i32) -> i16x8 {
 }
 
 /// Return a mask of the most significant bit of each element in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmovmskb))]
 pub unsafe fn _mm_movemask_epi8(a: i8x16) -> i32 {
@@ -998,7 +998,7 @@ pub unsafe fn _mm_movemask_epi8(a: i8x16) -> i32 {
 }
 
 /// Shuffle 32-bit integers in `a` using the control in `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pshufd, imm8 = 9))]
 pub unsafe fn _mm_shuffle_epi32(a: i32x4, imm8: i32) -> i32x4 {
@@ -1059,7 +1059,7 @@ pub unsafe fn _mm_shuffle_epi32(a: i32x4, imm8: i32) -> i32x4 {
 ///
 /// Put the results in the high 64 bits of the returned vector, with the low 64
 /// bits being copied from from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pshufhw, imm8 = 9))]
 pub unsafe fn _mm_shufflehi_epi16(a: i16x8, imm8: i32) -> i16x8 {
@@ -1115,7 +1115,7 @@ pub unsafe fn _mm_shufflehi_epi16(a: i16x8, imm8: i32) -> i16x8 {
 ///
 /// Put the results in the low 64 bits of the returned vector, with the high 64
 /// bits being copied from from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pshuflw, imm8 = 9))]
 pub unsafe fn _mm_shufflelo_epi16(a: i16x8, imm8: i32) -> i16x8 {
@@ -1166,7 +1166,7 @@ pub unsafe fn _mm_shufflelo_epi16(a: i16x8, imm8: i32) -> i16x8 {
 }
 
 /// Unpack and interleave 8-bit integers from the high half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpckhbw))]
 pub unsafe fn _mm_unpackhi_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -1178,7 +1178,7 @@ pub unsafe fn _mm_unpackhi_epi8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Unpack and interleave 16-bit integers from the high half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpckhwd))]
 pub unsafe fn _mm_unpackhi_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -1186,7 +1186,7 @@ pub unsafe fn _mm_unpackhi_epi16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Unpack and interleave 32-bit integers from the high half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpckhdq))]
 pub unsafe fn _mm_unpackhi_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -1194,7 +1194,7 @@ pub unsafe fn _mm_unpackhi_epi32(a: i32x4, b: i32x4) -> i32x4 {
 }
 
 /// Unpack and interleave 64-bit integers from the high half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpckhqdq))]
 pub unsafe fn _mm_unpackhi_epi64(a: i64x2, b: i64x2) -> i64x2 {
@@ -1202,7 +1202,7 @@ pub unsafe fn _mm_unpackhi_epi64(a: i64x2, b: i64x2) -> i64x2 {
 }
 
 /// Unpack and interleave 8-bit integers from the low half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpcklbw))]
 pub unsafe fn _mm_unpacklo_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -1214,7 +1214,7 @@ pub unsafe fn _mm_unpacklo_epi8(a: i8x16, b: i8x16) -> i8x16 {
 }
 
 /// Unpack and interleave 16-bit integers from the low half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpcklwd))]
 pub unsafe fn _mm_unpacklo_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -1222,7 +1222,7 @@ pub unsafe fn _mm_unpacklo_epi16(a: i16x8, b: i16x8) -> i16x8 {
 }
 
 /// Unpack and interleave 32-bit integers from the low half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpckldq))]
 pub unsafe fn _mm_unpacklo_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -1230,7 +1230,7 @@ pub unsafe fn _mm_unpacklo_epi32(a: i32x4, b: i32x4) -> i32x4 {
 }
 
 /// Unpack and interleave 64-bit integers from the low half of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(punpcklqdq))]
 pub unsafe fn _mm_unpacklo_epi64(a: i64x2, b: i64x2) -> i64x2 {
@@ -1239,7 +1239,7 @@ pub unsafe fn _mm_unpacklo_epi64(a: i64x2, b: i64x2) -> i64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the sum of the
 /// low elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(addsd))]
 pub unsafe fn _mm_add_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1248,7 +1248,7 @@ pub unsafe fn _mm_add_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Add packed double-precision (64-bit) floating-point elements in `a` and
 /// `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(addpd))]
 pub unsafe fn _mm_add_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1257,7 +1257,7 @@ pub unsafe fn _mm_add_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the result of
 /// diving the lower element of `a` by the lower element of `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(divsd))]
 pub unsafe fn _mm_div_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1266,7 +1266,7 @@ pub unsafe fn _mm_div_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Divide packed double-precision (64-bit) floating-point elements in `a` by
 /// packed elements in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(divpd))]
 pub unsafe fn _mm_div_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1275,7 +1275,7 @@ pub unsafe fn _mm_div_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the maximum
 /// of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(maxsd))]
 pub unsafe fn _mm_max_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1284,7 +1284,7 @@ pub unsafe fn _mm_max_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the maximum values from corresponding elements in
 /// `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(maxpd))]
 pub unsafe fn _mm_max_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1293,7 +1293,7 @@ pub unsafe fn _mm_max_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the minimum
 /// of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(minsd))]
 pub unsafe fn _mm_min_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1302,7 +1302,7 @@ pub unsafe fn _mm_min_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the minimum values from corresponding elements in
 /// `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(minpd))]
 pub unsafe fn _mm_min_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1311,7 +1311,7 @@ pub unsafe fn _mm_min_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by multiplying the
 /// low elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(mulsd))]
 pub unsafe fn _mm_mul_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1320,7 +1320,7 @@ pub unsafe fn _mm_mul_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Multiply packed double-precision (64-bit) floating-point elements in `a`
 /// and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(mulpd))]
 pub unsafe fn _mm_mul_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1329,7 +1329,7 @@ pub unsafe fn _mm_mul_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the square
 /// root of the lower element `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(sqrtsd))]
 pub unsafe fn _mm_sqrt_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1337,7 +1337,7 @@ pub unsafe fn _mm_sqrt_sd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Return a new vector with the square root of each of the values in `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(sqrtpd))]
 pub unsafe fn _mm_sqrt_pd(a: f64x2) -> f64x2 {
@@ -1346,7 +1346,7 @@ pub unsafe fn _mm_sqrt_pd(a: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by subtracting the
 /// low element by `b` from the low element of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(subsd))]
 pub unsafe fn _mm_sub_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1355,7 +1355,7 @@ pub unsafe fn _mm_sub_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Subtract packed double-precision (64-bit) floating-point elements in `b`
 /// from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(subpd))]
 pub unsafe fn _mm_sub_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1364,7 +1364,7 @@ pub unsafe fn _mm_sub_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Compute the bitwise AND of packed double-precision (64-bit) floating-point
 /// elements in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(andps))]
 pub unsafe fn _mm_and_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1374,7 +1374,7 @@ pub unsafe fn _mm_and_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compute the bitwise NOT of `a` and then AND with `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(andnps))]
 pub unsafe fn _mm_andnot_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1384,7 +1384,7 @@ pub unsafe fn _mm_andnot_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compute the bitwise OR of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(orps))]
 pub unsafe fn _mm_or_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1394,7 +1394,7 @@ pub unsafe fn _mm_or_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compute the bitwise OR of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(xorps))]
 pub unsafe fn _mm_xor_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1405,7 +1405,7 @@ pub unsafe fn _mm_xor_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the equality
 /// comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpeqsd))]
 pub unsafe fn _mm_cmpeq_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1414,7 +1414,7 @@ pub unsafe fn _mm_cmpeq_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the less-than
 /// comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpltsd))]
 pub unsafe fn _mm_cmplt_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1423,7 +1423,7 @@ pub unsafe fn _mm_cmplt_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the
 /// less-than-or-equal comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmplesd))]
 pub unsafe fn _mm_cmple_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1432,7 +1432,7 @@ pub unsafe fn _mm_cmple_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the
 /// greater-than comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpltsd))]
 pub unsafe fn _mm_cmpgt_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1441,7 +1441,7 @@ pub unsafe fn _mm_cmpgt_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the
 /// greater-than-or-equal comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmplesd))]
 pub unsafe fn _mm_cmpge_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1452,7 +1452,7 @@ pub unsafe fn _mm_cmpge_sd(a: f64x2, b: f64x2) -> f64x2 {
 /// of comparing both of the lower elements of `a` and `b` to `NaN`. If
 /// neither are equal to `NaN` then `0xFFFFFFFFFFFFFFFF` is used and `0`
 /// otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpordsd))]
 pub unsafe fn _mm_cmpord_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1462,7 +1462,7 @@ pub unsafe fn _mm_cmpord_sd(a: f64x2, b: f64x2) -> f64x2 {
 /// Return a new vector with the low element of `a` replaced by the result of
 /// comparing both of the lower elements of `a` and `b` to `NaN`. If either is
 /// equal to `NaN` then `0xFFFFFFFFFFFFFFFF` is used and `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpunordsd))]
 pub unsafe fn _mm_cmpunord_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1471,7 +1471,7 @@ pub unsafe fn _mm_cmpunord_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the not-equal
 /// comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpneqsd))]
 pub unsafe fn _mm_cmpneq_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1480,7 +1480,7 @@ pub unsafe fn _mm_cmpneq_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the
 /// not-less-than comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnltsd))]
 pub unsafe fn _mm_cmpnlt_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1489,7 +1489,7 @@ pub unsafe fn _mm_cmpnlt_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the
 /// not-less-than-or-equal comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnlesd))]
 pub unsafe fn _mm_cmpnle_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1498,7 +1498,7 @@ pub unsafe fn _mm_cmpnle_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the
 /// not-greater-than comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnltsd))]
 pub unsafe fn _mm_cmpngt_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1507,7 +1507,7 @@ pub unsafe fn _mm_cmpngt_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Return a new vector with the low element of `a` replaced by the
 /// not-greater-than-or-equal comparison of the lower elements of `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnlesd))]
 pub unsafe fn _mm_cmpnge_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1515,7 +1515,7 @@ pub unsafe fn _mm_cmpnge_sd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpeqpd))]
 pub unsafe fn _mm_cmpeq_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1523,7 +1523,7 @@ pub unsafe fn _mm_cmpeq_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for less-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpltpd))]
 pub unsafe fn _mm_cmplt_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1531,7 +1531,7 @@ pub unsafe fn _mm_cmplt_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for less-than-or-equal
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmplepd))]
 pub unsafe fn _mm_cmple_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1539,7 +1539,7 @@ pub unsafe fn _mm_cmple_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpltpd))]
 pub unsafe fn _mm_cmpgt_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1547,7 +1547,7 @@ pub unsafe fn _mm_cmpgt_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for greater-than-or-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmplepd))]
 pub unsafe fn _mm_cmpge_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1555,7 +1555,7 @@ pub unsafe fn _mm_cmpge_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` to see if neither is `NaN`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpordpd))]
 pub unsafe fn _mm_cmpord_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1563,7 +1563,7 @@ pub unsafe fn _mm_cmpord_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` to see if either is `NaN`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpunordpd))]
 pub unsafe fn _mm_cmpunord_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1571,7 +1571,7 @@ pub unsafe fn _mm_cmpunord_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for not-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpneqpd))]
 pub unsafe fn _mm_cmpneq_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1579,7 +1579,7 @@ pub unsafe fn _mm_cmpneq_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for not-less-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnltpd))]
 pub unsafe fn _mm_cmpnlt_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1587,7 +1587,7 @@ pub unsafe fn _mm_cmpnlt_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for not-less-than-or-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnlepd))]
 pub unsafe fn _mm_cmpnle_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1595,7 +1595,7 @@ pub unsafe fn _mm_cmpnle_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare corresponding elements in `a` and `b` for not-greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnltpd))]
 pub unsafe fn _mm_cmpngt_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1604,7 +1604,7 @@ pub unsafe fn _mm_cmpngt_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Compare corresponding elements in `a` and `b` for
 /// not-greater-than-or-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cmpnlepd))]
 pub unsafe fn _mm_cmpnge_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -1612,7 +1612,7 @@ pub unsafe fn _mm_cmpnge_pd(a: f64x2, b: f64x2) -> f64x2 {
 }
 
 /// Compare the lower element of `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
 pub unsafe fn _mm_comieq_sd(a: f64x2, b: f64x2) -> bool {
@@ -1620,7 +1620,7 @@ pub unsafe fn _mm_comieq_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for less-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
 pub unsafe fn _mm_comilt_sd(a: f64x2, b: f64x2) -> bool {
@@ -1628,7 +1628,7 @@ pub unsafe fn _mm_comilt_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for less-than-or-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
 pub unsafe fn _mm_comile_sd(a: f64x2, b: f64x2) -> bool {
@@ -1636,7 +1636,7 @@ pub unsafe fn _mm_comile_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
 pub unsafe fn _mm_comigt_sd(a: f64x2, b: f64x2) -> bool {
@@ -1644,7 +1644,7 @@ pub unsafe fn _mm_comigt_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for greater-than-or-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
 pub unsafe fn _mm_comige_sd(a: f64x2, b: f64x2) -> bool {
@@ -1652,7 +1652,7 @@ pub unsafe fn _mm_comige_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for not-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(comisd))]
 pub unsafe fn _mm_comineq_sd(a: f64x2, b: f64x2) -> bool {
@@ -1660,7 +1660,7 @@ pub unsafe fn _mm_comineq_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for equality.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
 pub unsafe fn _mm_ucomieq_sd(a: f64x2, b: f64x2) -> bool {
@@ -1668,7 +1668,7 @@ pub unsafe fn _mm_ucomieq_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for less-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
 pub unsafe fn _mm_ucomilt_sd(a: f64x2, b: f64x2) -> bool {
@@ -1676,7 +1676,7 @@ pub unsafe fn _mm_ucomilt_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for less-than-or-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
 pub unsafe fn _mm_ucomile_sd(a: f64x2, b: f64x2) -> bool {
@@ -1684,7 +1684,7 @@ pub unsafe fn _mm_ucomile_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for greater-than.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
 pub unsafe fn _mm_ucomigt_sd(a: f64x2, b: f64x2) -> bool {
@@ -1692,7 +1692,7 @@ pub unsafe fn _mm_ucomigt_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for greater-than-or-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
 pub unsafe fn _mm_ucomige_sd(a: f64x2, b: f64x2) -> bool {
@@ -1700,7 +1700,7 @@ pub unsafe fn _mm_ucomige_sd(a: f64x2, b: f64x2) -> bool {
 }
 
 /// Compare the lower element of `a` and `b` for not-equal.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(ucomisd))]
 pub unsafe fn _mm_ucomineq_sd(a: f64x2, b: f64x2) -> bool {
@@ -1709,7 +1709,7 @@ pub unsafe fn _mm_ucomineq_sd(a: f64x2, b: f64x2) -> bool {
 
 /// Convert packed double-precision (64-bit) floating-point elements in "a" to
 /// packed single-precision (32-bit) floating-point elements
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtpd2ps))]
 pub unsafe fn _mm_cvtpd_ps(a: f64x2) -> f32x4 {
@@ -1719,7 +1719,7 @@ pub unsafe fn _mm_cvtpd_ps(a: f64x2) -> f32x4 {
 /// Convert packed single-precision (32-bit) floating-point elements in `a` to
 /// packed
 /// double-precision (64-bit) floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtps2pd))]
 pub unsafe fn _mm_cvtps_pd(a: f32x4) -> f64x2 {
@@ -1728,7 +1728,7 @@ pub unsafe fn _mm_cvtps_pd(a: f32x4) -> f64x2 {
 
 /// Convert packed double-precision (64-bit) floating-point elements in `a` to
 /// packed 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtpd2dq))]
 pub unsafe fn _mm_cvtpd_epi32(a: f64x2) -> i32x4 {
@@ -1737,7 +1737,7 @@ pub unsafe fn _mm_cvtpd_epi32(a: f64x2) -> i32x4 {
 
 /// Convert the lower double-precision (64-bit) floating-point element in a to
 /// a 32-bit integer.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtsd2si))]
 pub unsafe fn _mm_cvtsd_si32(a: f64x2) -> i32 {
@@ -1748,7 +1748,7 @@ pub unsafe fn _mm_cvtsd_si32(a: f64x2) -> i32 {
 /// to a single-precision (32-bit) floating-point element, store the result in
 /// the lower element of the return value, and copy the upper element from `a`
 /// to the upper element the return value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtsd2ss))]
 pub unsafe fn _mm_cvtsd_ss(a: f32x4, b: f64x2) -> f32x4 {
@@ -1756,7 +1756,7 @@ pub unsafe fn _mm_cvtsd_ss(a: f32x4, b: f64x2) -> f32x4 {
 }
 
 /// Return the lower double-precision (64-bit) floating-point element of "a".
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, windows), assert_instr(movsd))] // FIXME movq/movlps/mov on other platform
 pub unsafe fn _mm_cvtsd_f64(a: f64x2) -> f64 {
@@ -1767,7 +1767,7 @@ pub unsafe fn _mm_cvtsd_f64(a: f64x2) -> f64 {
 /// to a double-precision (64-bit) floating-point element, store the result in
 /// the lower element of the return value, and copy the upper element from `a`
 /// to the upper element the return value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtss2sd))]
 pub unsafe fn _mm_cvtss_sd(a: f64x2, b: f32x4) -> f64x2 {
@@ -1776,7 +1776,7 @@ pub unsafe fn _mm_cvtss_sd(a: f64x2, b: f32x4) -> f64x2 {
 
 /// Convert packed double-precision (64-bit) floating-point elements in `a` to
 /// packed 32-bit integers with truncation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvttpd2dq))]
 pub unsafe fn _mm_cvttpd_epi32(a: f64x2) -> i32x4 {
@@ -1785,7 +1785,7 @@ pub unsafe fn _mm_cvttpd_epi32(a: f64x2) -> i32x4 {
 
 /// Convert the lower double-precision (64-bit) floating-point element in `a`
 /// to a 32-bit integer with truncation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvttsd2si))]
 pub unsafe fn _mm_cvttsd_si32(a: f64x2) -> i32 {
@@ -1794,7 +1794,7 @@ pub unsafe fn _mm_cvttsd_si32(a: f64x2) -> i32 {
 
 /// Convert packed single-precision (32-bit) floating-point elements in `a` to
 /// packed 32-bit integers with truncation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvttps2dq))]
 pub unsafe fn _mm_cvttps_epi32(a: f32x4) -> i32x4 {
@@ -1803,7 +1803,7 @@ pub unsafe fn _mm_cvttps_epi32(a: f32x4) -> i32x4 {
 
 /// Copy double-precision (64-bit) floating-point element `a` to the lower
 /// element of the packed 64-bit return value.
-#[inline(always)]
+#[inline]
 
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_set_sd(a: f64) -> f64x2 {
@@ -1812,7 +1812,7 @@ pub unsafe fn _mm_set_sd(a: f64) -> f64x2 {
 
 /// Broadcast double-precision (64-bit) floating-point value a to all elements
 /// of the return value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_set1_pd(a: f64) -> f64x2 {
     f64x2::new(a, a)
@@ -1820,7 +1820,7 @@ pub unsafe fn _mm_set1_pd(a: f64) -> f64x2 {
 
 /// Broadcast double-precision (64-bit) floating-point value a to all elements
 /// of the return value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_set_pd1(a: f64) -> f64x2 {
     f64x2::new(a, a)
@@ -1828,7 +1828,7 @@ pub unsafe fn _mm_set_pd1(a: f64) -> f64x2 {
 
 /// Set packed double-precision (64-bit) floating-point elements in the return
 /// value with the supplied values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_set_pd(a: f64, b: f64) -> f64x2 {
     f64x2::new(b, a)
@@ -1836,7 +1836,7 @@ pub unsafe fn _mm_set_pd(a: f64, b: f64) -> f64x2 {
 
 /// Set packed double-precision (64-bit) floating-point elements in the return
 /// value with the supplied values in reverse order.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_setr_pd(a: f64, b: f64) -> f64x2 {
     f64x2::new(a, b)
@@ -1844,7 +1844,7 @@ pub unsafe fn _mm_setr_pd(a: f64, b: f64) -> f64x2 {
 
 /// Returns packed double-precision (64-bit) floating-point elements with all
 /// zeros.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(xorps))] // FIXME xorpd expected
 pub unsafe fn _mm_setzero_pd() -> f64x2 {
@@ -1855,7 +1855,7 @@ pub unsafe fn _mm_setzero_pd() -> f64x2 {
 ///
 /// The mask is stored in the 2 least significant bits of the return value.
 /// All other bits are set to `0`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movmskpd))]
 pub unsafe fn _mm_movemask_pd(a: f64x2) -> i32 {
@@ -1866,7 +1866,7 @@ pub unsafe fn _mm_movemask_pd(a: f64x2) -> i32 {
 /// floating-point elements) from memory into the returned vector.
 /// `mem_addr` must be aligned on a 16-byte boundary or a general-protection
 /// exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_load_pd(mem_addr: *const f64) -> f64x2 {
@@ -1875,7 +1875,7 @@ pub unsafe fn _mm_load_pd(mem_addr: *const f64) -> f64x2 {
 
 /// Loads a 64-bit double-precision value to the low element of a
 /// 128-bit integer vector and clears the upper element.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movsd))]
 pub unsafe fn _mm_load_sd(mem_addr: *const f64) -> f64x2 {
@@ -1885,7 +1885,7 @@ pub unsafe fn _mm_load_sd(mem_addr: *const f64) -> f64x2 {
 /// Loads a double-precision value into the high-order bits of a 128-bit
 /// vector of [2 x double]. The low-order bits are copied from the low-order
 /// bits of the first operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movhpd))]
 pub unsafe fn _mm_loadh_pd(a: f64x2, mem_addr: *const f64) -> f64x2 {
@@ -1895,7 +1895,7 @@ pub unsafe fn _mm_loadh_pd(a: f64x2, mem_addr: *const f64) -> f64x2 {
 /// Loads a double-precision value into the low-order bits of a 128-bit
 /// vector of [2 x double]. The high-order bits are copied from the
 /// high-order bits of the first operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movlpd))]
 pub unsafe fn _mm_loadl_pd(a: f64x2, mem_addr: *const f64) -> f64x2 {
@@ -1906,7 +1906,7 @@ pub unsafe fn _mm_loadl_pd(a: f64x2, mem_addr: *const f64) -> f64x2 {
 /// aligned memory location.
 /// To minimize caching, the data is flagged as non-temporal (unlikely to be
 /// used again soon).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movntps))] // FIXME movntpd
 pub unsafe fn _mm_stream_pd(mem_addr: *mut f64, a: f64x2) {
@@ -1915,7 +1915,7 @@ pub unsafe fn _mm_stream_pd(mem_addr: *mut f64, a: f64x2) {
 
 /// Stores the lower 64 bits of a 128-bit vector of [2 x double] to a
 /// memory location.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movlps))] // FIXME movsd only on windows
 pub unsafe fn _mm_store_sd(mem_addr: *mut f64, a: f64x2) {
@@ -1925,7 +1925,7 @@ pub unsafe fn _mm_store_sd(mem_addr: *mut f64, a: f64x2) {
 /// Store 128-bits (composed of 2 packed double-precision (64-bit)
 /// floating-point elements) from `a` into memory. `mem_addr` must be aligned
 /// on a 16-byte boundary or a general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movaps))]
 pub unsafe fn _mm_store_pd(mem_addr: *mut f64, a: f64x2) {
@@ -1935,7 +1935,7 @@ pub unsafe fn _mm_store_pd(mem_addr: *mut f64, a: f64x2) {
 /// Store 128-bits (composed of 2 packed double-precision (64-bit)
 /// floating-point elements) from `a` into memory.
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movups))] // FIXME movupd expected
 pub unsafe fn _mm_storeu_pd(mem_addr: *mut f64, a: f64x2) {
@@ -1945,7 +1945,7 @@ pub unsafe fn _mm_storeu_pd(mem_addr: *mut f64, a: f64x2) {
 /// Store the lower double-precision (64-bit) floating-point element from `a`
 /// into 2 contiguous elements in memory. `mem_addr` must be aligned on a
 /// 16-byte boundary or a general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_store1_pd(mem_addr: *mut f64, a: f64x2) {
     let b: f64x2 = simd_shuffle2(a, a, [0, 0]);
@@ -1955,7 +1955,7 @@ pub unsafe fn _mm_store1_pd(mem_addr: *mut f64, a: f64x2) {
 /// Store the lower double-precision (64-bit) floating-point element from `a`
 /// into 2 contiguous elements in memory. `mem_addr` must be aligned on a
 /// 16-byte boundary or a general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_store_pd1(mem_addr: *mut f64, a: f64x2) {
     let b: f64x2 = simd_shuffle2(a, a, [0, 0]);
@@ -1966,7 +1966,7 @@ pub unsafe fn _mm_store_pd1(mem_addr: *mut f64, a: f64x2) {
 /// memory in reverse order.
 /// `mem_addr` must be aligned on a 16-byte boundary or a general-protection
 /// exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_storer_pd(mem_addr: *mut f64, a: f64x2) {
     let b: f64x2 = simd_shuffle2(a, a, [1, 0]);
@@ -1975,7 +1975,7 @@ pub unsafe fn _mm_storer_pd(mem_addr: *mut f64, a: f64x2) {
 
 /// Stores the upper 64 bits of a 128-bit vector of [2 x double] to a
 /// memory location.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movhpd))]
 pub unsafe fn _mm_storeh_pd(mem_addr: *mut f64, a: f64x2) {
@@ -1984,7 +1984,7 @@ pub unsafe fn _mm_storeh_pd(mem_addr: *mut f64, a: f64x2) {
 
 /// Stores the lower 64 bits of a 128-bit vector of [2 x double] to a
 /// memory location.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movlps))] // FIXME movlpd (movsd on windows)
 pub unsafe fn _mm_storel_pd(mem_addr: *mut f64, a: f64x2) {
@@ -1993,7 +1993,7 @@ pub unsafe fn _mm_storel_pd(mem_addr: *mut f64, a: f64x2) {
 
 /// Load a double-precision (64-bit) floating-point element from memory
 /// into both elements of returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 //#[cfg_attr(test, assert_instr(movapd))] FIXME movapd expected
 pub unsafe fn _mm_load1_pd(mem_addr: *const f64) -> f64x2 {
@@ -2003,7 +2003,7 @@ pub unsafe fn _mm_load1_pd(mem_addr: *const f64) -> f64x2 {
 
 /// Load a double-precision (64-bit) floating-point element from memory
 /// into both elements of returned vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 //#[cfg_attr(test, assert_instr(movapd))] FIXME movapd expected
 pub unsafe fn _mm_load_pd1(mem_addr: *const f64) -> f64x2 {
@@ -2014,7 +2014,7 @@ pub unsafe fn _mm_load_pd1(mem_addr: *const f64) -> f64x2 {
 /// Load 2 double-precision (64-bit) floating-point elements from memory into
 /// the returned vector in reverse order. `mem_addr` must be aligned on a
 /// 16-byte boundary or a general-protection exception may be generated.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movapd))]
 pub unsafe fn _mm_loadr_pd(mem_addr: *const f64) -> f64x2 {
@@ -2025,7 +2025,7 @@ pub unsafe fn _mm_loadr_pd(mem_addr: *const f64) -> f64x2 {
 /// Load 128-bits (composed of 2 packed double-precision (64-bit)
 /// floating-point elements) from memory into the returned vector.
 /// `mem_addr` does not need to be aligned on any particular boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movups))]
 pub unsafe fn _mm_loadu_pd(mem_addr: *const f64) -> f64x2 {
@@ -2041,7 +2041,7 @@ pub unsafe fn _mm_loadu_pd(mem_addr: *const f64) -> f64x2 {
 /// Constructs a 128-bit floating-point vector of [2 x double] from two
 /// 128-bit vector parameters of [2 x double], using the immediate-value
 /// parameter as a specifier.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(shufpd, imm8 = 1))]
 pub unsafe fn _mm_shuffle_pd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
@@ -2056,7 +2056,7 @@ pub unsafe fn _mm_shuffle_pd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
 /// Constructs a 128-bit floating-point vector of [2 x double]. The lower
 /// 64 bits are set to the lower 64 bits of the second parameter. The upper
 /// 64 bits are set to the upper 64 bits of the first parameter.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(movsd))]
 pub unsafe fn _mm_move_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -2065,7 +2065,7 @@ pub unsafe fn _mm_move_sd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Casts a 128-bit floating-point vector of [2 x double] into a 128-bit
 /// floating-point vector of [4 x float].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_castpd_ps(a: f64x2) -> f32x4 {
     mem::transmute(a)
@@ -2073,7 +2073,7 @@ pub unsafe fn _mm_castpd_ps(a: f64x2) -> f32x4 {
 
 /// Casts a 128-bit floating-point vector of [2 x double] into a 128-bit
 /// integer vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_castpd_si128(a: f64x2) -> __m128i {
     simd_cast(a)
@@ -2081,7 +2081,7 @@ pub unsafe fn _mm_castpd_si128(a: f64x2) -> __m128i {
 
 /// Casts a 128-bit floating-point vector of [4 x float] into a 128-bit
 /// floating-point vector of [2 x double].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_castps_pd(a: f32x4) -> f64x2 {
     mem::transmute(a)
@@ -2089,7 +2089,7 @@ pub unsafe fn _mm_castps_pd(a: f32x4) -> f64x2 {
 
 /// Casts a 128-bit floating-point vector of [4 x float] into a 128-bit
 /// integer vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_castps_si128(a: f32x4) -> __m128i {
     mem::transmute(a)
@@ -2097,7 +2097,7 @@ pub unsafe fn _mm_castps_si128(a: f32x4) -> __m128i {
 
 /// Casts a 128-bit integer vector into a 128-bit floating-point vector
 /// of [2 x double].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_castsi128_pd(a: __m128i) -> f64x2 {
     simd_cast(a)
@@ -2105,21 +2105,21 @@ pub unsafe fn _mm_castsi128_pd(a: __m128i) -> f64x2 {
 
 /// Casts a 128-bit integer vector into a 128-bit floating-point vector
 /// of [4 x float].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_castsi128_ps(a: __m128i) -> f32x4 {
     mem::transmute(a)
 }
 
 /// Return vector of type __m128d with undefined elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_undefined_pd() -> f64x2 {
     f64x2::splat(mem::uninitialized())
 }
 
 /// Return vector of type __m128i with undefined elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 pub unsafe fn _mm_undefined_si128() -> __m128i {
     mem::transmute(i32x4::splat(mem::uninitialized()))
@@ -2130,7 +2130,7 @@ pub unsafe fn _mm_undefined_si128() -> __m128i {
 ///
 /// * The [127:64] bits are copied from the [127:64] bits of the second input
 /// * The [63:0] bits are copied from the [127:64] bits of the first input
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(unpckhpd))]
 pub unsafe fn _mm_unpackhi_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -2142,7 +2142,7 @@ pub unsafe fn _mm_unpackhi_pd(a: f64x2, b: f64x2) -> f64x2 {
 ///
 /// * The [127:64] bits are copied from the [63:0] bits of the second input
 /// * The [63:0] bits are copied from the [63:0] bits of the first input
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(unpcklpd))]
 pub unsafe fn _mm_unpacklo_pd(a: f64x2, b: f64x2) -> f64x2 {

--- a/coresimd/src/x86/i586/sse3.rs
+++ b/coresimd/src/x86/i586/sse3.rs
@@ -8,7 +8,7 @@ use stdsimd_test::assert_instr;
 
 /// Alternatively add and subtract packed single-precision (32-bit)
 /// floating-point elements in `a` to/from packed elements in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(addsubps))]
 pub unsafe fn _mm_addsub_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -17,7 +17,7 @@ pub unsafe fn _mm_addsub_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Alternatively add and subtract packed double-precision (64-bit)
 /// floating-point elements in `a` to/from packed elements in `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(addsubpd))]
 pub unsafe fn _mm_addsub_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -26,7 +26,7 @@ pub unsafe fn _mm_addsub_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Horizontally add adjacent pairs of double-precision (64-bit)
 /// floating-point elements in `a` and `b`, and pack the results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(haddpd))]
 pub unsafe fn _mm_hadd_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -35,7 +35,7 @@ pub unsafe fn _mm_hadd_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Horizontally add adjacent pairs of single-precision (32-bit)
 /// floating-point elements in `a` and `b`, and pack the results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(haddps))]
 pub unsafe fn _mm_hadd_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -44,7 +44,7 @@ pub unsafe fn _mm_hadd_ps(a: f32x4, b: f32x4) -> f32x4 {
 
 /// Horizontally subtract adjacent pairs of double-precision (64-bit)
 /// floating-point elements in `a` and `b`, and pack the results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(hsubpd))]
 pub unsafe fn _mm_hsub_pd(a: f64x2, b: f64x2) -> f64x2 {
@@ -53,7 +53,7 @@ pub unsafe fn _mm_hsub_pd(a: f64x2, b: f64x2) -> f64x2 {
 
 /// Horizontally add adjacent pairs of single-precision (32-bit)
 /// floating-point elements in `a` and `b`, and pack the results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(hsubps))]
 pub unsafe fn _mm_hsub_ps(a: f32x4, b: f32x4) -> f32x4 {
@@ -63,7 +63,7 @@ pub unsafe fn _mm_hsub_ps(a: f32x4, b: f32x4) -> f32x4 {
 /// Load 128-bits of integer data from unaligned memory.
 /// This intrinsic may perform better than `_mm_loadu_si128`
 /// when the data crosses a cache line boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(lddqu))]
 pub unsafe fn _mm_lddqu_si128(mem_addr: *const __m128i) -> __m128i {
@@ -72,7 +72,7 @@ pub unsafe fn _mm_lddqu_si128(mem_addr: *const __m128i) -> __m128i {
 
 /// Duplicate the low double-precision (64-bit) floating-point element
 /// from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(movddup))]
 pub unsafe fn _mm_movedup_pd(a: f64x2) -> f64x2 {
@@ -81,7 +81,7 @@ pub unsafe fn _mm_movedup_pd(a: f64x2) -> f64x2 {
 
 /// Load a double-precision (64-bit) floating-point element from memory
 /// into both elements of return vector.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(movddup))]
 pub unsafe fn _mm_loaddup_pd(mem_addr: *const f64) -> f64x2 {
@@ -91,7 +91,7 @@ pub unsafe fn _mm_loaddup_pd(mem_addr: *const f64) -> f64x2 {
 
 /// Duplicate odd-indexed single-precision (32-bit) floating-point elements
 /// from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(movshdup))]
 pub unsafe fn _mm_movehdup_ps(a: f32x4) -> f32x4 {
@@ -100,7 +100,7 @@ pub unsafe fn _mm_movehdup_ps(a: f32x4) -> f32x4 {
 
 /// Duplicate even-indexed single-precision (32-bit) floating-point elements
 /// from `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse3")]
 #[cfg_attr(test, assert_instr(movsldup))]
 pub unsafe fn _mm_moveldup_ps(a: f32x4) -> f32x4 {

--- a/coresimd/src/x86/i586/sse41.rs
+++ b/coresimd/src/x86/i586/sse41.rs
@@ -46,7 +46,7 @@ pub const _MM_FROUND_NEARBYINT: i32 =
 /// The high bit of each corresponding mask byte determines the selection.
 /// If the high bit is set the element of `a` is selected. The element
 /// of `b` is selected otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pblendvb))]
 pub unsafe fn _mm_blendv_epi8(a: i8x16, b: i8x16, mask: i8x16) -> i8x16 {
@@ -58,7 +58,7 @@ pub unsafe fn _mm_blendv_epi8(a: i8x16, b: i8x16, mask: i8x16) -> i8x16 {
 /// The mask bits determine the selection. A clear bit selects the
 /// corresponding element of `a`, and a set bit the corresponding
 /// element of `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pblendw, imm8 = 0xF0))]
 pub unsafe fn _mm_blend_epi16(a: i16x8, b: i16x8, imm8: i32) -> i16x8 {
@@ -70,7 +70,7 @@ pub unsafe fn _mm_blend_epi16(a: i16x8, b: i16x8, imm8: i32) -> i16x8 {
 
 /// Blend packed double-precision (64-bit) floating-point elements from `a`
 /// and `b` using `mask`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(blendvpd))]
 pub unsafe fn _mm_blendv_pd(a: f64x2, b: f64x2, mask: f64x2) -> f64x2 {
@@ -79,7 +79,7 @@ pub unsafe fn _mm_blendv_pd(a: f64x2, b: f64x2, mask: f64x2) -> f64x2 {
 
 /// Blend packed single-precision (32-bit) floating-point elements from `a`
 /// and `b` using `mask`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(blendvps))]
 pub unsafe fn _mm_blendv_ps(a: f32x4, b: f32x4, mask: f32x4) -> f32x4 {
@@ -88,7 +88,7 @@ pub unsafe fn _mm_blendv_ps(a: f32x4, b: f32x4, mask: f32x4) -> f32x4 {
 
 /// Blend packed double-precision (64-bit) floating-point elements from `a`
 /// and `b` using control mask `imm2`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(blendpd, imm2 = 0b10))]
 pub unsafe fn _mm_blend_pd(a: f64x2, b: f64x2, imm2: i32) -> f64x2 {
@@ -100,7 +100,7 @@ pub unsafe fn _mm_blend_pd(a: f64x2, b: f64x2, imm2: i32) -> f64x2 {
 
 /// Blend packed single-precision (32-bit) floating-point elements from `a`
 /// and `b` using mask `imm4`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(blendps, imm4 = 0b0101))]
 pub unsafe fn _mm_blend_ps(a: f32x4, b: f32x4, imm4: i32) -> f32x4 {
@@ -112,7 +112,7 @@ pub unsafe fn _mm_blend_ps(a: f32x4, b: f32x4, imm4: i32) -> f32x4 {
 
 /// Extract a single-precision (32-bit) floating-point element from `a`,
 /// selected with `imm8`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 // TODO: Add test for Windows
 #[cfg_attr(all(test, not(windows)), assert_instr(extractps, imm8 = 0))]
@@ -124,7 +124,7 @@ pub unsafe fn _mm_extract_ps(a: f32x4, imm8: i32) -> i32 {
 /// integer containing the zero-extended integer data.
 ///
 /// See [LLVM commit D20468][https://reviews.llvm.org/D20468].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pextrb, imm8 = 0))]
 pub unsafe fn _mm_extract_epi8(a: i8x16, imm8: i32) -> i32 {
@@ -133,7 +133,7 @@ pub unsafe fn _mm_extract_epi8(a: i8x16, imm8: i32) -> i32 {
 }
 
 /// Extract an 32-bit integer from `a` selected with `imm8`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 // TODO: Add test for Windows
 #[cfg_attr(all(test, not(windows)), assert_instr(pextrd, imm8 = 1))]
@@ -164,7 +164,7 @@ pub unsafe fn _mm_extract_epi32(a: i32x4, imm8: i32) -> i32 {
 ///
 /// * Bits `[3:0]`: If any of these bits are set, the corresponding result
 /// element is cleared.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(insertps, imm8 = 0b1010))]
 pub unsafe fn _mm_insert_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
@@ -176,7 +176,7 @@ pub unsafe fn _mm_insert_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
 
 /// Return a copy of `a` with the 8-bit integer from `i` inserted at a
 /// location specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pinsrb, imm8 = 0))]
 pub unsafe fn _mm_insert_epi8(a: i8x16, i: i8, imm8: i32) -> i8x16 {
@@ -185,7 +185,7 @@ pub unsafe fn _mm_insert_epi8(a: i8x16, i: i8, imm8: i32) -> i8x16 {
 
 /// Return a copy of `a` with the 32-bit integer from `i` inserted at a
 /// location specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pinsrd, imm8 = 0))]
 pub unsafe fn _mm_insert_epi32(a: i32x4, i: i32, imm8: i32) -> i32x4 {
@@ -194,7 +194,7 @@ pub unsafe fn _mm_insert_epi32(a: i32x4, i: i32, imm8: i32) -> i32x4 {
 
 /// Compare packed 8-bit integers in `a` and `b` and return packed maximum
 /// values in dst.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmaxsb))]
 pub unsafe fn _mm_max_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -203,7 +203,7 @@ pub unsafe fn _mm_max_epi8(a: i8x16, b: i8x16) -> i8x16 {
 
 /// Compare packed unsigned 16-bit integers in `a` and `b`, and return packed
 /// maximum.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmaxuw))]
 pub unsafe fn _mm_max_epu16(a: u16x8, b: u16x8) -> u16x8 {
@@ -212,7 +212,7 @@ pub unsafe fn _mm_max_epu16(a: u16x8, b: u16x8) -> u16x8 {
 
 /// Compare packed 32-bit integers in `a` and `b`, and return packed maximum
 /// values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmaxsd))]
 pub unsafe fn _mm_max_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -221,7 +221,7 @@ pub unsafe fn _mm_max_epi32(a: i32x4, b: i32x4) -> i32x4 {
 
 /// Compare packed unsigned 32-bit integers in `a` and `b`, and return packed
 /// maximum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmaxud))]
 pub unsafe fn _mm_max_epu32(a: u32x4, b: u32x4) -> u32x4 {
@@ -230,7 +230,7 @@ pub unsafe fn _mm_max_epu32(a: u32x4, b: u32x4) -> u32x4 {
 
 /// Compare packed 8-bit integers in `a` and `b` and return packed minimum
 /// values in dst.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pminsb))]
 pub unsafe fn _mm_min_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -239,7 +239,7 @@ pub unsafe fn _mm_min_epi8(a: i8x16, b: i8x16) -> i8x16 {
 
 /// Compare packed unsigned 16-bit integers in `a` and `b`, and return packed
 /// minimum.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pminuw))]
 pub unsafe fn _mm_min_epu16(a: u16x8, b: u16x8) -> u16x8 {
@@ -248,7 +248,7 @@ pub unsafe fn _mm_min_epu16(a: u16x8, b: u16x8) -> u16x8 {
 
 /// Compare packed 32-bit integers in `a` and `b`, and return packed minimum
 /// values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pminsd))]
 pub unsafe fn _mm_min_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -257,7 +257,7 @@ pub unsafe fn _mm_min_epi32(a: i32x4, b: i32x4) -> i32x4 {
 
 /// Compare packed unsigned 32-bit integers in `a` and `b`, and return packed
 /// minimum values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pminud))]
 pub unsafe fn _mm_min_epu32(a: u32x4, b: u32x4) -> u32x4 {
@@ -266,7 +266,7 @@ pub unsafe fn _mm_min_epu32(a: u32x4, b: u32x4) -> u32x4 {
 
 /// Convert packed 32-bit integers from `a` and `b` to packed 16-bit integers
 /// using unsigned saturation
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(packusdw))]
 pub unsafe fn _mm_packus_epi32(a: i32x4, b: i32x4) -> u16x8 {
@@ -274,7 +274,7 @@ pub unsafe fn _mm_packus_epi32(a: i32x4, b: i32x4) -> u16x8 {
 }
 
 /// Compare packed 64-bit integers in `a` and `b` for equality
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pcmpeqq))]
 pub unsafe fn _mm_cmpeq_epi64(a: i64x2, b: i64x2) -> i64x2 {
@@ -282,7 +282,7 @@ pub unsafe fn _mm_cmpeq_epi64(a: i64x2, b: i64x2) -> i64x2 {
 }
 
 /// Sign extend packed 8-bit integers in `a` to packed 16-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovsxbw))]
 pub unsafe fn _mm_cvtepi8_epi16(a: i8x16) -> i16x8 {
@@ -290,7 +290,7 @@ pub unsafe fn _mm_cvtepi8_epi16(a: i8x16) -> i16x8 {
 }
 
 /// Sign extend packed 8-bit integers in `a` to packed 32-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovsxbd))]
 pub unsafe fn _mm_cvtepi8_epi32(a: i8x16) -> i32x4 {
@@ -299,7 +299,7 @@ pub unsafe fn _mm_cvtepi8_epi32(a: i8x16) -> i32x4 {
 
 /// Sign extend packed 8-bit integers in the low 8 bytes of `a` to packed
 /// 64-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovsxbq))]
 pub unsafe fn _mm_cvtepi8_epi64(a: i8x16) -> i64x2 {
@@ -307,7 +307,7 @@ pub unsafe fn _mm_cvtepi8_epi64(a: i8x16) -> i64x2 {
 }
 
 /// Sign extend packed 16-bit integers in `a` to packed 32-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovsxwd))]
 pub unsafe fn _mm_cvtepi16_epi32(a: i16x8) -> i32x4 {
@@ -315,7 +315,7 @@ pub unsafe fn _mm_cvtepi16_epi32(a: i16x8) -> i32x4 {
 }
 
 /// Sign extend packed 16-bit integers in `a` to packed 64-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovsxwq))]
 pub unsafe fn _mm_cvtepi16_epi64(a: i16x8) -> i64x2 {
@@ -323,7 +323,7 @@ pub unsafe fn _mm_cvtepi16_epi64(a: i16x8) -> i64x2 {
 }
 
 /// Sign extend packed 32-bit integers in `a` to packed 64-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovsxdq))]
 pub unsafe fn _mm_cvtepi32_epi64(a: i32x4) -> i64x2 {
@@ -331,7 +331,7 @@ pub unsafe fn _mm_cvtepi32_epi64(a: i32x4) -> i64x2 {
 }
 
 /// Zero extend packed unsigned 8-bit integers in `a` to packed 16-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovzxbw))]
 pub unsafe fn _mm_cvtepu8_epi16(a: u8x16) -> i16x8 {
@@ -339,7 +339,7 @@ pub unsafe fn _mm_cvtepu8_epi16(a: u8x16) -> i16x8 {
 }
 
 /// Zero extend packed unsigned 8-bit integers in `a` to packed 32-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovzxbd))]
 pub unsafe fn _mm_cvtepu8_epi32(a: u8x16) -> i32x4 {
@@ -347,7 +347,7 @@ pub unsafe fn _mm_cvtepu8_epi32(a: u8x16) -> i32x4 {
 }
 
 /// Zero extend packed unsigned 8-bit integers in `a` to packed 64-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovzxbq))]
 pub unsafe fn _mm_cvtepu8_epi64(a: u8x16) -> i64x2 {
@@ -356,7 +356,7 @@ pub unsafe fn _mm_cvtepu8_epi64(a: u8x16) -> i64x2 {
 
 /// Zero extend packed unsigned 16-bit integers in `a`
 /// to packed 32-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovzxwd))]
 pub unsafe fn _mm_cvtepu16_epi32(a: u16x8) -> i32x4 {
@@ -365,7 +365,7 @@ pub unsafe fn _mm_cvtepu16_epi32(a: u16x8) -> i32x4 {
 
 /// Zero extend packed unsigned 16-bit integers in `a`
 /// to packed 64-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovzxwq))]
 pub unsafe fn _mm_cvtepu16_epi64(a: u16x8) -> i64x2 {
@@ -374,7 +374,7 @@ pub unsafe fn _mm_cvtepu16_epi64(a: u16x8) -> i64x2 {
 
 /// Zero extend packed unsigned 32-bit integers in `a`
 /// to packed 64-bit integers
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmovzxdq))]
 pub unsafe fn _mm_cvtepu32_epi64(a: u32x4) -> i64x2 {
@@ -388,7 +388,7 @@ pub unsafe fn _mm_cvtepu32_epi64(a: u32x4) -> i64x2 {
 /// replaced by a value of `0.0`. If a broadcast mask bit is one, the result of
 /// the dot product will be stored in the return value component. Otherwise if
 /// the broadcast mask bit is zero then the return component will be zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(dppd, imm8 = 0))]
 pub unsafe fn _mm_dp_pd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
@@ -405,7 +405,7 @@ pub unsafe fn _mm_dp_pd(a: f64x2, b: f64x2, imm8: i32) -> f64x2 {
 /// replaced by a value of `0.0`. If a broadcast mask bit is one, the result of
 /// the dot product will be stored in the return value component. Otherwise if
 /// the broadcast mask bit is zero then the return component will be zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(dpps, imm8 = 0))]
 pub unsafe fn _mm_dp_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
@@ -418,7 +418,7 @@ pub unsafe fn _mm_dp_ps(a: f32x4, b: f32x4, imm8: i32) -> f32x4 {
 /// Round the packed double-precision (64-bit) floating-point elements in `a`
 /// down to an integer value, and store the results as packed double-precision
 /// floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundpd))]
 pub unsafe fn _mm_floor_pd(a: f64x2) -> f64x2 {
@@ -428,7 +428,7 @@ pub unsafe fn _mm_floor_pd(a: f64x2) -> f64x2 {
 /// Round the packed single-precision (32-bit) floating-point elements in `a`
 /// down to an integer value, and store the results as packed single-precision
 /// floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundps))]
 pub unsafe fn _mm_floor_ps(a: f32x4) -> f32x4 {
@@ -440,7 +440,7 @@ pub unsafe fn _mm_floor_ps(a: f32x4) -> f32x4 {
 /// floating-point element in the lower element of the intrinsic result,
 /// and copy the upper element from `a` to the upper element of the intrinsic
 /// result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundsd))]
 pub unsafe fn _mm_floor_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -452,7 +452,7 @@ pub unsafe fn _mm_floor_sd(a: f64x2, b: f64x2) -> f64x2 {
 /// floating-point element in the lower element of the intrinsic result,
 /// and copy the upper 3 packed elements from `a` to the upper elements
 /// of the intrinsic result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundss))]
 pub unsafe fn _mm_floor_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -462,7 +462,7 @@ pub unsafe fn _mm_floor_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// Round the packed double-precision (64-bit) floating-point elements in `a`
 /// up to an integer value, and store the results as packed double-precision
 /// floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundpd))]
 pub unsafe fn _mm_ceil_pd(a: f64x2) -> f64x2 {
@@ -472,7 +472,7 @@ pub unsafe fn _mm_ceil_pd(a: f64x2) -> f64x2 {
 /// Round the packed single-precision (32-bit) floating-point elements in `a`
 /// up to an integer value, and store the results as packed single-precision
 /// floating-point elements.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundps))]
 pub unsafe fn _mm_ceil_ps(a: f32x4) -> f32x4 {
@@ -484,7 +484,7 @@ pub unsafe fn _mm_ceil_ps(a: f32x4) -> f32x4 {
 /// floating-point element in the lower element of the intrisic result,
 /// and copy the upper element from `a` to the upper element
 /// of the intrinsic result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundsd))]
 pub unsafe fn _mm_ceil_sd(a: f64x2, b: f64x2) -> f64x2 {
@@ -496,7 +496,7 @@ pub unsafe fn _mm_ceil_sd(a: f64x2, b: f64x2) -> f64x2 {
 /// floating-point element in the lower element of the intrinsic result,
 /// and copy the upper 3 packed elements from `a` to the upper elements
 /// of the intrinsic result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundss))]
 pub unsafe fn _mm_ceil_ss(a: f32x4, b: f32x4) -> f32x4 {
@@ -522,7 +522,7 @@ pub unsafe fn _mm_ceil_ss(a: f32x4, b: f32x4) -> f32x4 {
 /// // use MXCSR.RC; see `vendor::_MM_SET_ROUNDING_MODE`:
 /// vendor::_MM_FROUND_CUR_DIRECTION;
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundpd, rounding = 0))]
 pub unsafe fn _mm_round_pd(a: f64x2, rounding: i32) -> f64x2 {
@@ -551,7 +551,7 @@ pub unsafe fn _mm_round_pd(a: f64x2, rounding: i32) -> f64x2 {
 /// // use MXCSR.RC; see `vendor::_MM_SET_ROUNDING_MODE`:
 /// vendor::_MM_FROUND_CUR_DIRECTION;
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundps, rounding = 0))]
 pub unsafe fn _mm_round_ps(a: f32x4, rounding: i32) -> f32x4 {
@@ -582,7 +582,7 @@ pub unsafe fn _mm_round_ps(a: f32x4, rounding: i32) -> f32x4 {
 /// // use MXCSR.RC; see `vendor::_MM_SET_ROUNDING_MODE`:
 /// vendor::_MM_FROUND_CUR_DIRECTION;
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundsd, rounding = 0))]
 pub unsafe fn _mm_round_sd(a: f64x2, b: f64x2, rounding: i32) -> f64x2 {
@@ -613,7 +613,7 @@ pub unsafe fn _mm_round_sd(a: f64x2, b: f64x2, rounding: i32) -> f64x2 {
 /// // use MXCSR.RC; see `vendor::_MM_SET_ROUNDING_MODE`:
 /// vendor::_MM_FROUND_CUR_DIRECTION;
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(roundss, rounding = 0))]
 pub unsafe fn _mm_round_ss(a: f32x4, b: f32x4, rounding: i32) -> f32x4 {
@@ -642,7 +642,7 @@ pub unsafe fn _mm_round_ss(a: f32x4, b: f32x4, rounding: i32) -> f32x4 {
 /// * bits `[15:0]` - contain the minimum value found in parameter `a`,
 /// * bits `[18:16]` - contain the index of the minimum value
 /// * remaining bits are set to `0`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(phminposuw))]
 pub unsafe fn _mm_minpos_epu16(a: u16x8) -> u16x8 {
@@ -651,7 +651,7 @@ pub unsafe fn _mm_minpos_epu16(a: u16x8) -> u16x8 {
 
 /// Multiply the low 32-bit integers from each packed 64-bit
 /// element in `a` and `b`, and return the signed 64-bit result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmuldq))]
 pub unsafe fn _mm_mul_epi32(a: i32x4, b: i32x4) -> i64x2 {
@@ -664,7 +664,7 @@ pub unsafe fn _mm_mul_epi32(a: i32x4, b: i32x4) -> i64x2 {
 /// i32x4::splat(2)` returns the obvious `i32x4::splat(4)`, due to wrapping
 /// arithmetic `pmulld i32x4::splat(i32::MAX), i32x4::splat(2)` would return a
 /// negative number.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pmulld))]
 pub unsafe fn _mm_mullo_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -702,7 +702,7 @@ pub unsafe fn _mm_mullo_epi32(a: i32x4, b: i32x4) -> i32x4 {
 ///
 /// * A `i16x8` vector containing the sums of the sets of
 ///   absolute differences between both operands.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(mpsadbw, imm8 = 0))]
 pub unsafe fn _mm_mpsadbw_epu8(a: u8x16, b: u8x16, imm8: i32) -> u16x8 {

--- a/coresimd/src/x86/i586/sse42.rs
+++ b/coresimd/src/x86/i586/sse42.rs
@@ -47,7 +47,7 @@ pub const _SIDD_UNIT_MASK: i32 = 0b0100_0000;
 
 /// Compare packed strings with implicit lengths in `a` and `b` using the
 /// control in `imm8`, and return the generated mask.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpistrm, imm8 = 0))]
 pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
@@ -267,7 +267,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// [`_SIDD_LEAST_SIGNIFICANT`]: constant._SIDD_LEAST_SIGNIFICANT.html
 /// [`_SIDD_MOST_SIGNIFICANT`]: constant._SIDD_MOST_SIGNIFICANT.html
 /// [`_mm_cmpestri`]: fn._mm_cmpestri.html
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
 pub unsafe fn _mm_cmpistri(a: __m128i, b: __m128i, imm8: i32) -> i32 {
@@ -280,7 +280,7 @@ pub unsafe fn _mm_cmpistri(a: __m128i, b: __m128i, imm8: i32) -> i32 {
 /// Compare packed strings with implicit lengths in `a` and `b` using the
 /// control in `imm8`, and return `1` if any character in `b` was null.
 /// and `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
 pub unsafe fn _mm_cmpistrz(a: __m128i, b: __m128i, imm8: i32) -> i32 {
@@ -295,7 +295,7 @@ pub unsafe fn _mm_cmpistrz(a: __m128i, b: __m128i, imm8: i32) -> i32 {
 /// Compare packed strings with implicit lengths in `a` and `b` using the
 /// control in `imm8`, and return `1` if the resulting mask was non-zero,
 /// and `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
 pub unsafe fn _mm_cmpistrc(a: __m128i, b: __m128i, imm8: i32) -> i32 {
@@ -308,7 +308,7 @@ pub unsafe fn _mm_cmpistrc(a: __m128i, b: __m128i, imm8: i32) -> i32 {
 /// Compare packed strings with implicit lengths in `a` and `b` using the
 /// control in `imm8`, and returns `1` if any character in `a` was null,
 /// and `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
 pub unsafe fn _mm_cmpistrs(a: __m128i, b: __m128i, imm8: i32) -> i32 {
@@ -320,7 +320,7 @@ pub unsafe fn _mm_cmpistrs(a: __m128i, b: __m128i, imm8: i32) -> i32 {
 
 /// Compare packed strings with implicit lengths in `a` and `b` using the
 /// control in `imm8`, and return bit `0` of the resulting bit mask.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
 pub unsafe fn _mm_cmpistro(a: __m128i, b: __m128i, imm8: i32) -> i32 {
@@ -333,7 +333,7 @@ pub unsafe fn _mm_cmpistro(a: __m128i, b: __m128i, imm8: i32) -> i32 {
 /// Compare packed strings with implicit lengths in `a` and `b` using the
 /// control in `imm8`, and return `1` if `b` did not contain a null
 /// character and the resulting mask was zero, and `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpistri, imm8 = 0))]
 pub unsafe fn _mm_cmpistra(a: __m128i, b: __m128i, imm8: i32) -> i32 {
@@ -345,7 +345,7 @@ pub unsafe fn _mm_cmpistra(a: __m128i, b: __m128i, imm8: i32) -> i32 {
 
 /// Compare packed strings in `a` and `b` with lengths `la` and `lb`
 /// using the control in `imm8`, and return the generated mask.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpestrm, imm8 = 0))]
 pub unsafe fn _mm_cmpestrm(
@@ -441,7 +441,7 @@ pub unsafe fn _mm_cmpestrm(
 /// [`_SIDD_LEAST_SIGNIFICANT`]: constant._SIDD_LEAST_SIGNIFICANT.html
 /// [`_SIDD_MOST_SIGNIFICANT`]: constant._SIDD_MOST_SIGNIFICANT.html
 /// [`_mm_cmpistri`]: fn._mm_cmpistri.html
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestri(
@@ -456,7 +456,7 @@ pub unsafe fn _mm_cmpestri(
 /// Compare packed strings in `a` and `b` with lengths `la` and `lb`
 /// using the control in `imm8`, and return `1` if any character in
 /// `b` was null, and `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestrz(
@@ -471,7 +471,7 @@ pub unsafe fn _mm_cmpestrz(
 /// Compare packed strings in `a` and `b` with lengths `la` and `lb`
 /// using the control in `imm8`, and return `1` if the resulting mask
 /// was non-zero, and `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestrc(
@@ -486,7 +486,7 @@ pub unsafe fn _mm_cmpestrc(
 /// Compare packed strings in `a` and `b` with lengths `la` and `lb`
 /// using the control in `imm8`, and return `1` if any character in
 /// a was null, and `0` otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestrs(
@@ -501,7 +501,7 @@ pub unsafe fn _mm_cmpestrs(
 /// Compare packed strings in `a` and `b` with lengths `la` and `lb`
 /// using the control in `imm8`, and return bit `0` of the resulting
 /// bit mask.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestro(
@@ -517,7 +517,7 @@ pub unsafe fn _mm_cmpestro(
 /// using the control in `imm8`, and return `1` if `b` did not
 /// contain a null character and the resulting mask was zero, and `0`
 /// otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 pub unsafe fn _mm_cmpestra(
@@ -531,7 +531,7 @@ pub unsafe fn _mm_cmpestra(
 
 /// Starting with the initial value in `crc`, return the accumulated
 /// CRC32 value for unsigned 8-bit integer `v`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(crc32))]
 pub unsafe fn _mm_crc32_u8(crc: u32, v: u8) -> u32 {
@@ -540,7 +540,7 @@ pub unsafe fn _mm_crc32_u8(crc: u32, v: u8) -> u32 {
 
 /// Starting with the initial value in `crc`, return the accumulated
 /// CRC32 value for unsigned 16-bit integer `v`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(crc32))]
 pub unsafe fn _mm_crc32_u16(crc: u32, v: u16) -> u32 {
@@ -549,7 +549,7 @@ pub unsafe fn _mm_crc32_u16(crc: u32, v: u16) -> u32 {
 
 /// Starting with the initial value in `crc`, return the accumulated
 /// CRC32 value for unsigned 32-bit integer `v`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(crc32))]
 pub unsafe fn _mm_crc32_u32(crc: u32, v: u32) -> u32 {

--- a/coresimd/src/x86/i586/ssse3.rs
+++ b/coresimd/src/x86/i586/ssse3.rs
@@ -8,7 +8,7 @@ use v128::*;
 
 /// Compute the absolute value of packed 8-bit signed integers in `a` and
 /// return the unsigned results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pabsb))]
 pub unsafe fn _mm_abs_epi8(a: i8x16) -> u8x16 {
@@ -18,7 +18,7 @@ pub unsafe fn _mm_abs_epi8(a: i8x16) -> u8x16 {
 /// Compute the absolute value of each of the packed 16-bit signed integers in
 /// `a` and
 /// return the 16-bit unsigned integer
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pabsw))]
 pub unsafe fn _mm_abs_epi16(a: i16x8) -> u16x8 {
@@ -28,7 +28,7 @@ pub unsafe fn _mm_abs_epi16(a: i16x8) -> u16x8 {
 /// Compute the absolute value of each of the packed 32-bit signed integers in
 /// `a` and
 /// return the 32-bit unsigned integer
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pabsd))]
 pub unsafe fn _mm_abs_epi32(a: i32x4) -> u32x4 {
@@ -59,7 +59,7 @@ pub unsafe fn _mm_abs_epi32(a: i32x4) -> u32x4 {
 ///     r
 /// }
 /// ```
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pshufb))]
 pub unsafe fn _mm_shuffle_epi8(a: u8x16, b: u8x16) -> u8x16 {
@@ -68,7 +68,7 @@ pub unsafe fn _mm_shuffle_epi8(a: u8x16, b: u8x16) -> u8x16 {
 
 /// Concatenate 16-byte blocks in `a` and `b` into a 32-byte temporary result,
 /// shift the result right by `n` bytes, and return the low 16 bytes.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(palignr, n = 15))]
 pub unsafe fn _mm_alignr_epi8(a: i8x16, b: i8x16, n: i32) -> i8x16 {
@@ -123,7 +123,7 @@ pub unsafe fn _mm_alignr_epi8(a: i8x16, b: i8x16, n: i32) -> i8x16 {
 
 /// Horizontally add the adjacent pairs of values contained in 2 packed
 /// 128-bit vectors of [8 x i16].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phaddw))]
 pub unsafe fn _mm_hadd_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -133,7 +133,7 @@ pub unsafe fn _mm_hadd_epi16(a: i16x8, b: i16x8) -> i16x8 {
 /// Horizontally add the adjacent pairs of values contained in 2 packed
 /// 128-bit vectors of [8 x i16]. Positive sums greater than 7FFFh are
 /// saturated to 7FFFh. Negative sums less than 8000h are saturated to 8000h.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phaddsw))]
 pub unsafe fn _mm_hadds_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -142,7 +142,7 @@ pub unsafe fn _mm_hadds_epi16(a: i16x8, b: i16x8) -> i16x8 {
 
 /// Horizontally add the adjacent pairs of values contained in 2 packed
 /// 128-bit vectors of [4 x i32].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phaddd))]
 pub unsafe fn _mm_hadd_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -151,7 +151,7 @@ pub unsafe fn _mm_hadd_epi32(a: i32x4, b: i32x4) -> i32x4 {
 
 /// Horizontally subtract the adjacent pairs of values contained in 2
 /// packed 128-bit vectors of [8 x i16].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phsubw))]
 pub unsafe fn _mm_hsub_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -162,7 +162,7 @@ pub unsafe fn _mm_hsub_epi16(a: i16x8, b: i16x8) -> i16x8 {
 /// packed 128-bit vectors of [8 x i16]. Positive differences greater than
 /// 7FFFh are saturated to 7FFFh. Negative differences less than 8000h are
 /// saturated to 8000h.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phsubsw))]
 pub unsafe fn _mm_hsubs_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -171,7 +171,7 @@ pub unsafe fn _mm_hsubs_epi16(a: i16x8, b: i16x8) -> i16x8 {
 
 /// Horizontally subtract the adjacent pairs of values contained in 2
 /// packed 128-bit vectors of [4 x i32].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phsubd))]
 pub unsafe fn _mm_hsub_epi32(a: i32x4, b: i32x4) -> i32x4 {
@@ -183,7 +183,7 @@ pub unsafe fn _mm_hsub_epi32(a: i32x4, b: i32x4) -> i32x4 {
 /// integer values contained in the second source operand, add pairs of
 /// contiguous products with signed saturation, and writes the 16-bit sums to
 /// the corresponding bits in the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pmaddubsw))]
 pub unsafe fn _mm_maddubs_epi16(a: u8x16, b: i8x16) -> i16x8 {
@@ -193,7 +193,7 @@ pub unsafe fn _mm_maddubs_epi16(a: u8x16, b: i8x16) -> i16x8 {
 /// Multiply packed 16-bit signed integer values, truncate the 32-bit
 /// product to the 18 most significant bits by right-shifting, round the
 /// truncated value by adding 1, and write bits [16:1] to the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pmulhrsw))]
 pub unsafe fn _mm_mulhrs_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -204,7 +204,7 @@ pub unsafe fn _mm_mulhrs_epi16(a: i16x8, b: i16x8) -> i16x8 {
 /// integer in `b` is negative, and return the result.
 /// Elements in result are zeroed out when the corresponding element in `b`
 /// is zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(psignb))]
 pub unsafe fn _mm_sign_epi8(a: i8x16, b: i8x16) -> i8x16 {
@@ -215,7 +215,7 @@ pub unsafe fn _mm_sign_epi8(a: i8x16, b: i8x16) -> i8x16 {
 /// integer in `b` is negative, and return the results.
 /// Elements in result are zeroed out when the corresponding element in `b`
 /// is zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(psignw))]
 pub unsafe fn _mm_sign_epi16(a: i16x8, b: i16x8) -> i16x8 {
@@ -226,7 +226,7 @@ pub unsafe fn _mm_sign_epi16(a: i16x8, b: i16x8) -> i16x8 {
 /// integer in `b` is negative, and return the results.
 /// Element in result are zeroed out when the corresponding element in `b`
 /// is zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(psignd))]
 pub unsafe fn _mm_sign_epi32(a: i32x4, b: i32x4) -> i32x4 {

--- a/coresimd/src/x86/i586/tbm.rs
+++ b/coresimd/src/x86/i586/tbm.rs
@@ -27,7 +27,7 @@ extern "C" {
 
 /// Extracts bits in range [`start`, `start` + `length`) from `a` into
 /// the least significant bits of the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 pub fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
     _bextr2_u32(a, (start & 0xffu32) | ((len & 0xffu32) << 8u32))
@@ -35,7 +35,7 @@ pub fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
 
 /// Extracts bits in range [`start`, `start` + `length`) from `a` into
 /// the least significant bits of the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 pub fn _bextr_u64(a: u64, start: u64, len: u64) -> u64 {
     _bextr2_u64(a, (start & 0xffu64) | ((len & 0xffu64) << 8u64))
@@ -46,7 +46,7 @@ pub fn _bextr_u64(a: u64, start: u64, len: u64) -> u64 {
 ///
 /// Bits [7,0] of `control` specify the index to the first bit in the range to
 /// be extracted, and bits [15,8] specify the length of the range.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 pub fn _bextr2_u32(a: u32, control: u32) -> u32 {
     unsafe { x86_tbm_bextri_u32(a, control) }
@@ -57,7 +57,7 @@ pub fn _bextr2_u32(a: u32, control: u32) -> u32 {
 ///
 /// Bits [7,0] of `control` specify the index to the first bit in the range to
 /// be extracted, and bits [15,8] specify the length of the range.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 pub fn _bextr2_u64(a: u64, control: u64) -> u64 {
     unsafe { x86_tbm_bextri_u64(a, control) }
@@ -67,7 +67,7 @@ pub fn _bextr2_u64(a: u64, control: u64) -> u64 {
 /// Clears all bits below the least significant zero bit of `x`.
 ///
 /// If there is no zero bit in `x`, it returns zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcfill))]
 pub unsafe fn _blcfill_u32(x: u32) -> u32 {
@@ -77,7 +77,7 @@ pub unsafe fn _blcfill_u32(x: u32) -> u32 {
 /// Clears all bits below the least significant zero bit of `x`.
 ///
 /// If there is no zero bit in `x`, it returns zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcfill))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
@@ -88,7 +88,7 @@ pub unsafe fn _blcfill_u64(x: u64) -> u64 {
 /// Sets all bits of `x` to 1 except for the least significant zero bit.
 ///
 /// If there is no zero bit in `x`, it sets all bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blci))]
 pub unsafe fn _blci_u32(x: u32) -> u32 {
@@ -98,7 +98,7 @@ pub unsafe fn _blci_u32(x: u32) -> u32 {
 /// Sets all bits of `x` to 1 except for the least significant zero bit.
 ///
 /// If there is no zero bit in `x`, it sets all bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blci))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
@@ -109,7 +109,7 @@ pub unsafe fn _blci_u64(x: u64) -> u64 {
 /// Sets the least significant zero bit of `x` and clears all other bits.
 ///
 /// If there is no zero bit in `x`, it returns zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcic))]
 pub unsafe fn _blcic_u32(x: u32) -> u32 {
@@ -119,7 +119,7 @@ pub unsafe fn _blcic_u32(x: u32) -> u32 {
 /// Sets the least significant zero bit of `x` and clears all other bits.
 ///
 /// If there is no zero bit in `x`, it returns zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcic))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
@@ -131,7 +131,7 @@ pub unsafe fn _blcic_u64(x: u64) -> u64 {
 /// that bit.
 ///
 /// If there is no zero bit in `x`, it sets all the bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcmsk))]
 pub unsafe fn _blcmsk_u32(x: u32) -> u32 {
@@ -142,7 +142,7 @@ pub unsafe fn _blcmsk_u32(x: u32) -> u32 {
 /// that bit.
 ///
 /// If there is no zero bit in `x`, it sets all the bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcmsk))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
@@ -153,7 +153,7 @@ pub unsafe fn _blcmsk_u64(x: u64) -> u64 {
 /// Sets the least significant zero bit of `x`.
 ///
 /// If there is no zero bit in `x`, it returns `x`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcs))]
 pub unsafe fn _blcs_u32(x: u32) -> u32 {
@@ -163,7 +163,7 @@ pub unsafe fn _blcs_u32(x: u32) -> u32 {
 /// Sets the least significant zero bit of `x`.
 ///
 /// If there is no zero bit in `x`, it returns `x`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blcs))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
@@ -174,7 +174,7 @@ pub unsafe fn _blcs_u64(x: u64) -> u64 {
 /// Sets all bits of `x` below the least significant one.
 ///
 /// If there is no set bit in `x`, it sets all the bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blsfill))]
 pub unsafe fn _blsfill_u32(x: u32) -> u32 {
@@ -184,7 +184,7 @@ pub unsafe fn _blsfill_u32(x: u32) -> u32 {
 /// Sets all bits of `x` below the least significant one.
 ///
 /// If there is no set bit in `x`, it sets all the bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blsfill))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
@@ -195,7 +195,7 @@ pub unsafe fn _blsfill_u64(x: u64) -> u64 {
 /// Clears least significant bit and sets all other bits.
 ///
 /// If there is no set bit in `x`, it sets all the bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blsic))]
 pub unsafe fn _blsic_u32(x: u32) -> u32 {
@@ -205,7 +205,7 @@ pub unsafe fn _blsic_u32(x: u32) -> u32 {
 /// Clears least significant bit and sets all other bits.
 ///
 /// If there is no set bit in `x`, it sets all the bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(blsic))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
@@ -217,7 +217,7 @@ pub unsafe fn _blsic_u64(x: u64) -> u64 {
 /// bits.
 ///
 /// If the least significant bit of `x` is 0, it sets all bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(t1mskc))]
 pub unsafe fn _t1mskc_u32(x: u32) -> u32 {
@@ -228,7 +228,7 @@ pub unsafe fn _t1mskc_u32(x: u32) -> u32 {
 /// bits.
 ///
 /// If the least significant bit of `x` is 0, it sets all bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(t1mskc))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions
@@ -240,7 +240,7 @@ pub unsafe fn _t1mskc_u64(x: u64) -> u64 {
 /// bits.
 ///
 /// If the least significant bit of `x` is 1, it returns zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(tzmsk))]
 pub unsafe fn _tzmsk_u32(x: u32) -> u32 {
@@ -251,7 +251,7 @@ pub unsafe fn _tzmsk_u32(x: u32) -> u32 {
 /// bits.
 ///
 /// If the least significant bit of `x` is 1, it returns zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "tbm")]
 #[cfg_attr(test, assert_instr(tzmsk))]
 #[cfg(not(target_arch = "x86"))] // generates lots of instructions

--- a/coresimd/src/x86/i586/xsave.rs
+++ b/coresimd/src/x86/i586/xsave.rs
@@ -33,7 +33,7 @@ extern "C" {
 ///
 /// The format of the XSAVE area is detailed in Section 13.4, “XSAVE Area,” of
 /// Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 1.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave")]
 #[cfg_attr(test, assert_instr(xsave))]
 pub unsafe fn _xsave(mem_addr: *mut u8, save_mask: u64) {
@@ -46,7 +46,7 @@ pub unsafe fn _xsave(mem_addr: *mut u8, save_mask: u64) {
 /// State is restored based on bits [62:0] in `rs_mask`, `XCR0`, and
 /// `mem_addr.HEADER.XSTATE_BV`. `mem_addr` must be aligned on a 64-byte
 /// boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave")]
 #[cfg_attr(test, assert_instr(xrstor))]
 pub unsafe fn _xrstor(mem_addr: *const u8, rs_mask: u64) {
@@ -62,7 +62,7 @@ const _XCR_XFEATURE_ENABLED_MASK: u32 = 0;
 /// by `a`.
 ///
 /// Currently only `XFEATURE_ENABLED_MASK` `XCR` is supported.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave")]
 #[cfg_attr(test, assert_instr(xsetbv))]
 pub unsafe fn _xsetbv(a: u32, val: u64) {
@@ -71,7 +71,7 @@ pub unsafe fn _xsetbv(a: u32, val: u64) {
 
 /// Reads the contents of the extended control register `XCR`
 /// specified in `xcr_no`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave")]
 #[cfg_attr(test, assert_instr(xgetbv))]
 pub unsafe fn _xgetbv(xcr_no: u32) -> u64 {
@@ -85,7 +85,7 @@ pub unsafe fn _xgetbv(xcr_no: u32) -> u64 {
 /// `mem_addr` must be aligned on a 64-byte boundary. The hardware may optimize
 /// the manner in which data is saved. The performance of this instruction will
 /// be equal to or better than using the `XSAVE` instruction.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave,xsaveopt")]
 #[cfg_attr(test, assert_instr(xsaveopt))]
 pub unsafe fn _xsaveopt(mem_addr: *mut u8, save_mask: u64) {
@@ -98,7 +98,7 @@ pub unsafe fn _xsaveopt(mem_addr: *mut u8, save_mask: u64) {
 /// `xsavec` differs from `xsave` in that it uses compaction and that it may
 /// use init optimization. State is saved based on bits [62:0] in `save_mask`
 /// and `XCR0`. `mem_addr` must be aligned on a 64-byte boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave,xsavec")]
 #[cfg_attr(test, assert_instr(xsavec))]
 pub unsafe fn _xsavec(mem_addr: *mut u8, save_mask: u64) {
@@ -112,7 +112,7 @@ pub unsafe fn _xsavec(mem_addr: *mut u8, save_mask: u64) {
 /// corresponding to bits set in `IA32_XSS` `MSR` and that it may use the
 /// modified optimization. State is saved based on bits [62:0] in `save_mask`
 /// and `XCR0`. `mem_addr` must be aligned on a 64-byte boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave,xsaves")]
 #[cfg_attr(test, assert_instr(xsaves))]
 pub unsafe fn _xsaves(mem_addr: *mut u8, save_mask: u64) {
@@ -128,7 +128,7 @@ pub unsafe fn _xsaves(mem_addr: *mut u8, save_mask: u64) {
 /// State is restored based on bits [62:0] in `rs_mask`, `XCR0`, and
 /// `mem_addr.HEADER.XSTATE_BV`. `mem_addr` must be aligned on a 64-byte
 /// boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave,xsaves")]
 #[cfg_attr(test, assert_instr(xrstors))]
 pub unsafe fn _xrstors(mem_addr: *const u8, rs_mask: u64) {

--- a/coresimd/src/x86/i686/mmx.rs
+++ b/coresimd/src/x86/i686/mmx.rs
@@ -15,7 +15,7 @@ use core::mem;
 use stdsimd_test::assert_instr;
 
 /// Constructs a 64-bit integer vector initialized to zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "mmx")]
 // FIXME: this produces a movl instead of xorps on x86
 // FIXME: this produces a xor intrinsic instead of xorps on x86_64
@@ -25,7 +25,7 @@ pub unsafe fn _mm_setzero_si64() -> __m64 {
 }
 
 /// Add packed 8-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddb))]
 pub unsafe fn _mm_add_pi8(a: __m64, b: __m64) -> __m64 {
@@ -33,7 +33,7 @@ pub unsafe fn _mm_add_pi8(a: __m64, b: __m64) -> __m64 {
 }
 
 /// Add packed 16-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddw))]
 pub unsafe fn _mm_add_pi16(a: __m64, b: __m64) -> __m64 {
@@ -41,7 +41,7 @@ pub unsafe fn _mm_add_pi16(a: __m64, b: __m64) -> __m64 {
 }
 
 /// Add packed 32-bit integers in `a` and `b`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddd))]
 pub unsafe fn _mm_add_pi32(a: __m64, b: __m64) -> __m64 {
@@ -49,7 +49,7 @@ pub unsafe fn _mm_add_pi32(a: __m64, b: __m64) -> __m64 {
 }
 
 /// Add packed 8-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddsb))]
 pub unsafe fn _mm_adds_pi8(a: __m64, b: __m64) -> __m64 {
@@ -57,7 +57,7 @@ pub unsafe fn _mm_adds_pi8(a: __m64, b: __m64) -> __m64 {
 }
 
 /// Add packed 16-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddsw))]
 pub unsafe fn _mm_adds_pi16(a: __m64, b: __m64) -> __m64 {
@@ -65,7 +65,7 @@ pub unsafe fn _mm_adds_pi16(a: __m64, b: __m64) -> __m64 {
 }
 
 /// Add packed unsigned 8-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddusb))]
 pub unsafe fn _mm_adds_pu8(a: __m64, b: __m64) -> __m64 {
@@ -73,7 +73,7 @@ pub unsafe fn _mm_adds_pu8(a: __m64, b: __m64) -> __m64 {
 }
 
 /// Add packed unsigned 16-bit integers in `a` and `b` using saturation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "mmx")]
 #[cfg_attr(test, assert_instr(paddusw))]
 pub unsafe fn _mm_adds_pu16(a: __m64, b: __m64) -> __m64 {

--- a/coresimd/src/x86/i686/sse.rs
+++ b/coresimd/src/x86/i686/sse.rs
@@ -46,7 +46,7 @@ extern "C" {
 
 /// Compares the packed 16-bit signed integers of `a` and `b` writing the
 /// greatest value into the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pmaxsw))]
 pub unsafe fn _mm_max_pi16(a: __m64, b: __m64) -> __m64 {
@@ -55,7 +55,7 @@ pub unsafe fn _mm_max_pi16(a: __m64, b: __m64) -> __m64 {
 
 /// Compares the packed 16-bit signed integers of `a` and `b` writing the
 /// greatest value into the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pmaxsw))]
 pub unsafe fn _m_pmaxsw(a: __m64, b: __m64) -> __m64 {
@@ -64,7 +64,7 @@ pub unsafe fn _m_pmaxsw(a: __m64, b: __m64) -> __m64 {
 
 /// Compares the packed 8-bit signed integers of `a` and `b` writing the
 /// greatest value into the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pmaxub))]
 pub unsafe fn _mm_max_pu8(a: __m64, b: __m64) -> __m64 {
@@ -73,7 +73,7 @@ pub unsafe fn _mm_max_pu8(a: __m64, b: __m64) -> __m64 {
 
 /// Compares the packed 8-bit signed integers of `a` and `b` writing the
 /// greatest value into the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pmaxub))]
 pub unsafe fn _m_pmaxub(a: __m64, b: __m64) -> __m64 {
@@ -82,7 +82,7 @@ pub unsafe fn _m_pmaxub(a: __m64, b: __m64) -> __m64 {
 
 /// Compares the packed 16-bit signed integers of `a` and `b` writing the
 /// smallest value into the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pminsw))]
 pub unsafe fn _mm_min_pi16(a: __m64, b: __m64) -> __m64 {
@@ -91,7 +91,7 @@ pub unsafe fn _mm_min_pi16(a: __m64, b: __m64) -> __m64 {
 
 /// Compares the packed 16-bit signed integers of `a` and `b` writing the
 /// smallest value into the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pminsw))]
 pub unsafe fn _m_pminsw(a: __m64, b: __m64) -> __m64 {
@@ -100,7 +100,7 @@ pub unsafe fn _m_pminsw(a: __m64, b: __m64) -> __m64 {
 
 /// Compares the packed 8-bit signed integers of `a` and `b` writing the
 /// smallest value into the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pminub))]
 pub unsafe fn _mm_min_pu8(a: __m64, b: __m64) -> __m64 {
@@ -109,7 +109,7 @@ pub unsafe fn _mm_min_pu8(a: __m64, b: __m64) -> __m64 {
 
 /// Compares the packed 8-bit signed integers of `a` and `b` writing the
 /// smallest value into the result.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pminub))]
 pub unsafe fn _m_pminub(a: __m64, b: __m64) -> __m64 {
@@ -119,7 +119,7 @@ pub unsafe fn _m_pminub(a: __m64, b: __m64) -> __m64 {
 /// Multiplies packed 16-bit unsigned integer values and writes the
 /// high-order 16 bits of each 32-bit product to the corresponding bits in
 /// the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pmulhuw))]
 pub unsafe fn _mm_mulhi_pu16(a: __m64, b: __m64) -> __m64 {
@@ -129,7 +129,7 @@ pub unsafe fn _mm_mulhi_pu16(a: __m64, b: __m64) -> __m64 {
 /// Multiplies packed 16-bit unsigned integer values and writes the
 /// high-order 16 bits of each 32-bit product to the corresponding bits in
 /// the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pmulhuw))]
 pub unsafe fn _m_pmulhuw(a: __m64, b: __m64) -> __m64 {
@@ -139,7 +139,7 @@ pub unsafe fn _m_pmulhuw(a: __m64, b: __m64) -> __m64 {
 /// Computes the rounded averages of the packed unsigned 8-bit integer
 /// values and writes the averages to the corresponding bits in the
 /// destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pavgb))]
 pub unsafe fn _mm_avg_pu8(a: __m64, b: __m64) -> __m64 {
@@ -149,7 +149,7 @@ pub unsafe fn _mm_avg_pu8(a: __m64, b: __m64) -> __m64 {
 /// Computes the rounded averages of the packed unsigned 8-bit integer
 /// values and writes the averages to the corresponding bits in the
 /// destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pavgb))]
 pub unsafe fn _m_pavgb(a: __m64, b: __m64) -> __m64 {
@@ -159,7 +159,7 @@ pub unsafe fn _m_pavgb(a: __m64, b: __m64) -> __m64 {
 /// Computes the rounded averages of the packed unsigned 16-bit integer
 /// values and writes the averages to the corresponding bits in the
 /// destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pavgw))]
 pub unsafe fn _mm_avg_pu16(a: __m64, b: __m64) -> __m64 {
@@ -169,7 +169,7 @@ pub unsafe fn _mm_avg_pu16(a: __m64, b: __m64) -> __m64 {
 /// Computes the rounded averages of the packed unsigned 16-bit integer
 /// values and writes the averages to the corresponding bits in the
 /// destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pavgw))]
 pub unsafe fn _m_pavgw(a: __m64, b: __m64) -> __m64 {
@@ -180,7 +180,7 @@ pub unsafe fn _m_pavgw(a: __m64, b: __m64) -> __m64 {
 /// 64-bit vector operands and computes the absolute value for each of the
 /// difference. Then sum of the 8 absolute differences is written to the
 /// bits [15:0] of the destination; the remaining bits [63:16] are cleared.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(psadbw))]
 pub unsafe fn _mm_sad_pu8(a: __m64, b: __m64) -> __m64 {
@@ -191,7 +191,7 @@ pub unsafe fn _mm_sad_pu8(a: __m64, b: __m64) -> __m64 {
 /// 64-bit vector operands and computes the absolute value for each of the
 /// difference. Then sum of the 8 absolute differences is written to the
 /// bits [15:0] of the destination; the remaining bits [63:16] are cleared.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(psadbw))]
 pub unsafe fn _m_psadbw(a: __m64, b: __m64) -> __m64 {
@@ -202,7 +202,7 @@ pub unsafe fn _m_psadbw(a: __m64, b: __m64) -> __m64 {
 /// floating point values and writes them to the lower 64-bits of the
 /// destination. The remaining higher order elements of the destination are
 /// copied from the corresponding elements in the first operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtpi2ps))]
 pub unsafe fn _mm_cvtpi32_ps(a: f32x4, b: i32x2) -> f32x4 {
@@ -213,7 +213,7 @@ pub unsafe fn _mm_cvtpi32_ps(a: f32x4, b: i32x2) -> f32x4 {
 /// floating point values and writes them to the lower 64-bits of the
 /// destination. The remaining higher order elements of the destination are
 /// copied from the corresponding elements in the first operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtpi2ps))]
 pub unsafe fn _mm_cvt_pi2ps(a: f32x4, b: i32x2) -> f32x4 {
@@ -222,7 +222,7 @@ pub unsafe fn _mm_cvt_pi2ps(a: f32x4, b: i32x2) -> f32x4 {
 
 /// Converts the two 32-bit signed integer values from each 64-bit vector
 /// operand of [2 x i32] into a 128-bit vector of [4 x float].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtpi2ps))]
 pub unsafe fn _mm_cvtpi32x2_ps(a: i32x2, b: i32x2) -> f32x4 {
@@ -239,7 +239,7 @@ pub unsafe fn _mm_cvtpi32x2_ps(a: i32x2, b: i32x2) -> f32x4 {
 ///
 /// To minimize caching, the data is flagged as non-temporal
 /// (unlikely to be used again soon).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(maskmovq))]
 pub unsafe fn _mm_maskmove_si64(a: __m64, mask: __m64, mem_addr: *mut i8) {
@@ -253,7 +253,7 @@ pub unsafe fn _mm_maskmove_si64(a: __m64, mask: __m64, mem_addr: *mut i8) {
 ///
 /// To minimize caching, the data is flagged as non-temporal
 /// (unlikely to be used again soon).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(maskmovq))]
 pub unsafe fn _m_maskmovq(a: __m64, mask: __m64, mem_addr: *mut i8) {
@@ -262,7 +262,7 @@ pub unsafe fn _m_maskmovq(a: __m64, mask: __m64, mem_addr: *mut i8) {
 
 /// Extracts 16-bit element from a 64-bit vector of [4 x i16] and
 /// returns it, as specified by the immediate integer operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pextrw, imm2 = 0))]
 pub unsafe fn _mm_extract_pi16(a: i16x4, imm2: i32) -> i16 {
@@ -274,7 +274,7 @@ pub unsafe fn _mm_extract_pi16(a: i16x4, imm2: i32) -> i16 {
 
 /// Extracts 16-bit element from a 64-bit vector of [4 x i16] and
 /// returns it, as specified by the immediate integer operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pextrw, imm2 = 0))]
 pub unsafe fn _m_pextrw(a: i16x4, imm2: i32) -> i16 {
@@ -284,7 +284,7 @@ pub unsafe fn _m_pextrw(a: i16x4, imm2: i32) -> i16 {
 /// Copies data from the 64-bit vector of [4 x i16] to the destination,
 /// and inserts the lower 16-bits of an integer operand at the 16-bit offset
 /// specified by the immediate operand `n`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pinsrw, imm2 = 0))]
 pub unsafe fn _mm_insert_pi16(a: __m64, d: i32, imm2: i32) -> __m64 {
@@ -297,7 +297,7 @@ pub unsafe fn _mm_insert_pi16(a: __m64, d: i32, imm2: i32) -> __m64 {
 /// Copies data from the 64-bit vector of [4 x i16] to the destination,
 /// and inserts the lower 16-bits of an integer operand at the 16-bit offset
 /// specified by the immediate operand `n`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pinsrw, imm2 = 0))]
 pub unsafe fn _m_pinsrw(a: __m64, d: i32, imm2: i32) -> __m64 {
@@ -307,7 +307,7 @@ pub unsafe fn _m_pinsrw(a: __m64, d: i32, imm2: i32) -> __m64 {
 /// Takes the most significant bit from each 8-bit element in a 64-bit
 /// integer vector to create a 16-bit mask value. Zero-extends the value to
 /// 32-bit integer and writes it to the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pmovmskb))]
 pub unsafe fn _mm_movemask_pi8(a: i16x4) -> i32 {
@@ -317,7 +317,7 @@ pub unsafe fn _mm_movemask_pi8(a: i16x4) -> i32 {
 /// Takes the most significant bit from each 8-bit element in a 64-bit
 /// integer vector to create a 16-bit mask value. Zero-extends the value to
 /// 32-bit integer and writes it to the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pmovmskb))]
 pub unsafe fn _m_pmovmskb(a: i16x4) -> i32 {
@@ -326,7 +326,7 @@ pub unsafe fn _m_pmovmskb(a: i16x4) -> i32 {
 
 /// Shuffles the 4 16-bit integers from a 64-bit integer vector to the
 /// destination, as specified by the immediate value operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pshufw, imm8 = 0))]
 pub unsafe fn _mm_shuffle_pi16(a: __m64, imm8: i32) -> __m64 {
@@ -338,7 +338,7 @@ pub unsafe fn _mm_shuffle_pi16(a: __m64, imm8: i32) -> __m64 {
 
 /// Shuffles the 4 16-bit integers from a 64-bit integer vector to the
 /// destination, as specified by the immediate value operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(pshufw, imm8 = 0))]
 pub unsafe fn _m_pshufw(a: __m64, imm8: i32) -> __m64 {
@@ -347,7 +347,7 @@ pub unsafe fn _m_pshufw(a: __m64, imm8: i32) -> __m64 {
 
 /// Convert the two lower packed single-precision (32-bit) floating-point
 /// elements in `a` to packed 32-bit integers with truncation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvttps2pi))]
 pub unsafe fn _mm_cvttps_pi32(a: f32x4) -> i32x2 {
@@ -356,7 +356,7 @@ pub unsafe fn _mm_cvttps_pi32(a: f32x4) -> i32x2 {
 
 /// Convert the two lower packed single-precision (32-bit) floating-point
 /// elements in `a` to packed 32-bit integers with truncation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvttps2pi))]
 pub unsafe fn _mm_cvtt_ps2pi(a: f32x4) -> i32x2 {
@@ -365,7 +365,7 @@ pub unsafe fn _mm_cvtt_ps2pi(a: f32x4) -> i32x2 {
 
 /// Convert the two lower packed single-precision (32-bit) floating-point
 /// elements in `a` to packed 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtps2pi))]
 pub unsafe fn _mm_cvtps_pi32(a: f32x4) -> __m64 {
@@ -374,7 +374,7 @@ pub unsafe fn _mm_cvtps_pi32(a: f32x4) -> __m64 {
 
 /// Convert the two lower packed single-precision (32-bit) floating-point
 /// elements in `a` to packed 32-bit integers.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtps2pi))]
 pub unsafe fn _mm_cvt_ps2pi(a: f32x4) -> __m64 {

--- a/coresimd/src/x86/i686/sse2.rs
+++ b/coresimd/src/x86/i686/sse2.rs
@@ -9,7 +9,7 @@ use stdsimd_test::assert_instr;
 
 /// Adds two signed or unsigned 64-bit integer values, returning the
 /// lower 64 bits of the sum.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(paddq))]
 pub unsafe fn _mm_add_si64(a: __m64, b: __m64) -> __m64 {
@@ -19,7 +19,7 @@ pub unsafe fn _mm_add_si64(a: __m64, b: __m64) -> __m64 {
 /// Multiplies 32-bit unsigned integer values contained in the lower bits
 /// of the two 64-bit integer vectors and returns the 64-bit unsigned
 /// product.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(pmuludq))]
 pub unsafe fn _mm_mul_su32(a: u32x2, b: u32x2) -> __m64 {
@@ -28,7 +28,7 @@ pub unsafe fn _mm_mul_su32(a: u32x2, b: u32x2) -> __m64 {
 
 /// Subtracts signed or unsigned 64-bit integer values and writes the
 /// difference to the corresponding bits in the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(psubq))]
 pub unsafe fn _mm_sub_si64(a: __m64, b: __m64) -> __m64 {
@@ -38,7 +38,7 @@ pub unsafe fn _mm_sub_si64(a: __m64, b: __m64) -> __m64 {
 /// Converts the two signed 32-bit integer elements of a 64-bit vector of
 /// [2 x i32] into two double-precision floating-point values, returned in a
 /// 128-bit vector of [2 x double].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtpi2pd))]
 pub unsafe fn _mm_cvtpi32_pd(a: i32x2) -> f64x2 {
@@ -47,7 +47,7 @@ pub unsafe fn _mm_cvtpi32_pd(a: i32x2) -> f64x2 {
 
 /// Initializes both 64-bit values in a 128-bit vector of [2 x i64] with
 /// the specified 64-bit integer values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set_epi64(e1: __m64, e0: __m64) -> i64x2 {
@@ -56,7 +56,7 @@ pub unsafe fn _mm_set_epi64(e1: __m64, e0: __m64) -> i64x2 {
 
 /// Initializes both values in a 128-bit vector of [2 x i64] with the
 /// specified 64-bit value.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_set1_epi64(a: __m64) -> i64x2 {
@@ -65,7 +65,7 @@ pub unsafe fn _mm_set1_epi64(a: __m64) -> i64x2 {
 
 /// Constructs a 128-bit integer vector, initialized in reverse order
 /// with the specified 64-bit integral values.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // no particular instruction to test
 pub unsafe fn _mm_setr_epi64(e1: __m64, e0: __m64) -> i64x2 {
@@ -74,7 +74,7 @@ pub unsafe fn _mm_setr_epi64(e1: __m64, e0: __m64) -> i64x2 {
 
 /// Returns the lower 64 bits of a 128-bit integer vector as a 64-bit
 /// integer.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // #[cfg_attr(test, assert_instr(movdq2q))] // FIXME: llvm codegens wrong
 // instr?
@@ -84,7 +84,7 @@ pub unsafe fn _mm_movepi64_pi64(a: i64x2) -> __m64 {
 
 /// Moves the 64-bit operand to a 128-bit integer vector, zeroing the
 /// upper bits.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // #[cfg_attr(test, assert_instr(movq2dq))] // FIXME: llvm codegens wrong
 // instr?
@@ -95,7 +95,7 @@ pub unsafe fn _mm_movpi64_epi64(a: __m64) -> i64x2 {
 /// Converts the two double-precision floating-point elements of a
 /// 128-bit vector of [2 x double] into two signed 32-bit integer values,
 /// returned in a 64-bit vector of [2 x i32].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtpd2pi))]
 pub unsafe fn _mm_cvtpd_pi32(a: f64x2) -> i32x2 {
@@ -107,7 +107,7 @@ pub unsafe fn _mm_cvtpd_pi32(a: f64x2) -> i32x2 {
 /// returned in a 64-bit vector of [2 x i32].
 /// If the result of either conversion is inexact, the result is truncated
 /// (rounded towards zero) regardless of the current MXCSR setting.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvttpd2pi))]
 pub unsafe fn _mm_cvttpd_pi32(a: f64x2) -> i32x2 {

--- a/coresimd/src/x86/i686/sse41.rs
+++ b/coresimd/src/x86/i686/sse41.rs
@@ -28,7 +28,7 @@ extern "C" {
 ///
 /// * `1` - if the specified bits are all zeros,
 /// * `0` - otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(ptest))]
 pub unsafe fn _mm_testz_si128(a: __m128i, mask: __m128i) -> i32 {
@@ -48,7 +48,7 @@ pub unsafe fn _mm_testz_si128(a: __m128i, mask: __m128i) -> i32 {
 ///
 /// * `1` - if the specified bits are all ones,
 /// * `0` - otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(ptest))]
 pub unsafe fn _mm_testc_si128(a: __m128i, mask: __m128i) -> i32 {
@@ -68,7 +68,7 @@ pub unsafe fn _mm_testc_si128(a: __m128i, mask: __m128i) -> i32 {
 ///
 /// * `1` - if the specified bits are neither all zeros nor all ones,
 /// * `0` - otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(ptest))]
 pub unsafe fn _mm_testnzc_si128(a: __m128i, mask: __m128i) -> i32 {
@@ -88,7 +88,7 @@ pub unsafe fn _mm_testnzc_si128(a: __m128i, mask: __m128i) -> i32 {
 ///
 /// * `1` - if the specified bits are all zeros,
 /// * `0` - otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(ptest))]
 pub unsafe fn _mm_test_all_zeros(a: __m128i, mask: __m128i) -> i32 {
@@ -106,7 +106,7 @@ pub unsafe fn _mm_test_all_zeros(a: __m128i, mask: __m128i) -> i32 {
 ///
 /// * `1` - if the bits specified in the operand are all set to 1,
 /// * `0` - otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pcmpeqd))]
 #[cfg_attr(test, assert_instr(ptest))]
@@ -128,7 +128,7 @@ pub unsafe fn _mm_test_all_ones(a: __m128i) -> i32 {
 ///
 /// * `1` - if the specified bits are neither all zeros nor all ones,
 /// * `0` - otherwise.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(ptest))]
 pub unsafe fn _mm_test_mix_ones_zeros(a: __m128i, mask: __m128i) -> i32 {

--- a/coresimd/src/x86/i686/sse42.rs
+++ b/coresimd/src/x86/i686/sse42.rs
@@ -7,7 +7,7 @@ use stdsimd_test::assert_instr;
 
 /// Compare packed 64-bit integers in `a` and `b` for greater-than,
 /// return the results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(pcmpgtq))]
 pub unsafe fn _mm_cmpgt_epi64(a: i64x2, b: i64x2) -> i64x2 {

--- a/coresimd/src/x86/i686/sse4a.rs
+++ b/coresimd/src/x86/i686/sse4a.rs
@@ -32,7 +32,7 @@ extern "C" {
 ///
 /// If `length == 0 && index > 0` or `lenght + index > 64` the result is
 /// undefined.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4a")]
 #[cfg_attr(test, assert_instr(extrq))]
 pub unsafe fn _mm_extract_si64(x: i64x2, y: i64x2) -> i64x2 {
@@ -48,7 +48,7 @@ pub unsafe fn _mm_extract_si64(x: i64x2, y: i64x2) -> i64x2 {
 ///
 /// If the `length` is zero it is interpreted as `64`. If `index + length > 64`
 /// or `index > 0 && length == 0` the result is undefined.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4a")]
 #[cfg_attr(test, assert_instr(insertq))]
 pub unsafe fn _mm_insert_si64(x: i64x2, y: i64x2) -> i64x2 {
@@ -56,7 +56,7 @@ pub unsafe fn _mm_insert_si64(x: i64x2, y: i64x2) -> i64x2 {
 }
 
 /// Non-temporal store of `a.0` into `p`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4a")]
 #[cfg_attr(test, assert_instr(movntsd))]
 pub unsafe fn _mm_stream_sd(p: *mut f64, a: f64x2) {
@@ -64,7 +64,7 @@ pub unsafe fn _mm_stream_sd(p: *mut f64, a: f64x2) {
 }
 
 /// Non-temporal store of `a.0` into `p`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4a")]
 #[cfg_attr(test, assert_instr(movntss))]
 pub unsafe fn _mm_stream_ss(p: *mut f32, a: f32x4) {

--- a/coresimd/src/x86/i686/ssse3.rs
+++ b/coresimd/src/x86/i686/ssse3.rs
@@ -7,7 +7,7 @@ use v64::*;
 
 /// Compute the absolute value of packed 8-bit integers in `a` and
 /// return the unsigned results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pabsb))]
 pub unsafe fn _mm_abs_pi8(a: __m64) -> __m64 {
@@ -16,7 +16,7 @@ pub unsafe fn _mm_abs_pi8(a: __m64) -> __m64 {
 
 /// Compute the absolute value of packed 8-bit integers in `a`, and return the
 /// unsigned results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pabsw))]
 pub unsafe fn _mm_abs_pi16(a: __m64) -> __m64 {
@@ -25,7 +25,7 @@ pub unsafe fn _mm_abs_pi16(a: __m64) -> __m64 {
 
 /// Compute the absolute value of packed 32-bit integers in `a`, and return the
 /// unsigned results.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pabsd))]
 pub unsafe fn _mm_abs_pi32(a: __m64) -> __m64 {
@@ -34,7 +34,7 @@ pub unsafe fn _mm_abs_pi32(a: __m64) -> __m64 {
 
 /// Shuffle packed 8-bit integers in `a` according to shuffle control mask in
 /// the corresponding 8-bit element of `b`, and return the results
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pshufb))]
 pub unsafe fn _mm_shuffle_pi8(a: __m64, b: __m64) -> __m64 {
@@ -43,7 +43,7 @@ pub unsafe fn _mm_shuffle_pi8(a: __m64, b: __m64) -> __m64 {
 
 /// Concatenates the two 64-bit integer vector operands, and right-shifts
 /// the result by the number of bytes specified in the immediate operand.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(palignr, n = 15))]
 pub unsafe fn _mm_alignr_pi8(a: __m64, b: __m64, n: i32) -> __m64 {
@@ -57,7 +57,7 @@ pub unsafe fn _mm_alignr_pi8(a: __m64, b: __m64, n: i32) -> __m64 {
 
 /// Horizontally add the adjacent pairs of values contained in 2 packed
 /// 64-bit vectors of [4 x i16].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phaddw))]
 pub unsafe fn _mm_hadd_pi16(a: __m64, b: __m64) -> __m64 {
@@ -66,7 +66,7 @@ pub unsafe fn _mm_hadd_pi16(a: __m64, b: __m64) -> __m64 {
 
 /// Horizontally add the adjacent pairs of values contained in 2 packed
 /// 64-bit vectors of [2 x i32].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phaddd))]
 pub unsafe fn _mm_hadd_pi32(a: __m64, b: __m64) -> __m64 {
@@ -76,7 +76,7 @@ pub unsafe fn _mm_hadd_pi32(a: __m64, b: __m64) -> __m64 {
 /// Horizontally add the adjacent pairs of values contained in 2 packed
 /// 64-bit vectors of [4 x i16]. Positive sums greater than 7FFFh are
 /// saturated to 7FFFh. Negative sums less than 8000h are saturated to 8000h.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phaddsw))]
 pub unsafe fn _mm_hadds_pi16(a: __m64, b: __m64) -> __m64 {
@@ -85,7 +85,7 @@ pub unsafe fn _mm_hadds_pi16(a: __m64, b: __m64) -> __m64 {
 
 /// Horizontally subtracts the adjacent pairs of values contained in 2
 /// packed 64-bit vectors of [4 x i16].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phsubw))]
 pub unsafe fn _mm_hsub_pi16(a: __m64, b: __m64) -> __m64 {
@@ -94,7 +94,7 @@ pub unsafe fn _mm_hsub_pi16(a: __m64, b: __m64) -> __m64 {
 
 /// Horizontally subtracts the adjacent pairs of values contained in 2
 /// packed 64-bit vectors of [2 x i32].
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phsubd))]
 pub unsafe fn _mm_hsub_pi32(a: __m64, b: __m64) -> __m64 {
@@ -105,7 +105,7 @@ pub unsafe fn _mm_hsub_pi32(a: __m64, b: __m64) -> __m64 {
 /// packed 64-bit vectors of [4 x i16]. Positive differences greater than
 /// 7FFFh are saturated to 7FFFh. Negative differences less than 8000h are
 /// saturated to 8000h.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(phsubsw))]
 pub unsafe fn _mm_hsubs_pi16(a: __m64, b: __m64) -> __m64 {
@@ -117,7 +117,7 @@ pub unsafe fn _mm_hsubs_pi16(a: __m64, b: __m64) -> __m64 {
 /// integer values contained in the second source operand, adds pairs of
 /// contiguous products with signed saturation, and writes the 16-bit sums to
 /// the corresponding bits in the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pmaddubsw))]
 pub unsafe fn _mm_maddubs_pi16(a: __m64, b: __m64) -> __m64 {
@@ -127,7 +127,7 @@ pub unsafe fn _mm_maddubs_pi16(a: __m64, b: __m64) -> __m64 {
 /// Multiplies packed 16-bit signed integer values, truncates the 32-bit
 /// products to the 18 most significant bits by right-shifting, rounds the
 /// truncated value by adding 1, and writes bits [16:1] to the destination.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(pmulhrsw))]
 pub unsafe fn _mm_mulhrs_pi16(a: __m64, b: __m64) -> __m64 {
@@ -138,7 +138,7 @@ pub unsafe fn _mm_mulhrs_pi16(a: __m64, b: __m64) -> __m64 {
 /// integer in `b` is negative, and return the results.
 /// Element in result are zeroed out when the corresponding element in `b` is
 /// zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(psignb))]
 pub unsafe fn _mm_sign_pi8(a: __m64, b: __m64) -> __m64 {
@@ -149,7 +149,7 @@ pub unsafe fn _mm_sign_pi8(a: __m64, b: __m64) -> __m64 {
 /// integer in `b` is negative, and return the results.
 /// Element in result are zeroed out when the corresponding element in `b` is
 /// zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(psignw))]
 pub unsafe fn _mm_sign_pi16(a: __m64, b: __m64) -> __m64 {
@@ -160,7 +160,7 @@ pub unsafe fn _mm_sign_pi16(a: __m64, b: __m64) -> __m64 {
 /// integer in `b` is negative, and return the results.
 /// Element in result are zeroed out when the corresponding element in `b` is
 /// zero.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "ssse3")]
 #[cfg_attr(test, assert_instr(psignd))]
 pub unsafe fn _mm_sign_pi32(a: __m64, b: __m64) -> __m64 {

--- a/coresimd/src/x86/x86_64/fxsr.rs
+++ b/coresimd/src/x86/x86_64/fxsr.rs
@@ -21,7 +21,7 @@ extern "C" {
 ///
 /// [fxsave]: http://www.felixcloutier.com/x86/FXSAVE.html
 /// [fxrstor]: http://www.felixcloutier.com/x86/FXRSTOR.html
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "fxsr")]
 #[cfg_attr(test, assert_instr(fxsave64))]
 pub unsafe fn _fxsave64(mem_addr: *mut u8) {
@@ -42,7 +42,7 @@ pub unsafe fn _fxsave64(mem_addr: *mut u8) {
 ///
 /// [fxsave]: http://www.felixcloutier.com/x86/FXSAVE.html
 /// [fxrstor]: http://www.felixcloutier.com/x86/FXRSTOR.html
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "fxsr")]
 #[cfg_attr(test, assert_instr(fxrstor64))]
 pub unsafe fn _fxrstor64(mem_addr: *const u8) {

--- a/coresimd/src/x86/x86_64/sse.rs
+++ b/coresimd/src/x86/x86_64/sse.rs
@@ -24,7 +24,7 @@ extern "C" {
 /// [`_mm_setcsr`](fn._mm_setcsr.html)).
 ///
 /// This corresponds to the `CVTSS2SI` instruction (with 64 bit output).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtss2si))]
 pub unsafe fn _mm_cvtss_si64(a: f32x4) -> i64 {
@@ -40,7 +40,7 @@ pub unsafe fn _mm_cvtss_si64(a: f32x4) -> i64 {
 /// point exception if unmasked (see [`_mm_setcsr`](fn._mm_setcsr.html)).
 ///
 /// This corresponds to the `CVTTSS2SI` instruction (with 64 bit output).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvttss2si))]
 pub unsafe fn _mm_cvttss_si64(a: f32x4) -> i64 {
@@ -52,7 +52,7 @@ pub unsafe fn _mm_cvttss_si64(a: f32x4) -> i64 {
 ///
 /// This intrinsic corresponds to the `CVTSI2SS` instruction (with 64 bit
 /// input).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse")]
 #[cfg_attr(test, assert_instr(cvtsi2ss))]
 pub unsafe fn _mm_cvtsi64_ss(a: f32x4, b: i64) -> f32x4 {

--- a/coresimd/src/x86/x86_64/sse2.rs
+++ b/coresimd/src/x86/x86_64/sse2.rs
@@ -15,7 +15,7 @@ extern "C" {
 
 /// Convert the lower double-precision (64-bit) floating-point element in a to
 /// a 64-bit integer.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtsd2si))]
 pub unsafe fn _mm_cvtsd_si64(a: f64x2) -> i64 {
@@ -23,7 +23,7 @@ pub unsafe fn _mm_cvtsd_si64(a: f64x2) -> i64 {
 }
 
 /// Alias for [`_mm_cvtsd_si64`](fn._mm_cvtsd_si64_ss.html).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtsd2si))]
 pub unsafe fn _mm_cvtsd_si64x(a: f64x2) -> i64 {
@@ -32,7 +32,7 @@ pub unsafe fn _mm_cvtsd_si64x(a: f64x2) -> i64 {
 
 /// Convert the lower double-precision (64-bit) floating-point element in `a`
 /// to a 64-bit integer with truncation.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvttsd2si))]
 pub unsafe fn _mm_cvttsd_si64(a: f64x2) -> i64 {
@@ -40,7 +40,7 @@ pub unsafe fn _mm_cvttsd_si64(a: f64x2) -> i64 {
 }
 
 /// Alias for [`_mm_cvttsd_si64`](fn._mm_cvttsd_si64_ss.html).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvttsd2si))]
 pub unsafe fn _mm_cvttsd_si64x(a: f64x2) -> i64 {
@@ -50,7 +50,7 @@ pub unsafe fn _mm_cvttsd_si64x(a: f64x2) -> i64 {
 /// Stores a 64-bit integer value in the specified memory location.
 /// To minimize caching, the data is flagged as non-temporal (unlikely to be
 /// used again soon).
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 // FIXME movnti on windows and linux x86_64
 //#[cfg_attr(test, assert_instr(movntiq))]
@@ -60,7 +60,7 @@ pub unsafe fn _mm_stream_si64(mem_addr: *mut i64, a: i64) {
 
 /// Return a vector whose lowest element is `a` and all higher elements are
 /// `0`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movq))]
 pub unsafe fn _mm_cvtsi64_si128(a: i64) -> i64x2 {
@@ -69,7 +69,7 @@ pub unsafe fn _mm_cvtsi64_si128(a: i64) -> i64x2 {
 
 /// Return a vector whose lowest element is `a` and all higher elements are
 /// `0`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movq))]
 pub unsafe fn _mm_cvtsi64x_si128(a: i64) -> i64x2 {
@@ -77,7 +77,7 @@ pub unsafe fn _mm_cvtsi64x_si128(a: i64) -> i64x2 {
 }
 
 /// Return the lowest element of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movq))]
 pub unsafe fn _mm_cvtsi128_si64(a: i64x2) -> i64 {
@@ -85,7 +85,7 @@ pub unsafe fn _mm_cvtsi128_si64(a: i64x2) -> i64 {
 }
 
 /// Return the lowest element of `a`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(all(test, not(windows)), assert_instr(movq))]
 pub unsafe fn _mm_cvtsi128_si64x(a: i64x2) -> i64 {
@@ -94,7 +94,7 @@ pub unsafe fn _mm_cvtsi128_si64x(a: i64x2) -> i64 {
 
 /// Return `a` with its lower element replaced by `b` after converting it to
 /// an `f64`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtsi2sd))]
 pub unsafe fn _mm_cvtsi64_sd(a: f64x2, b: i64) -> f64x2 {
@@ -103,7 +103,7 @@ pub unsafe fn _mm_cvtsi64_sd(a: f64x2, b: i64) -> f64x2 {
 
 /// Return `a` with its lower element replaced by `b` after converting it to
 /// an `f64`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(cvtsi2sd))]
 pub unsafe fn _mm_cvtsi64x_sd(a: f64x2, b: i64) -> f64x2 {

--- a/coresimd/src/x86/x86_64/sse41.rs
+++ b/coresimd/src/x86/x86_64/sse41.rs
@@ -6,7 +6,7 @@ use v128::*;
 use stdsimd_test::assert_instr;
 
 /// Extract an 64-bit integer from `a` selected with `imm8`
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 // TODO: Add test for Windows
 #[cfg_attr(all(test, not(windows)), assert_instr(pextrq, imm8 = 1))]
@@ -17,7 +17,7 @@ pub unsafe fn _mm_extract_epi64(a: i64x2, imm8: i32) -> i64 {
 
 /// Return a copy of `a` with the 64-bit integer from `i` inserted at a
 /// location specified by `imm8`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pinsrq, imm8 = 0))]
 pub unsafe fn _mm_insert_epi64(a: i64x2, i: i64, imm8: i32) -> i64x2 {

--- a/coresimd/src/x86/x86_64/sse42.rs
+++ b/coresimd/src/x86/x86_64/sse42.rs
@@ -11,7 +11,7 @@ extern "C" {
 
 /// Starting with the initial value in `crc`, return the accumulated
 /// CRC32 value for unsigned 64-bit integer `v`.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "sse4.2")]
 #[cfg_attr(test, assert_instr(crc32))]
 pub unsafe fn _mm_crc32_u64(crc: u64, v: u64) -> u64 {

--- a/coresimd/src/x86/x86_64/xsave.rs
+++ b/coresimd/src/x86/x86_64/xsave.rs
@@ -29,7 +29,7 @@ extern "C" {
 ///
 /// The format of the XSAVE area is detailed in Section 13.4, “XSAVE Area,” of
 /// Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 1.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave")]
 #[cfg_attr(test, assert_instr(xsave64))]
 pub unsafe fn _xsave64(mem_addr: *mut u8, save_mask: u64) {
@@ -42,7 +42,7 @@ pub unsafe fn _xsave64(mem_addr: *mut u8, save_mask: u64) {
 /// State is restored based on bits [62:0] in `rs_mask`, `XCR0`, and
 /// `mem_addr.HEADER.XSTATE_BV`. `mem_addr` must be aligned on a 64-byte
 /// boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave")]
 #[cfg_attr(test, assert_instr(xrstor64))]
 pub unsafe fn _xrstor64(mem_addr: *const u8, rs_mask: u64) {
@@ -56,7 +56,7 @@ pub unsafe fn _xrstor64(mem_addr: *const u8, rs_mask: u64) {
 /// `mem_addr` must be aligned on a 64-byte boundary. The hardware may optimize
 /// the manner in which data is saved. The performance of this instruction will
 /// be equal to or better than using the `XSAVE64` instruction.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave,xsaveopt")]
 #[cfg_attr(test, assert_instr(xsaveopt64))]
 pub unsafe fn _xsaveopt64(mem_addr: *mut u8, save_mask: u64) {
@@ -69,7 +69,7 @@ pub unsafe fn _xsaveopt64(mem_addr: *mut u8, save_mask: u64) {
 /// `xsavec` differs from `xsave` in that it uses compaction and that it may
 /// use init optimization. State is saved based on bits [62:0] in `save_mask`
 /// and `XCR0`. `mem_addr` must be aligned on a 64-byte boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave,xsavec")]
 #[cfg_attr(test, assert_instr(xsavec64))]
 pub unsafe fn _xsavec64(mem_addr: *mut u8, save_mask: u64) {
@@ -83,7 +83,7 @@ pub unsafe fn _xsavec64(mem_addr: *mut u8, save_mask: u64) {
 /// corresponding to bits set in `IA32_XSS` `MSR` and that it may use the
 /// modified optimization. State is saved based on bits [62:0] in `save_mask`
 /// and `XCR0`. `mem_addr` must be aligned on a 64-byte boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave,xsaves")]
 #[cfg_attr(test, assert_instr(xsaves64))]
 pub unsafe fn _xsaves64(mem_addr: *mut u8, save_mask: u64) {
@@ -99,7 +99,7 @@ pub unsafe fn _xsaves64(mem_addr: *mut u8, save_mask: u64) {
 /// State is restored based on bits [62:0] in `rs_mask`, `XCR0`, and
 /// `mem_addr.HEADER.XSTATE_BV`. `mem_addr` must be aligned on a 64-byte
 /// boundary.
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "xsave,xsaves")]
 #[cfg_attr(test, assert_instr(xrstors64))]
 pub unsafe fn _xrstors64(mem_addr: *const u8, rs_mask: u64) {

--- a/coresimd/tests/cpu-detection.rs
+++ b/coresimd/tests/cpu-detection.rs
@@ -34,7 +34,7 @@ fn x86_all() {
     );
     println!("fma: {:?}", cfg_feature_enabled!("fma"));
     println!("abm: {:?}", cfg_feature_enabled!("abm"));
-    println!("bmi: {:?}", cfg_feature_enabled!("bmi"));
+    println!("bmi: {:?}", cfg_feature_enabled!("bmi1"));
     println!("bmi2: {:?}", cfg_feature_enabled!("bmi2"));
     println!("tbm: {:?}", cfg_feature_enabled!("tbm"));
     println!("popcnt: {:?}", cfg_feature_enabled!("popcnt"));

--- a/stdsimd-test/assert-instr-macro/src/lib.rs
+++ b/stdsimd-test/assert-instr-macro/src/lib.rs
@@ -10,8 +10,8 @@
 
 #![feature(proc_macro)]
 
-extern crate proc_macro2;
 extern crate proc_macro;
+extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
 #[macro_use]
@@ -39,59 +39,71 @@ pub fn assert_instr(
         (quote! { #[ignore] }).into()
     };
     let name = &func.ident;
+    use quote::ToTokens;
+    let instr_str = instr
+        .clone()
+        .into_tokens()
+        .to_string()
+        .replace('.', "_")
+        .replace(|c: char| c.is_whitespace(), "");
     let assert_name = syn::Ident::from(
-        &format!("assert_{}_{}", name.as_ref(), instr.as_ref())[..],
+        &format!("assert_{}_{}", name.as_ref(), instr_str)[..],
     );
     let shim_name = syn::Ident::from(format!("{}_shim", name.as_ref()));
-    let (to_test, test_name) = if invoc.args.len() == 0 {
-        (TokenStream::empty(), &func.ident)
-    } else {
-        let mut inputs = Vec::new();
-        let mut input_vals = Vec::new();
-        let ret = &func.decl.output;
-        for arg in func.decl.inputs.iter() {
-            let capture = match *arg {
-                syn::FnArg::Captured(ref c) => c,
-                _ => panic!("arguments must not have patterns"),
-            };
-            let ident = match capture.pat {
-                syn::Pat::Ident(ref i) => &i.ident,
-                _ => panic!("must have bare arguments"),
-            };
-            match invoc.args.iter().find(|a| a.0 == ident.as_ref()) {
-                Some(&(_, ref tts)) => {
-                    input_vals.push(quote! { #tts });
-                }
-                None => {
-                    inputs.push(capture);
-                    input_vals.push(quote! { #ident });
-                }
-            };
-        }
-
-        let attrs = func.attrs
+    let mut inputs = Vec::new();
+    let mut input_vals = Vec::new();
+    let ret = &func.decl.output;
+    for arg in func.decl.inputs.iter() {
+        let capture = match *arg {
+            syn::FnArg::Captured(ref c) => c,
+            _ => panic!("arguments must not have patterns"),
+        };
+        let ident = match capture.pat {
+            syn::Pat::Ident(ref i) => &i.ident,
+            _ => panic!("must have bare arguments"),
+        };
+        match invoc
+            .args
             .iter()
-            .filter(|attr| {
-                attr.path
-                    .segments
-                    .first()
-                    .unwrap()
-                    .value()
-                    .ident
-                    .as_ref()
-                    .starts_with("target")
-            })
-            .collect::<Vec<_>>();
-        let attrs = Append(&attrs);
-        (
-            quote! {
-                #attrs
-                unsafe fn #shim_name(#(#inputs),*) #ret {
-                    #name(#(#input_vals),*)
-                }
-            }.into(),
-            &shim_name,
-        )
+            .find(|a| a.0 == ident.as_ref())
+        {
+            Some(&(_, ref tts)) => {
+                input_vals.push(quote! { #tts });
+            }
+            None => {
+                inputs.push(capture);
+                input_vals.push(quote! { #ident });
+            }
+        };
+    }
+
+    let attrs = func.attrs
+        .iter()
+        .filter(|attr| {
+            attr.path
+                .segments
+                .first()
+                .expect("attr.path.segments.first() failed")
+                .value()
+                .ident
+                .as_ref()
+                .starts_with("target")
+        })
+        .collect::<Vec<_>>();
+    let attrs = Append(&attrs);
+
+    // Use an ABI on Windows that passes SIMD values in registers, like what
+    // happens on Unix (I think?) by default.
+    let abi = if cfg!(windows) {
+        syn::LitStr::new("vectorcall", proc_macro2::Span::call_site())
+    } else {
+        syn::LitStr::new("C", proc_macro2::Span::call_site())
+    };
+    let to_test = quote! {
+        #attrs
+        unsafe extern #abi fn #shim_name(#(#inputs),*) #ret {
+            #name(#(#input_vals),*)
+        }
     };
 
     let tts: TokenStream = quote_spanned! {
@@ -102,13 +114,15 @@ pub fn assert_instr(
         fn #assert_name() {
             #to_test
 
-            ::stdsimd_test::assert(#test_name as usize,
-                                   stringify!(#test_name),
+            ::stdsimd_test::assert(#shim_name as usize,
+                                   stringify!(#shim_name),
                                    stringify!(#instr));
         }
     }.into();
     // why? necessary now to get tests to work?
-    let tts: TokenStream = tts.to_string().parse().unwrap();
+    let tts: TokenStream = tts.to_string()
+        .parse()
+        .expect("cannot parse tokenstream");
 
     let tts: TokenStream = quote! {
         #item
@@ -118,13 +132,13 @@ pub fn assert_instr(
 }
 
 struct Invoc {
-    instr: syn::Ident,
+    instr: syn::Expr,
     args: Vec<(syn::Ident, syn::Expr)>,
 }
 
 impl syn::synom::Synom for Invoc {
     named!(parse -> Self, map!(parens!(do_parse!(
-        instr: syn!(syn::Ident) >>
+        instr: syn!(syn::Expr) >>
         args: many0!(do_parse!(
             syn!(syn::token::Comma) >>
             name: syn!(syn::Ident) >>

--- a/tests/cpu-detection.rs
+++ b/tests/cpu-detection.rs
@@ -58,7 +58,7 @@ fn x86_all() {
     );
     println!("fma: {:?}", cfg_feature_enabled!("fma"));
     println!("abm: {:?}", cfg_feature_enabled!("abm"));
-    println!("bmi: {:?}", cfg_feature_enabled!("bmi"));
+    println!("bmi: {:?}", cfg_feature_enabled!("bmi1"));
     println!("bmi2: {:?}", cfg_feature_enabled!("bmi2"));
     println!("tbm: {:?}", cfg_feature_enabled!("tbm"));
     println!("popcnt: {:?}", cfg_feature_enabled!("popcnt"));


### PR DESCRIPTION
This makes the before-vendor-types branch compile on newer versions of rustc. Would it be possible to release this a 0.0.4-1 or something similar? Everything on crates.io at the moment won't compile on the latest nightly.