### PR TITLE
updates intel SDE version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ matrix:
     - env: DOCUMENTATION
       install: true
       script: ci/dox.sh
-    - script: cargo test --manifest-path crates/stdsimd-verify/Cargo.toml
+    - env: VERIFY_X86
+      script: cargo test --manifest-path crates/stdsimd-verify/Cargo.toml
       install: true
     - env: RUSTFMT=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
       before_script:
@@ -54,6 +55,7 @@ matrix:
         cargo clippy --all -- -D clippy-pedantic
   allow_failures:
     - env: CLIPPY=On TARGET=x86_64-unknown-linux-gnu NO_ADD=1
+    - env: VERIFY_X86
 
 before_install:
   # FIXME (travis-ci/travis-ci#8920) shouldn't be necessary...

--- a/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   libc6-dev \

--- a/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu-emulated/Dockerfile
@@ -8,6 +8,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
   bzip2
 
-RUN wget https://github.com/gnzlbg/intel_sde/raw/master/sde-external-8.12.0-2017-10-23-lin.tar.bz2
-RUN tar -xjf sde-external-8.12.0-2017-10-23-lin.tar.bz2
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/sde-external-8.12.0-2017-10-23-lin/sde64 --"
+RUN wget https://github.com/gnzlbg/intel_sde/raw/master/sde-external-8.16.0-2018-01-30-lin.tar.bz2
+RUN tar -xjf sde-external-8.16.0-2018-01-30-lin.tar.bz2
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/sde-external-8.16.0-2018-01-30-lin/sde64 --"

--- a/coresimd/ppsv/api/arithmetic_ops.rs
+++ b/coresimd/ppsv/api/arithmetic_ops.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_arithmetic_ops {
-    ($id: ident) => {
+    ($id:ident) => {
         impl ::ops::Add for $id {
             type Output = Self;
             #[inline]
@@ -87,7 +87,7 @@ macro_rules! impl_arithmetic_ops {
 
 #[cfg(test)]
 macro_rules! test_arithmetic_ops {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn arithmetic() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/arithmetic_reductions.rs
+++ b/coresimd/ppsv/api/arithmetic_reductions.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_arithmetic_reductions {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl $id {
             /// Lane-wise addition of the vector elements.
             ///
@@ -65,7 +65,7 @@ macro_rules! impl_arithmetic_reductions {
 
 #[cfg(test)]
 macro_rules! test_arithmetic_reductions {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         fn alternating(x: usize) -> ::coresimd::simd::$id {
             use coresimd::simd::$id;
             let mut v = $id::splat(1 as $elem_ty);

--- a/coresimd/ppsv/api/arithmetic_scalar_ops.rs
+++ b/coresimd/ppsv/api/arithmetic_scalar_ops.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_arithmetic_scalar_ops {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl ::ops::Add<$elem_ty> for $id {
             type Output = Self;
             #[inline]
@@ -117,7 +117,7 @@ macro_rules! impl_arithmetic_scalar_ops {
 
 #[cfg(test)]
 macro_rules! test_arithmetic_scalar_ops {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn arithmetic_scalar() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/bitwise_ops.rs
+++ b/coresimd/ppsv/api/bitwise_ops.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_bitwise_ops {
-    ($id: ident, $true_val: expr) => {
+    ($id:ident, $true_val:expr) => {
         impl ::ops::Not for $id {
             type Output = Self;
             #[inline]
@@ -57,7 +57,7 @@ macro_rules! impl_bitwise_ops {
 
 #[cfg(test)]
 macro_rules! test_int_bitwise_ops {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn bitwise_ops() {
             use coresimd::simd::$id;
@@ -124,7 +124,7 @@ macro_rules! test_int_bitwise_ops {
 
 #[cfg(test)]
 macro_rules! test_bool_bitwise_ops {
-    ($id: ident) => {
+    ($id:ident) => {
         #[test]
         fn bool_arithmetic() {
             use coresimd::simd::*;

--- a/coresimd/ppsv/api/bitwise_reductions.rs
+++ b/coresimd/ppsv/api/bitwise_reductions.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_bitwise_reductions {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl $id {
             /// Lane-wise bitwise `and` of the vector elements.
             #[cfg(not(target_arch = "aarch64"))]
@@ -68,7 +68,7 @@ macro_rules! impl_bitwise_reductions {
 }
 
 macro_rules! impl_bool_bitwise_reductions {
-    ($id: ident, $elem_ty: ident, $internal_ty: ident) => {
+    ($id:ident, $elem_ty:ident, $internal_ty:ident) => {
         impl $id {
             /// Lane-wise bitwise `and` of the vector elements.
             #[cfg(not(target_arch = "aarch64"))]
@@ -144,7 +144,7 @@ macro_rules! impl_bool_bitwise_reductions {
 
 #[cfg(test)]
 macro_rules! test_bitwise_reductions {
-    ($id: ident, $true: expr) => {
+    ($id:ident, $true:expr) => {
         #[test]
         fn and() {
             let false_ = !$true;

--- a/coresimd/ppsv/api/bitwise_scalar_ops.rs
+++ b/coresimd/ppsv/api/bitwise_scalar_ops.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_bitwise_scalar_ops {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl ::ops::BitXor<$elem_ty> for $id {
             type Output = Self;
             #[inline]
@@ -71,7 +71,7 @@ macro_rules! impl_bitwise_scalar_ops {
 
 #[cfg(test)]
 macro_rules! test_int_bitwise_scalar_ops {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn bitwise_scalar_ops() {
             use coresimd::simd::$id;
@@ -157,7 +157,7 @@ macro_rules! test_int_bitwise_scalar_ops {
 
 #[cfg(test)]
 macro_rules! test_bool_bitwise_scalar_ops {
-    ($id: ident) => {
+    ($id:ident) => {
         #[test]
         fn bool_scalar_arithmetic() {
             use coresimd::simd::*;

--- a/coresimd/ppsv/api/bool_vectors.rs
+++ b/coresimd/ppsv/api/bool_vectors.rs
@@ -89,7 +89,7 @@ macro_rules! impl_bool_minimal {
 
 #[cfg(test)]
 macro_rules! test_bool_minimal {
-    ($id: ident, $elem_count: expr) => {
+    ($id:ident, $elem_count:expr) => {
         #[test]
         fn minimal() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/boolean_reductions.rs
+++ b/coresimd/ppsv/api/boolean_reductions.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_bool_reductions {
-    ($id: ident) => {
+    ($id:ident) => {
         impl $id {
             /// Are `all` vector lanes `true`?
             #[cfg(not(target_arch = "aarch64"))]
@@ -47,7 +47,7 @@ macro_rules! impl_bool_reductions {
 
 #[cfg(test)]
 macro_rules! test_bool_reductions {
-    ($id: ident) => {
+    ($id:ident) => {
         #[test]
         fn all() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/cmp.rs
+++ b/coresimd/ppsv/api/cmp.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_cmp {
-    ($id: ident, $bool_ty: ident) => {
+    ($id:ident, $bool_ty:ident) => {
         impl $id {
             /// Lane-wise equality comparison.
             #[inline]
@@ -50,7 +50,7 @@ macro_rules! impl_cmp {
 }
 
 macro_rules! impl_bool_cmp {
-    ($id: ident, $bool_ty: ident) => {
+    ($id:ident, $bool_ty:ident) => {
         impl $id {
             /// Lane-wise equality comparison.
             #[inline]
@@ -99,13 +99,7 @@ macro_rules! impl_bool_cmp {
 
 #[cfg(test)]
 macro_rules! test_cmp {
-    (
-        $id: ident,
-        $elem_ty: ident,
-        $bool_ty: ident,
-        $true: expr,
-        $false: expr
-    ) => {
+    ($id:ident, $elem_ty:ident, $bool_ty:ident, $true:expr, $false:expr) => {
         #[test]
         fn cmp() {
             use coresimd::simd::*;

--- a/coresimd/ppsv/api/default.rs
+++ b/coresimd/ppsv/api/default.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_default {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl ::default::Default for $id {
             #[inline]
             fn default() -> Self {
@@ -14,7 +14,7 @@ macro_rules! impl_default {
 
 #[cfg(test)]
 macro_rules! test_default {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn default() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/eq.rs
+++ b/coresimd/ppsv/api/eq.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_eq {
-    ($id: ident) => {
+    ($id:ident) => {
         impl ::cmp::Eq for $id {}
     };
 }

--- a/coresimd/ppsv/api/fmt.rs
+++ b/coresimd/ppsv/api/fmt.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_hex_fmt {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl ::fmt::LowerHex for $id {
             fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
                 use mem;
@@ -140,7 +140,7 @@ macro_rules! test_hex_fmt_impl {
 
 #[cfg(test)]
 macro_rules! test_hex_fmt {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         test_hex_fmt_impl!(
             $id,
             $elem_ty,

--- a/coresimd/ppsv/api/from.rs
+++ b/coresimd/ppsv/api/from.rs
@@ -3,7 +3,7 @@
 #![allow(unused)]
 
 macro_rules! impl_from_impl {
-    ($from: ident, $to: ident) => {
+    ($from:ident, $to:ident) => {
         impl ::convert::From<::simd::$from> for $to {
             #[inline]
             fn from(f: ::simd::$from) -> $to {
@@ -15,7 +15,7 @@ macro_rules! impl_from_impl {
 }
 
 macro_rules! impl_from_ {
-    ($to: ident, $from: ident) => {
+    ($to:ident, $from:ident) => {
         vector_impl!([impl_from_impl, $to, $from]);
     };
 }

--- a/coresimd/ppsv/api/hash.rs
+++ b/coresimd/ppsv/api/hash.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_hash {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl ::hash::Hash for $id {
             #[inline]
             fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
@@ -18,7 +18,7 @@ macro_rules! impl_hash {
 
 #[cfg(test)]
 macro_rules! test_hash {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn hash() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/load_store.rs
+++ b/coresimd/ppsv/api/load_store.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_load_store {
-    ($id: ident, $elem_ty: ident, $elem_count: expr) => {
+    ($id:ident, $elem_ty:ident, $elem_count:expr) => {
         impl $id {
             /// Writes the values of the vector to the `slice`.
             ///
@@ -149,7 +149,7 @@ macro_rules! impl_load_store {
 
 #[cfg(test)]
 macro_rules! test_load_store {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn store_unaligned() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/minimal.rs
+++ b/coresimd/ppsv/api/minimal.rs
@@ -84,7 +84,7 @@ macro_rules! impl_minimal {
 
 #[cfg(test)]
 macro_rules! test_minimal {
-    ($id: ident, $elem_ty: ident, $elem_count: expr) => {
+    ($id:ident, $elem_ty:ident, $elem_count:expr) => {
         #[test]
         fn minimal() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/minmax_reductions.rs
+++ b/coresimd/ppsv/api/minmax_reductions.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_minmax_reductions {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl $id {
             /// Largest vector value.
             ///
@@ -63,7 +63,7 @@ macro_rules! impl_minmax_reductions {
 
 #[cfg(test)]
 macro_rules! test_minmax_reductions {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn max() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/neg.rs
+++ b/coresimd/ppsv/api/neg.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_neg_op {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl ::ops::Neg for $id {
             type Output = Self;
             #[inline]
@@ -15,7 +15,7 @@ macro_rules! impl_neg_op {
 
 #[cfg(test)]
 macro_rules! test_neg_op {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn neg() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/api/partial_eq.rs
+++ b/coresimd/ppsv/api/partial_eq.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_partial_eq {
-    ($id: ident) => {
+    ($id:ident) => {
         impl ::cmp::PartialEq<$id> for $id {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
@@ -18,7 +18,7 @@ macro_rules! impl_partial_eq {
 
 #[cfg(test)]
 macro_rules! test_partial_eq {
-    ($id: ident, $true: expr, $false: expr) => {
+    ($id:ident, $true:expr, $false:expr) => {
         #[test]
         fn partial_eq() {
             use coresimd::simd::*;

--- a/coresimd/ppsv/api/scalar_shifts.rs
+++ b/coresimd/ppsv/api/scalar_shifts.rs
@@ -39,7 +39,7 @@ macro_rules! impl_shifts {
 }
 
 macro_rules! impl_all_scalar_shifts {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl_shifts!(
             $id,
             $elem_ty,
@@ -123,7 +123,7 @@ macro_rules! test_shift_ops {
 
 #[cfg(test)]
 macro_rules! test_all_scalar_shift_ops {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         test_shift_ops!(
             $id,
             $elem_ty,

--- a/coresimd/ppsv/api/shifts.rs
+++ b/coresimd/ppsv/api/shifts.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 
 macro_rules! impl_vector_shifts {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         impl ::ops::Shl<$id> for $id {
             type Output = Self;
             #[inline]
@@ -36,7 +36,7 @@ macro_rules! impl_vector_shifts {
 
 #[cfg(test)]
 macro_rules! test_vector_shift_ops {
-    ($id: ident, $elem_ty: ident) => {
+    ($id:ident, $elem_ty:ident) => {
         #[test]
         fn shift_ops() {
             use coresimd::simd::$id;

--- a/coresimd/ppsv/v128.rs
+++ b/coresimd/ppsv/v128.rs
@@ -84,7 +84,7 @@ use coresimd::arch::x86::{__m128, __m128d, __m128i};
 use coresimd::arch::x86_64::{__m128, __m128d, __m128i};
 
 macro_rules! from_bits_x86 {
-    ($id: ident, $elem_ty: ident, $test_mod: ident) => {
+    ($id:ident, $elem_ty:ident, $test_mod:ident) => {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         impl_from_bits_!($id: __m128, __m128i, __m128d);
     };
@@ -121,12 +121,7 @@ use coresimd::arch::aarch64::{// FIXME: float16x8_t,
                               uint8x16_t};
 
 macro_rules! from_bits_arm {
-    (
-        $id: ident,
-        $elem_ty: ident,
-        $test_mod_arm: ident,
-        $test_mod_a64: ident
-    ) => {
+    ($id:ident, $elem_ty:ident, $test_mod_arm:ident, $test_mod_a64:ident) => {
         #[cfg(any(all(target_arch = "arm", target_feature = "neon",
                       target_feature = "v7"),
                   target_arch = "aarch64"))]

--- a/coresimd/ppsv/v256.rs
+++ b/coresimd/ppsv/v256.rs
@@ -100,7 +100,7 @@ use coresimd::arch::x86::{__m256, __m256d, __m256i};
 use coresimd::arch::x86_64::{__m256, __m256d, __m256i};
 
 macro_rules! from_bits_x86 {
-    ($id: ident, $elem_ty: ident, $test_mod: ident) => {
+    ($id:ident, $elem_ty:ident, $test_mod:ident) => {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         impl_from_bits_!($id: __m256, __m256i, __m256d);
     };

--- a/coresimd/ppsv/v64.rs
+++ b/coresimd/ppsv/v64.rs
@@ -64,7 +64,7 @@ use coresimd::arch::x86::__m64;
 use coresimd::arch::x86_64::__m64;
 
 macro_rules! from_bits_x86 {
-    ($id: ident, $elem_ty: ident, $test_mod: ident) => {
+    ($id:ident, $elem_ty:ident, $test_mod:ident) => {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         impl_from_bits_!($id: __m64);
     };
@@ -101,12 +101,7 @@ use coresimd::arch::aarch64::{// FIXME: float16x4_t,
                               uint8x8_t};
 
 macro_rules! from_bits_arm {
-    (
-        $id: ident,
-        $elem_ty: ident,
-        $test_mod_arm: ident,
-        $test_mod_a64: ident
-    ) => {
+    ($id:ident, $elem_ty:ident, $test_mod_arm:ident, $test_mod_a64:ident) => {
         #[cfg(any(all(target_arch = "arm", target_feature = "neon",
                       target_feature = "v7"),
                   target_arch = "aarch64"))]

--- a/coresimd/x86/aes.rs
+++ b/coresimd/x86/aes.rs
@@ -79,7 +79,7 @@ pub unsafe fn _mm_aesimc_si128(a: __m128i) -> __m128i {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_aeskeygenassist_si128(a: __m128i, imm8: i32) -> __m128i {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             aeskeygenassist(a, $imm8)
         };
     }

--- a/coresimd/x86/avx.rs
+++ b/coresimd/x86/avx.rs
@@ -99,12 +99,12 @@ pub unsafe fn _mm256_or_ps(a: __m256, b: __m256) -> __m256 {
 pub unsafe fn _mm256_shuffle_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             simd_shuffle4(a, b, [$a, $b, $c, $d]);
         };
     }
     macro_rules! shuffle3 {
-        ($a: expr, $b: expr, $c: expr) => {
+        ($a:expr, $b:expr, $c:expr) => {
             match (imm8 >> 3) & 0x1 {
                 0 => shuffle4!($a, $b, $c, 6),
                 _ => shuffle4!($a, $b, $c, 7),
@@ -112,7 +112,7 @@ pub unsafe fn _mm256_shuffle_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
         };
     }
     macro_rules! shuffle2 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match (imm8 >> 2) & 0x1 {
                 0 => shuffle3!($a, $b, 2),
                 _ => shuffle3!($a, $b, 3),
@@ -120,7 +120,7 @@ pub unsafe fn _mm256_shuffle_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
         };
     }
     macro_rules! shuffle1 {
-        ($a: expr) => {
+        ($a:expr) => {
             match (imm8 >> 1) & 0x1 {
                 0 => shuffle2!($a, 4),
                 _ => shuffle2!($a, 5),
@@ -143,20 +143,20 @@ pub unsafe fn _mm256_shuffle_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
         (
-            $a: expr,
-            $b: expr,
-            $c: expr,
-            $d: expr,
-            $e: expr,
-            $f: expr,
-            $g: expr,
-            $h: expr
+            $a:expr,
+            $b:expr,
+            $c:expr,
+            $d:expr,
+            $e:expr,
+            $f:expr,
+            $g:expr,
+            $h:expr
         ) => {
             simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
         };
     }
     macro_rules! shuffle3 {
-        ($a: expr, $b: expr, $c: expr, $e: expr, $f: expr, $g: expr) => {
+        ($a:expr, $b:expr, $c:expr, $e:expr, $f:expr, $g:expr) => {
             match (imm8 >> 6) & 0x3 {
                 0 => shuffle4!($a, $b, $c, 8, $e, $f, $g, 12),
                 1 => shuffle4!($a, $b, $c, 9, $e, $f, $g, 13),
@@ -166,7 +166,7 @@ pub unsafe fn _mm256_shuffle_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
         };
     }
     macro_rules! shuffle2 {
-        ($a: expr, $b: expr, $e: expr, $f: expr) => {
+        ($a:expr, $b:expr, $e:expr, $f:expr) => {
             match (imm8 >> 4) & 0x3 {
                 0 => shuffle3!($a, $b, 8, $e, $f, 12),
                 1 => shuffle3!($a, $b, 9, $e, $f, 13),
@@ -176,7 +176,7 @@ pub unsafe fn _mm256_shuffle_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
         };
     }
     macro_rules! shuffle1 {
-        ($a: expr, $e: expr) => {
+        ($a:expr, $e:expr) => {
             match (imm8 >> 2) & 0x3 {
                 0 => shuffle2!($a, 0, $e, 4),
                 1 => shuffle2!($a, 1, $e, 5),
@@ -343,7 +343,7 @@ pub unsafe fn _mm256_div_pd(a: __m256d, b: __m256d) -> __m256d {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm256_round_pd(a: __m256d, b: i32) -> __m256d {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             roundpd256(a, $imm8)
         };
     }
@@ -385,7 +385,7 @@ pub unsafe fn _mm256_floor_pd(a: __m256d) -> __m256d {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm256_round_ps(a: __m256, b: i32) -> __m256 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             roundps256(a, $imm8)
         };
     }
@@ -437,12 +437,12 @@ pub unsafe fn _mm256_sqrt_pd(a: __m256d) -> __m256d {
 pub unsafe fn _mm256_blend_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! blend4 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             simd_shuffle4(a, b, [$a, $b, $c, $d]);
         };
     }
     macro_rules! blend3 {
-        ($a: expr, $b: expr, $c: expr) => {
+        ($a:expr, $b:expr, $c:expr) => {
             match imm8 & 0x8 {
                 0 => blend4!($a, $b, $c, 3),
                 _ => blend4!($a, $b, $c, 7),
@@ -450,7 +450,7 @@ pub unsafe fn _mm256_blend_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
         };
     }
     macro_rules! blend2 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match imm8 & 0x4 {
                 0 => blend3!($a, $b, 2),
                 _ => blend3!($a, $b, 6),
@@ -458,7 +458,7 @@ pub unsafe fn _mm256_blend_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
         };
     }
     macro_rules! blend1 {
-        ($a: expr) => {
+        ($a:expr) => {
             match imm8 & 0x2 {
                 0 => blend2!($a, 1),
                 _ => blend2!($a, 5),
@@ -481,20 +481,20 @@ pub unsafe fn _mm256_blend_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! blend4 {
         (
-            $a: expr,
-            $b: expr,
-            $c: expr,
-            $d: expr,
-            $e: expr,
-            $f: expr,
-            $g: expr,
-            $h: expr
+            $a:expr,
+            $b:expr,
+            $c:expr,
+            $d:expr,
+            $e:expr,
+            $f:expr,
+            $g:expr,
+            $h:expr
         ) => {
             simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
         };
     }
     macro_rules! blend3 {
-        ($a: expr, $b: expr, $c: expr, $d: expr, $e: expr, $f: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => blend4!($a, $b, $c, $d, $e, $f, 6, 7),
                 0b01 => blend4!($a, $b, $c, $d, $e, $f, 14, 7),
@@ -504,7 +504,7 @@ pub unsafe fn _mm256_blend_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
         };
     }
     macro_rules! blend2 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => blend3!($a, $b, $c, $d, 4, 5),
                 0b01 => blend3!($a, $b, $c, $d, 12, 5),
@@ -514,7 +514,7 @@ pub unsafe fn _mm256_blend_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
         };
     }
     macro_rules! blend1 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => blend2!($a, $b, 2, 3),
                 0b01 => blend2!($a, $b, 10, 3),
@@ -559,7 +559,7 @@ pub unsafe fn _mm256_blendv_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm256_dp_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vdpps(a, b, $imm8)
         };
     }
@@ -709,7 +709,7 @@ pub const _CMP_TRUE_US: i32 = 0x1f;
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_cmp_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vcmppd(a, b, $imm8)
         };
     }
@@ -725,7 +725,7 @@ pub unsafe fn _mm_cmp_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm256_cmp_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vcmppd256(a, b, $imm8)
         };
     }
@@ -741,7 +741,7 @@ pub unsafe fn _mm256_cmp_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_cmp_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vcmpps(a, b, $imm8)
         };
     }
@@ -757,7 +757,7 @@ pub unsafe fn _mm_cmp_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm256_cmp_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vcmpps256(a, b, $imm8)
         };
     }
@@ -775,7 +775,7 @@ pub unsafe fn _mm256_cmp_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_cmp_sd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vcmpsd(a, b, $imm8)
         };
     }
@@ -793,7 +793,7 @@ pub unsafe fn _mm_cmp_sd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_cmp_ss(a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vcmpss(a, b, $imm8)
         };
     }
@@ -956,7 +956,7 @@ pub unsafe fn _mm_permutevar_ps(a: __m128, b: __m128i) -> __m128 {
 pub unsafe fn _mm256_permute_ps(a: __m256, imm8: i32) -> __m256 {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             simd_shuffle8(
                 a,
                 _mm256_undefined_ps(),
@@ -965,7 +965,7 @@ pub unsafe fn _mm256_permute_ps(a: __m256, imm8: i32) -> __m256 {
         };
     }
     macro_rules! shuffle3 {
-        ($a: expr, $b: expr, $c: expr) => {
+        ($a:expr, $b:expr, $c:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle4!($a, $b, $c, 0),
                 0b01 => shuffle4!($a, $b, $c, 1),
@@ -975,7 +975,7 @@ pub unsafe fn _mm256_permute_ps(a: __m256, imm8: i32) -> __m256 {
         };
     }
     macro_rules! shuffle2 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle3!($a, $b, 0),
                 0b01 => shuffle3!($a, $b, 1),
@@ -985,7 +985,7 @@ pub unsafe fn _mm256_permute_ps(a: __m256, imm8: i32) -> __m256 {
         };
     }
     macro_rules! shuffle1 {
-        ($a: expr) => {
+        ($a:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle2!($a, 0),
                 0b01 => shuffle2!($a, 1),
@@ -1011,12 +1011,12 @@ pub unsafe fn _mm256_permute_ps(a: __m256, imm8: i32) -> __m256 {
 pub unsafe fn _mm_permute_ps(a: __m128, imm8: i32) -> __m128 {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             simd_shuffle4(a, _mm_undefined_ps(), [$a, $b, $c, $d])
         };
     }
     macro_rules! shuffle3 {
-        ($a: expr, $b: expr, $c: expr) => {
+        ($a:expr, $b:expr, $c:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle4!($a, $b, $c, 0),
                 0b01 => shuffle4!($a, $b, $c, 1),
@@ -1026,7 +1026,7 @@ pub unsafe fn _mm_permute_ps(a: __m128, imm8: i32) -> __m128 {
         };
     }
     macro_rules! shuffle2 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle3!($a, $b, 0),
                 0b01 => shuffle3!($a, $b, 1),
@@ -1036,7 +1036,7 @@ pub unsafe fn _mm_permute_ps(a: __m128, imm8: i32) -> __m128 {
         };
     }
     macro_rules! shuffle1 {
-        ($a: expr) => {
+        ($a:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle2!($a, 0),
                 0b01 => shuffle2!($a, 1),
@@ -1080,12 +1080,12 @@ pub unsafe fn _mm_permutevar_pd(a: __m128d, b: __m128i) -> __m128d {
 pub unsafe fn _mm256_permute_pd(a: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle4 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             simd_shuffle4(a, _mm256_undefined_pd(), [$a, $b, $c, $d]);
         };
     }
     macro_rules! shuffle3 {
-        ($a: expr, $b: expr, $c: expr) => {
+        ($a:expr, $b:expr, $c:expr) => {
             match (imm8 >> 3) & 0x1 {
                 0 => shuffle4!($a, $b, $c, 2),
                 _ => shuffle4!($a, $b, $c, 3),
@@ -1093,7 +1093,7 @@ pub unsafe fn _mm256_permute_pd(a: __m256d, imm8: i32) -> __m256d {
         };
     }
     macro_rules! shuffle2 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match (imm8 >> 2) & 0x1 {
                 0 => shuffle3!($a, $b, 2),
                 _ => shuffle3!($a, $b, 3),
@@ -1101,7 +1101,7 @@ pub unsafe fn _mm256_permute_pd(a: __m256d, imm8: i32) -> __m256d {
         };
     }
     macro_rules! shuffle1 {
-        ($a: expr) => {
+        ($a:expr) => {
             match (imm8 >> 1) & 0x1 {
                 0 => shuffle2!($a, 0),
                 _ => shuffle2!($a, 1),
@@ -1123,12 +1123,12 @@ pub unsafe fn _mm256_permute_pd(a: __m256d, imm8: i32) -> __m256d {
 pub unsafe fn _mm_permute_pd(a: __m128d, imm8: i32) -> __m128d {
     let imm8 = (imm8 & 0xFF) as u8;
     macro_rules! shuffle2 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             simd_shuffle2(a, _mm_undefined_pd(), [$a, $b]);
         };
     }
     macro_rules! shuffle1 {
-        ($a: expr) => {
+        ($a:expr) => {
             match (imm8 >> 1) & 0x1 {
                 0 => shuffle2!($a, 0),
                 _ => shuffle2!($a, 1),
@@ -1151,7 +1151,7 @@ pub unsafe fn _mm256_permute2f128_ps(
     a: __m256, b: __m256, imm8: i32
 ) -> __m256 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vperm2f128ps256(a, b, $imm8)
         };
     }
@@ -1168,7 +1168,7 @@ pub unsafe fn _mm256_permute2f128_pd(
     a: __m256d, b: __m256d, imm8: i32
 ) -> __m256d {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vperm2f128pd256(a, b, $imm8)
         };
     }
@@ -1187,7 +1187,7 @@ pub unsafe fn _mm256_permute2f128_si256(
     let a = a.as_i32x8();
     let b = b.as_i32x8();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vperm2f128si256(a, b, $imm8)
         };
     }

--- a/coresimd/x86/avx2.rs
+++ b/coresimd/x86/avx2.rs
@@ -330,12 +330,12 @@ pub unsafe fn _mm_blend_epi32(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i32x4();
     let b = b.as_i32x4();
     macro_rules! blend2 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             simd_shuffle4(a, b, [$a, $b, $c, $d]);
         };
     }
     macro_rules! blend1 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => blend2!($a, $b, 2, 3),
                 0b01 => blend2!($a, $b, 6, 3),
@@ -366,20 +366,20 @@ pub unsafe fn _mm256_blend_epi32(
     let b = b.as_i32x8();
     macro_rules! blend4 {
         (
-            $a: expr,
-            $b: expr,
-            $c: expr,
-            $d: expr,
-            $e: expr,
-            $f: expr,
-            $g: expr,
-            $h: expr
+            $a:expr,
+            $b:expr,
+            $c:expr,
+            $d:expr,
+            $e:expr,
+            $f:expr,
+            $g:expr,
+            $h:expr
         ) => {
             simd_shuffle8(a, b, [$a, $b, $c, $d, $e, $f, $g, $h]);
         };
     }
     macro_rules! blend3 {
-        ($a: expr, $b: expr, $c: expr, $d: expr, $e: expr, $f: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr, $f:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => blend4!($a, $b, $c, $d, $e, $f, 6, 7),
                 0b01 => blend4!($a, $b, $c, $d, $e, $f, 14, 7),
@@ -389,7 +389,7 @@ pub unsafe fn _mm256_blend_epi32(
         };
     }
     macro_rules! blend2 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => blend3!($a, $b, $c, $d, 4, 5),
                 0b01 => blend3!($a, $b, $c, $d, 12, 5),
@@ -399,7 +399,7 @@ pub unsafe fn _mm256_blend_epi32(
         };
     }
     macro_rules! blend1 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => blend2!($a, $b, 2, 3),
                 0b01 => blend2!($a, $b, 10, 3),
@@ -430,22 +430,22 @@ pub unsafe fn _mm256_blend_epi16(
     let b = b.as_i16x16();
     macro_rules! blend4 {
         (
-            $a: expr,
-            $b: expr,
-            $c: expr,
-            $d: expr,
-            $e: expr,
-            $f: expr,
-            $g: expr,
-            $h: expr,
-            $i: expr,
-            $j: expr,
-            $k: expr,
-            $l: expr,
-            $m: expr,
-            $n: expr,
-            $o: expr,
-            $p: expr
+            $a:expr,
+            $b:expr,
+            $c:expr,
+            $d:expr,
+            $e:expr,
+            $f:expr,
+            $g:expr,
+            $h:expr,
+            $i:expr,
+            $j:expr,
+            $k:expr,
+            $l:expr,
+            $m:expr,
+            $n:expr,
+            $o:expr,
+            $p:expr
         ) => {
             simd_shuffle16(
                 a,
@@ -459,18 +459,18 @@ pub unsafe fn _mm256_blend_epi16(
     }
     macro_rules! blend3 {
         (
-            $a: expr,
-            $b: expr,
-            $c: expr,
-            $d: expr,
-            $e: expr,
-            $f: expr,
-            $a2: expr,
-            $b2: expr,
-            $c2: expr,
-            $d2: expr,
-            $e2: expr,
-            $f2: expr
+            $a:expr,
+            $b:expr,
+            $c:expr,
+            $d:expr,
+            $e:expr,
+            $f:expr,
+            $a2:expr,
+            $b2:expr,
+            $c2:expr,
+            $d2:expr,
+            $e2:expr,
+            $f2:expr
         ) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => blend4!(
@@ -550,14 +550,14 @@ pub unsafe fn _mm256_blend_epi16(
     }
     macro_rules! blend2 {
         (
-            $a: expr,
-            $b: expr,
-            $c: expr,
-            $d: expr,
-            $a2: expr,
-            $b2: expr,
-            $c2: expr,
-            $d2: expr
+            $a:expr,
+            $b:expr,
+            $c:expr,
+            $d:expr,
+            $a2:expr,
+            $b2:expr,
+            $c2:expr,
+            $d2:expr
         ) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => blend3!(
@@ -620,7 +620,7 @@ pub unsafe fn _mm256_blend_epi16(
         };
     }
     macro_rules! blend1 {
-        ($a1: expr, $b1: expr, $a2: expr, $b2: expr) => {
+        ($a1:expr, $b1:expr, $a2:expr, $b2:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => blend2!($a1, $b1, 2, 3, $a2, $b2, 10, 11),
                 0b01 => blend2!($a1, $b1, 18, 3, $a2, $b2, 26, 11),
@@ -1050,7 +1050,7 @@ pub unsafe fn _mm_i32gather_epi32(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherdd(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1075,7 +1075,7 @@ pub unsafe fn _mm_mask_i32gather_epi32(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherdd(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1098,7 +1098,7 @@ pub unsafe fn _mm256_i32gather_epi32(
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherdd(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1123,7 +1123,7 @@ pub unsafe fn _mm256_mask_i32gather_epi32(
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherdd(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1146,7 +1146,7 @@ pub unsafe fn _mm_i32gather_ps(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherdps(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1167,7 +1167,7 @@ pub unsafe fn _mm_mask_i32gather_ps(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherdps(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1189,7 +1189,7 @@ pub unsafe fn _mm256_i32gather_ps(
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherdps(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1210,7 +1210,7 @@ pub unsafe fn _mm256_mask_i32gather_ps(
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherdps(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1232,7 +1232,7 @@ pub unsafe fn _mm_i32gather_epi64(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherdq(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1257,7 +1257,7 @@ pub unsafe fn _mm_mask_i32gather_epi64(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherdq(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1280,7 +1280,7 @@ pub unsafe fn _mm256_i32gather_epi64(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherdq(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1305,7 +1305,7 @@ pub unsafe fn _mm256_mask_i32gather_epi64(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherdq(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1328,7 +1328,7 @@ pub unsafe fn _mm_i32gather_pd(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherdpd(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1350,7 +1350,7 @@ pub unsafe fn _mm_mask_i32gather_pd(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherdpd(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1372,7 +1372,7 @@ pub unsafe fn _mm256_i32gather_pd(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherdpd(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1394,7 +1394,7 @@ pub unsafe fn _mm256_mask_i32gather_pd(
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherdpd(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1416,7 +1416,7 @@ pub unsafe fn _mm_i64gather_epi32(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherqd(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1441,7 +1441,7 @@ pub unsafe fn _mm_mask_i64gather_epi32(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherqd(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1464,7 +1464,7 @@ pub unsafe fn _mm256_i64gather_epi32(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherqd(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1489,7 +1489,7 @@ pub unsafe fn _mm256_mask_i64gather_epi32(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherqd(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1512,7 +1512,7 @@ pub unsafe fn _mm_i64gather_ps(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherqps(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1533,7 +1533,7 @@ pub unsafe fn _mm_mask_i64gather_ps(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherqps(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1555,7 +1555,7 @@ pub unsafe fn _mm256_i64gather_ps(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherqps(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1576,7 +1576,7 @@ pub unsafe fn _mm256_mask_i64gather_ps(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherqps(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1598,7 +1598,7 @@ pub unsafe fn _mm_i64gather_epi64(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x2();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherqq(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1623,7 +1623,7 @@ pub unsafe fn _mm_mask_i64gather_epi64(
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherqq(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1646,7 +1646,7 @@ pub unsafe fn _mm256_i64gather_epi64(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x4();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherqq(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1671,7 +1671,7 @@ pub unsafe fn _mm256_mask_i64gather_epi64(
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherqq(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1694,7 +1694,7 @@ pub unsafe fn _mm_i64gather_pd(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x2();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherqpd(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1716,7 +1716,7 @@ pub unsafe fn _mm_mask_i64gather_pd(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x2();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pgatherqpd(src, slice, offsets, mask, $imm8)
         };
     }
@@ -1738,7 +1738,7 @@ pub unsafe fn _mm256_i64gather_pd(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x4();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherqpd(zero, slice, offsets, neg_one, $imm8)
         };
     }
@@ -1760,7 +1760,7 @@ pub unsafe fn _mm256_mask_i64gather_pd(
     let slice = slice as *const i8;
     let offsets = offsets.as_i64x4();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpgatherqpd(src, slice, offsets, mask, $imm8)
         };
     }
@@ -2064,7 +2064,7 @@ pub unsafe fn _mm256_mpsadbw_epu8(
     let a = a.as_u8x32();
     let b = b.as_u8x32();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             mpsadbw(a, b, $imm8)
         };
     }
@@ -2211,12 +2211,12 @@ pub unsafe fn _mm256_permute4x64_epi64(a: __m256i, imm8: i32) -> __m256i {
     let zero = _mm256_setzero_si256().as_i64x4();
     let a = a.as_i64x4();
     macro_rules! permute4 {
-        ($a: expr, $b: expr, $c: expr, $d: expr) => {
+        ($a:expr, $b:expr, $c:expr, $d:expr) => {
             simd_shuffle4(a, zero, [$a, $b, $c, $d]);
         };
     }
     macro_rules! permute3 {
-        ($a: expr, $b: expr, $c: expr) => {
+        ($a:expr, $b:expr, $c:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => permute4!($a, $b, $c, 0),
                 0b01 => permute4!($a, $b, $c, 1),
@@ -2226,7 +2226,7 @@ pub unsafe fn _mm256_permute4x64_epi64(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! permute2 {
-        ($a: expr, $b: expr) => {
+        ($a:expr, $b:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => permute3!($a, $b, 0),
                 0b01 => permute3!($a, $b, 1),
@@ -2236,7 +2236,7 @@ pub unsafe fn _mm256_permute4x64_epi64(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! permute1 {
-        ($a: expr) => {
+        ($a:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => permute2!($a, 0),
                 0b01 => permute2!($a, 1),
@@ -2265,7 +2265,7 @@ pub unsafe fn _mm256_permute2x128_si256(
     let a = a.as_i64x4();
     let b = b.as_i64x4();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vperm2i128(a, b, $imm8)
         };
     }
@@ -2282,12 +2282,12 @@ pub unsafe fn _mm256_permute4x64_pd(a: __m256d, imm8: i32) -> __m256d {
     let imm8 = (imm8 & 0xFF) as u8;
     let undef = _mm256_undefined_pd();
     macro_rules! shuffle_done {
-        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
             simd_shuffle4(a, undef, [$x01, $x23, $x45, $x67])
         };
     }
     macro_rules! shuffle_x67 {
-        ($x01: expr, $x23: expr, $x45: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
@@ -2297,7 +2297,7 @@ pub unsafe fn _mm256_permute4x64_pd(a: __m256d, imm8: i32) -> __m256d {
         };
     }
     macro_rules! shuffle_x45 {
-        ($x01: expr, $x23: expr) => {
+        ($x01:expr, $x23:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
@@ -2307,7 +2307,7 @@ pub unsafe fn _mm256_permute4x64_pd(a: __m256d, imm8: i32) -> __m256d {
         };
     }
     macro_rules! shuffle_x23 {
-        ($x01: expr) => {
+        ($x01:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
@@ -2432,7 +2432,7 @@ pub unsafe fn _mm256_shuffle_epi32(a: __m256i, imm8: i32) -> __m256i {
 
     let a = a.as_i32x8();
     macro_rules! shuffle_done {
-        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
             simd_shuffle8(
                 a,
                 a,
@@ -2450,7 +2450,7 @@ pub unsafe fn _mm256_shuffle_epi32(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! shuffle_x67 {
-        ($x01: expr, $x23: expr, $x45: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
@@ -2460,7 +2460,7 @@ pub unsafe fn _mm256_shuffle_epi32(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! shuffle_x45 {
-        ($x01: expr, $x23: expr) => {
+        ($x01:expr, $x23:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
@@ -2470,7 +2470,7 @@ pub unsafe fn _mm256_shuffle_epi32(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! shuffle_x23 {
-        ($x01: expr) => {
+        ($x01:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
@@ -2508,7 +2508,7 @@ pub unsafe fn _mm256_shufflehi_epi16(a: __m256i, imm8: i32) -> __m256i {
         }
     }
     macro_rules! shuffle_x67 {
-        ($x01: expr, $x23: expr, $x45: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
@@ -2518,7 +2518,7 @@ pub unsafe fn _mm256_shufflehi_epi16(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! shuffle_x45 {
-        ($x01: expr, $x23: expr) => {
+        ($x01:expr, $x23:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
@@ -2528,7 +2528,7 @@ pub unsafe fn _mm256_shufflehi_epi16(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! shuffle_x23 {
-        ($x01: expr) => {
+        ($x01:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
@@ -2566,7 +2566,7 @@ pub unsafe fn _mm256_shufflelo_epi16(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! shuffle_x67 {
-        ($x01: expr, $x23: expr, $x45: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
@@ -2576,7 +2576,7 @@ pub unsafe fn _mm256_shufflelo_epi16(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! shuffle_x45 {
-        ($x01: expr, $x23: expr) => {
+        ($x01:expr, $x23:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
@@ -2586,7 +2586,7 @@ pub unsafe fn _mm256_shufflelo_epi16(a: __m256i, imm8: i32) -> __m256i {
         };
     }
     macro_rules! shuffle_x23 {
-        ($x01: expr) => {
+        ($x01:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
@@ -2696,7 +2696,7 @@ pub unsafe fn _mm256_slli_epi64(a: __m256i, imm8: i32) -> __m256i {
 pub unsafe fn _mm256_slli_si256(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpslldq(a, $imm8)
         };
     }
@@ -2711,7 +2711,7 @@ pub unsafe fn _mm256_slli_si256(a: __m256i, imm8: i32) -> __m256i {
 pub unsafe fn _mm256_bslli_epi128(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpslldq(a, $imm8)
         };
     }
@@ -2820,7 +2820,7 @@ pub unsafe fn _mm256_srav_epi32(a: __m256i, count: __m256i) -> __m256i {
 pub unsafe fn _mm256_srli_si256(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpsrldq(a, $imm8)
         };
     }
@@ -2835,7 +2835,7 @@ pub unsafe fn _mm256_srli_si256(a: __m256i, imm8: i32) -> __m256i {
 pub unsafe fn _mm256_bsrli_epi128(a: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             vpsrldq(a, $imm8)
         };
     }

--- a/coresimd/x86/macros.rs
+++ b/coresimd/x86/macros.rs
@@ -1,7 +1,7 @@
 //! Utility macros.
 
 macro_rules! constify_imm8 {
-    ($imm8: expr, $expand: ident) => {
+    ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b1111_1111 {
             0 => $expand!(0),
@@ -265,7 +265,7 @@ macro_rules! constify_imm8 {
 }
 
 macro_rules! constify_imm6 {
-    ($imm8: expr, $expand: ident) => {
+    ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b1_1111 {
             0 => $expand!(0),
@@ -305,7 +305,7 @@ macro_rules! constify_imm6 {
 }
 
 macro_rules! constify_imm4 {
-    ($imm8: expr, $expand: ident) => {
+    ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b1111 {
             0 => $expand!(0),
@@ -329,7 +329,7 @@ macro_rules! constify_imm4 {
 }
 
 macro_rules! constify_imm3 {
-    ($imm8: expr, $expand: ident) => {
+    ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b111 {
             0 => $expand!(0),
@@ -345,7 +345,7 @@ macro_rules! constify_imm3 {
 }
 
 macro_rules! constify_imm2 {
-    ($imm8: expr, $expand: ident) => {
+    ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]
         match ($imm8) & 0b11 {
             0 => $expand!(0),

--- a/coresimd/x86/pclmulqdq.rs
+++ b/coresimd/x86/pclmulqdq.rs
@@ -38,7 +38,7 @@ pub unsafe fn _mm_clmulepi64_si128(
     a: __m128i, b: __m128i, imm8: i32
 ) -> __m128i {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pclmulqdq(a, b, $imm8)
         };
     }

--- a/coresimd/x86/sha.rs
+++ b/coresimd/x86/sha.rs
@@ -68,7 +68,7 @@ pub unsafe fn _mm_sha1rnds4_epu32(
     let a = a.as_i32x4();
     let b = b.as_i32x4();
     macro_rules! call {
-        ($imm2: expr) => {
+        ($imm2:expr) => {
             sha1rnds4(a, b, $imm2)
         };
     }

--- a/coresimd/x86/sse.rs
+++ b/coresimd/x86/sse.rs
@@ -768,12 +768,12 @@ pub unsafe fn _mm_shuffle_ps(a: __m128, b: __m128, mask: u32) -> __m128 {
     let mask = (mask & 0xFF) as u8;
 
     macro_rules! shuffle_done {
-        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
             simd_shuffle4(a, b, [$x01, $x23, $x45, $x67])
         };
     }
     macro_rules! shuffle_x67 {
-        ($x01: expr, $x23: expr, $x45: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr) => {
             match (mask >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 4),
                 0b01 => shuffle_done!($x01, $x23, $x45, 5),
@@ -783,7 +783,7 @@ pub unsafe fn _mm_shuffle_ps(a: __m128, b: __m128, mask: u32) -> __m128 {
         };
     }
     macro_rules! shuffle_x45 {
-        ($x01: expr, $x23: expr) => {
+        ($x01:expr, $x23:expr) => {
             match (mask >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 4),
                 0b01 => shuffle_x67!($x01, $x23, 5),
@@ -793,7 +793,7 @@ pub unsafe fn _mm_shuffle_ps(a: __m128, b: __m128, mask: u32) -> __m128 {
         };
     }
     macro_rules! shuffle_x23 {
-        ($x01: expr) => {
+        ($x01:expr) => {
             match (mask >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
@@ -1564,7 +1564,7 @@ pub unsafe fn _mm_prefetch(p: *const i8, strategy: i32) {
     // We use the `llvm.prefetch` instrinsic with `rw` = 0 (read), and
     // `cache type` = 1 (data cache). `locality` is based on our `strategy`.
     macro_rules! pref {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             match $imm8 {
                 0 => prefetch(p, 0, 0, 1),
                 1 => prefetch(p, 0, 1, 1),
@@ -2010,7 +2010,7 @@ pub unsafe fn _m_maskmovq(a: __m64, mask: __m64, mem_addr: *mut i8) {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_extract_pi16(a: __m64, imm2: i32) -> i32 {
     macro_rules! call {
-        ($imm2: expr) => {
+        ($imm2:expr) => {
             pextrw(a, $imm2) as i32
         };
     }
@@ -2025,7 +2025,7 @@ pub unsafe fn _mm_extract_pi16(a: __m64, imm2: i32) -> i32 {
 #[rustc_args_required_const(1)]
 pub unsafe fn _m_pextrw(a: __m64, imm2: i32) -> i32 {
     macro_rules! call {
-        ($imm2: expr) => {
+        ($imm2:expr) => {
             pextrw(a, $imm2) as i32
         };
     }
@@ -2041,7 +2041,7 @@ pub unsafe fn _m_pextrw(a: __m64, imm2: i32) -> i32 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_insert_pi16(a: __m64, d: i32, imm2: i32) -> __m64 {
     macro_rules! call {
-        ($imm2: expr) => {
+        ($imm2:expr) => {
             pinsrw(a, d, $imm2)
         };
     }
@@ -2057,7 +2057,7 @@ pub unsafe fn _mm_insert_pi16(a: __m64, d: i32, imm2: i32) -> __m64 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _m_pinsrw(a: __m64, d: i32, imm2: i32) -> __m64 {
     macro_rules! call {
-        ($imm2: expr) => {
+        ($imm2:expr) => {
             pinsrw(a, d, $imm2)
         };
     }
@@ -2092,7 +2092,7 @@ pub unsafe fn _m_pmovmskb(a: __m64) -> i32 {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_shuffle_pi16(a: __m64, imm8: i32) -> __m64 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pshufw(a, $imm8)
         };
     }
@@ -2107,7 +2107,7 @@ pub unsafe fn _mm_shuffle_pi16(a: __m64, imm8: i32) -> __m64 {
 #[rustc_args_required_const(1)]
 pub unsafe fn _m_pshufw(a: __m64, imm8: i32) -> __m64 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pshufw(a, $imm8)
         };
     }

--- a/coresimd/x86/sse2.rs
+++ b/coresimd/x86/sse2.rs
@@ -326,7 +326,7 @@ unsafe fn _mm_slli_si128_impl(a: __m128i, imm8: i32) -> __m128i {
     let (zero, imm8) = (_mm_set1_epi8(0).as_i8x16(), imm8 as u32);
     let a = a.as_i8x16();
     macro_rules! shuffle {
-        ($shift: expr) => {
+        ($shift:expr) => {
             simd_shuffle16::<i8x16, i8x16>(
                 zero,
                 a,
@@ -500,7 +500,7 @@ unsafe fn _mm_srli_si128_impl(a: __m128i, imm8: i32) -> __m128i {
     let (zero, imm8) = (_mm_set1_epi8(0).as_i8x16(), imm8 as u32);
     let a = a.as_i8x16();
     macro_rules! shuffle {
-        ($shift: expr) => {
+        ($shift:expr) => {
             simd_shuffle16(
                 a,
                 zero,
@@ -1079,12 +1079,12 @@ pub unsafe fn _mm_shuffle_epi32(a: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i32x4();
 
     macro_rules! shuffle_done {
-        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
             simd_shuffle4(a, a, [$x01, $x23, $x45, $x67])
         };
     }
     macro_rules! shuffle_x67 {
-        ($x01: expr, $x23: expr, $x45: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
@@ -1094,7 +1094,7 @@ pub unsafe fn _mm_shuffle_epi32(a: __m128i, imm8: i32) -> __m128i {
         };
     }
     macro_rules! shuffle_x45 {
-        ($x01: expr, $x23: expr) => {
+        ($x01:expr, $x23:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
@@ -1104,7 +1104,7 @@ pub unsafe fn _mm_shuffle_epi32(a: __m128i, imm8: i32) -> __m128i {
         };
     }
     macro_rules! shuffle_x23 {
-        ($x01: expr) => {
+        ($x01:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
@@ -1136,7 +1136,7 @@ pub unsafe fn _mm_shufflehi_epi16(a: __m128i, imm8: i32) -> __m128i {
     let imm8 = (imm8 & 0xFF) as u8;
     let a = a.as_i16x8();
     macro_rules! shuffle_done {
-        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
             simd_shuffle8(
                 a,
                 a,
@@ -1154,7 +1154,7 @@ pub unsafe fn _mm_shufflehi_epi16(a: __m128i, imm8: i32) -> __m128i {
         };
     }
     macro_rules! shuffle_x67 {
-        ($x01: expr, $x23: expr, $x45: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
@@ -1164,7 +1164,7 @@ pub unsafe fn _mm_shufflehi_epi16(a: __m128i, imm8: i32) -> __m128i {
         };
     }
     macro_rules! shuffle_x45 {
-        ($x01: expr, $x23: expr) => {
+        ($x01:expr, $x23:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
@@ -1174,7 +1174,7 @@ pub unsafe fn _mm_shufflehi_epi16(a: __m128i, imm8: i32) -> __m128i {
         };
     }
     macro_rules! shuffle_x23 {
-        ($x01: expr) => {
+        ($x01:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),
@@ -1207,12 +1207,12 @@ pub unsafe fn _mm_shufflelo_epi16(a: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i16x8();
 
     macro_rules! shuffle_done {
-        ($x01: expr, $x23: expr, $x45: expr, $x67: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
             simd_shuffle8(a, a, [$x01, $x23, $x45, $x67, 4, 5, 6, 7])
         };
     }
     macro_rules! shuffle_x67 {
-        ($x01: expr, $x23: expr, $x45: expr) => {
+        ($x01:expr, $x23:expr, $x45:expr) => {
             match (imm8 >> 6) & 0b11 {
                 0b00 => shuffle_done!($x01, $x23, $x45, 0),
                 0b01 => shuffle_done!($x01, $x23, $x45, 1),
@@ -1222,7 +1222,7 @@ pub unsafe fn _mm_shufflelo_epi16(a: __m128i, imm8: i32) -> __m128i {
         };
     }
     macro_rules! shuffle_x45 {
-        ($x01: expr, $x23: expr) => {
+        ($x01:expr, $x23:expr) => {
             match (imm8 >> 4) & 0b11 {
                 0b00 => shuffle_x67!($x01, $x23, 0),
                 0b01 => shuffle_x67!($x01, $x23, 1),
@@ -1232,7 +1232,7 @@ pub unsafe fn _mm_shufflelo_epi16(a: __m128i, imm8: i32) -> __m128i {
         };
     }
     macro_rules! shuffle_x23 {
-        ($x01: expr) => {
+        ($x01:expr) => {
             match (imm8 >> 2) & 0b11 {
                 0b00 => shuffle_x45!($x01, 0),
                 0b01 => shuffle_x45!($x01, 1),

--- a/coresimd/x86/sse41.rs
+++ b/coresimd/x86/sse41.rs
@@ -72,7 +72,7 @@ pub unsafe fn _mm_blend_epi16(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i16x8();
     let b = b.as_i16x8();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pblendw(a, b, $imm8)
         };
     }
@@ -105,7 +105,7 @@ pub unsafe fn _mm_blendv_ps(a: __m128, b: __m128, mask: __m128) -> __m128 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_blend_pd(a: __m128d, b: __m128d, imm2: i32) -> __m128d {
     macro_rules! call {
-        ($imm2: expr) => {
+        ($imm2:expr) => {
             blendpd(a, b, $imm2)
         };
     }
@@ -120,7 +120,7 @@ pub unsafe fn _mm_blend_pd(a: __m128d, b: __m128d, imm2: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_blend_ps(a: __m128, b: __m128, imm4: i32) -> __m128 {
     macro_rules! call {
-        ($imm4: expr) => {
+        ($imm4:expr) => {
             blendps(a, b, $imm4)
         };
     }
@@ -190,7 +190,7 @@ pub unsafe fn _mm_extract_epi32(a: __m128i, imm8: i32) -> i32 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_insert_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             insertps(a, b, $imm8)
         };
     }
@@ -451,7 +451,7 @@ pub unsafe fn _mm_cvtepu32_epi64(a: __m128i) -> __m128i {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_dp_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             dppd(a, b, $imm8)
         };
     }
@@ -471,7 +471,7 @@ pub unsafe fn _mm_dp_pd(a: __m128d, b: __m128d, imm8: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_dp_ps(a: __m128, b: __m128, imm8: i32) -> __m128 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             dpps(a, b, $imm8)
         };
     }
@@ -608,7 +608,7 @@ pub unsafe fn _mm_ceil_ss(a: __m128, b: __m128) -> __m128 {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_round_pd(a: __m128d, rounding: i32) -> __m128d {
     macro_rules! call {
-        ($imm4: expr) => {
+        ($imm4:expr) => {
             roundpd(a, $imm4)
         };
     }
@@ -658,7 +658,7 @@ pub unsafe fn _mm_round_pd(a: __m128d, rounding: i32) -> __m128d {
 #[rustc_args_required_const(1)]
 pub unsafe fn _mm_round_ps(a: __m128, rounding: i32) -> __m128 {
     macro_rules! call {
-        ($imm4: expr) => {
+        ($imm4:expr) => {
             roundps(a, $imm4)
         };
     }
@@ -709,7 +709,7 @@ pub unsafe fn _mm_round_ps(a: __m128, rounding: i32) -> __m128 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_round_sd(a: __m128d, b: __m128d, rounding: i32) -> __m128d {
     macro_rules! call {
-        ($imm4: expr) => {
+        ($imm4:expr) => {
             roundsd(a, b, $imm4)
         };
     }
@@ -760,7 +760,7 @@ pub unsafe fn _mm_round_sd(a: __m128d, b: __m128d, rounding: i32) -> __m128d {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_round_ss(a: __m128, b: __m128, rounding: i32) -> __m128 {
     macro_rules! call {
-        ($imm4: expr) => {
+        ($imm4:expr) => {
             roundss(a, b, $imm4)
         };
     }
@@ -854,7 +854,7 @@ pub unsafe fn _mm_mpsadbw_epu8(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let a = a.as_u8x16();
     let b = b.as_u8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             mpsadbw(a, b, $imm8)
         };
     }

--- a/coresimd/x86/sse42.rs
+++ b/coresimd/x86/sse42.rs
@@ -57,7 +57,7 @@ pub unsafe fn _mm_cmpistrm(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpistrm128(a, b, $imm8)
         };
     }
@@ -304,7 +304,7 @@ pub unsafe fn _mm_cmpistri(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpistri128(a, b, $imm8)
         };
     }
@@ -322,7 +322,7 @@ pub unsafe fn _mm_cmpistrz(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpistriz128(a, b, $imm8)
         };
     }
@@ -340,7 +340,7 @@ pub unsafe fn _mm_cmpistrc(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpistric128(a, b, $imm8)
         };
     }
@@ -358,7 +358,7 @@ pub unsafe fn _mm_cmpistrs(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpistris128(a, b, $imm8)
         };
     }
@@ -375,7 +375,7 @@ pub unsafe fn _mm_cmpistro(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpistrio128(a, b, $imm8)
         };
     }
@@ -393,7 +393,7 @@ pub unsafe fn _mm_cmpistra(a: __m128i, b: __m128i, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpistria128(a, b, $imm8)
         };
     }
@@ -412,7 +412,7 @@ pub unsafe fn _mm_cmpestrm(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpestrm128(a, la, b, lb, $imm8)
         };
     }
@@ -516,7 +516,7 @@ pub unsafe fn _mm_cmpestri(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpestri128(a, la, b, lb, $imm8)
         };
     }
@@ -536,7 +536,7 @@ pub unsafe fn _mm_cmpestrz(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpestriz128(a, la, b, lb, $imm8)
         };
     }
@@ -556,7 +556,7 @@ pub unsafe fn _mm_cmpestrc(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpestric128(a, la, b, lb, $imm8)
         };
     }
@@ -576,7 +576,7 @@ pub unsafe fn _mm_cmpestrs(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpestris128(a, la, b, lb, $imm8)
         };
     }
@@ -596,7 +596,7 @@ pub unsafe fn _mm_cmpestro(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpestrio128(a, la, b, lb, $imm8)
         };
     }
@@ -617,7 +617,7 @@ pub unsafe fn _mm_cmpestra(
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             pcmpestria128(a, la, b, lb, $imm8)
         };
     }

--- a/coresimd/x86/ssse3.rs
+++ b/coresimd/x86/ssse3.rs
@@ -92,7 +92,7 @@ pub unsafe fn _mm_alignr_epi8(a: __m128i, b: __m128i, n: i32) -> __m128i {
     let b = b.as_i8x16();
 
     macro_rules! shuffle {
-        ($shift: expr) => {
+        ($shift:expr) => {
             simd_shuffle16(
                 b,
                 a,
@@ -295,7 +295,7 @@ pub unsafe fn _mm_shuffle_pi8(a: __m64, b: __m64) -> __m64 {
 #[rustc_args_required_const(2)]
 pub unsafe fn _mm_alignr_pi8(a: __m64, b: __m64, n: i32) -> __m64 {
     macro_rules! call {
-        ($imm8: expr) => {
+        ($imm8:expr) => {
             palignrb(a, b, $imm8)
         };
     }

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -45,22 +45,22 @@ extern crate stdsimd_test;
 extern crate test;
 
 macro_rules! test_v16 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 macro_rules! test_v32 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 macro_rules! test_v64 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 macro_rules! test_v128 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 macro_rules! test_v256 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 macro_rules! test_v512 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 macro_rules! vector_impl {
     ($([$f:ident, $($args:tt)*]),*) => { $($f!($($args)*);)* }

--- a/crates/coresimd/tests/v128.rs
+++ b/crates/coresimd/tests/v128.rs
@@ -10,34 +10,34 @@ extern crate coresimd;
 
 #[cfg(test)]
 macro_rules! test_v16 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v32 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v64 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v128 {
-    ($item: item) => {
+    ($item:item) => {
         $item
     };
 }
 #[cfg(test)]
 macro_rules! test_v256 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v512 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f: ident, $($args: tt)*]),*) => {};
+    ($([$f:ident, $($args:tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v16.rs
+++ b/crates/coresimd/tests/v16.rs
@@ -10,34 +10,34 @@ extern crate coresimd;
 
 #[cfg(test)]
 macro_rules! test_v16 {
-    ($item: item) => {
+    ($item:item) => {
         $item
     };
 }
 #[cfg(test)]
 macro_rules! test_v32 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v64 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v128 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v256 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v512 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f: ident, $($args: tt)*]),*) => {};
+    ($([$f:ident, $($args:tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v256.rs
+++ b/crates/coresimd/tests/v256.rs
@@ -10,34 +10,34 @@ extern crate coresimd;
 
 #[cfg(test)]
 macro_rules! test_v16 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v32 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v64 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v128 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v256 {
-    ($item: item) => {
+    ($item:item) => {
         $item
     };
 }
 #[cfg(test)]
 macro_rules! test_v512 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f: ident, $($args: tt)*]),*) => {};
+    ($([$f:ident, $($args:tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v32.rs
+++ b/crates/coresimd/tests/v32.rs
@@ -10,34 +10,34 @@ extern crate coresimd;
 
 #[cfg(test)]
 macro_rules! test_v16 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v32 {
-    ($item: item) => {
+    ($item:item) => {
         $item
     };
 }
 #[cfg(test)]
 macro_rules! test_v64 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v128 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v256 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v512 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f: ident, $($args: tt)*]),*) => {};
+    ($([$f:ident, $($args:tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v512.rs
+++ b/crates/coresimd/tests/v512.rs
@@ -10,34 +10,34 @@ extern crate coresimd;
 
 #[cfg(test)]
 macro_rules! test_v16 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v32 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v64 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v128 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v256 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v512 {
-    ($item: item) => {
+    ($item:item) => {
         $item
     };
 }
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f: ident, $($args: tt)*]),*) => {};
+    ($([$f:ident, $($args:tt)*]),*) => {};
 }
 
 #[cfg(test)]

--- a/crates/coresimd/tests/v64.rs
+++ b/crates/coresimd/tests/v64.rs
@@ -10,34 +10,34 @@ extern crate coresimd;
 
 #[cfg(test)]
 macro_rules! test_v16 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v32 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v64 {
-    ($item: item) => {
+    ($item:item) => {
         $item
     };
 }
 #[cfg(test)]
 macro_rules! test_v128 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v256 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 #[cfg(test)]
 macro_rules! test_v512 {
-    ($item: item) => {};
+    ($item:item) => {};
 }
 
 #[cfg(test)]
 macro_rules! vector_impl {
-    ($([$f: ident, $($args: tt)*]),*) => {};
+    ($([$f:ident, $($args:tt)*]),*) => {};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR upgrades Intel SDE and Ubuntu Version to fix the SDE build bot. It seems that this was caused by a bug in glibc 2.25 that is fixed in glibc 2.26: https://sourceware.org/ml/libc-stable/2017-11/msg00027.html

The PR also upgrades the formatting, and we allow the stdsimd-verify build to fail because of #411 .