### PR TITLE
Enable fxsr

### DIFF
--- a/coresimd/x86/fxsr.rs
+++ b/coresimd/x86/fxsr.rs
@@ -51,8 +51,8 @@ pub unsafe fn _fxrstor(mem_addr: *const u8) {
 
 #[cfg(test)]
 mod tests {
-    use coresimd::x86::i386::fxsr;
-    use std::fmt;
+    use coresimd::x86::*;
+    use std::{fmt, cmp::PartialEq};
     use stdsimd_test::simd_test;
 
     #[repr(align(16))]

--- a/coresimd/x86/mod.rs
+++ b/coresimd/x86/mod.rs
@@ -535,9 +535,7 @@ impl_from_bits_!(
 mod eflags;
 pub use self::eflags::*;
 
-#[cfg(dont_compile_me)] // TODO: need to upstream `fxsr` target feature
 mod fxsr;
-#[cfg(dont_compile_me)] // TODO: need to upstream `fxsr` target feature
 pub use self::fxsr::*;
 
 mod bswap;

--- a/coresimd/x86_64/fxsr.rs
+++ b/coresimd/x86_64/fxsr.rs
@@ -55,7 +55,6 @@ mod tests {
     use std::{fmt, cmp::PartialEq};
     use stdsimd_test::simd_test;
 
-
     #[repr(align(16))]
     struct FxsaveArea {
         data: [u8; 512], // 512 bytes

--- a/coresimd/x86_64/fxsr.rs
+++ b/coresimd/x86_64/fxsr.rs
@@ -51,9 +51,10 @@ pub unsafe fn _fxrstor64(mem_addr: *const u8) {
 
 #[cfg(test)]
 mod tests {
-    use coresimd::x86::x86_64::fxsr;
-    use std::fmt;
+    use coresimd::x86_64::*;
+    use std::{fmt, cmp::PartialEq};
     use stdsimd_test::simd_test;
+
 
     #[repr(align(16))]
     struct FxsaveArea {

--- a/coresimd/x86_64/mod.rs
+++ b/coresimd/x86_64/mod.rs
@@ -1,8 +1,6 @@
 //! `x86_64` intrinsics
 
-#[cfg(dont_compile_me)] // TODO: need to upstream `fxsr` target feature
 mod fxsr;
-#[cfg(dont_compile_me)] // TODO: need to upstream `fxsr` target feature
 pub use self::fxsr::*;
 
 mod sse;


### PR DESCRIPTION
The `fxsr` feature was already whitelisted upstream. If this fails, then it has other issues.