### PR TITLE
Remove notes about stability

### DIFF
--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -14,9 +14,6 @@
 /// `i686-pc-windows-msvc` target will have an `x86` module here, whereas
 /// `x86_64-pc-windows-msvc` has `x86_64`.
 ///
-/// > **Note**: This module is currently unstable. It was designed in
-/// > [RFC 2325][rfc] and is currently [tracked] for stabilization.
-///
 /// [rfc]: https://github.com/rust-lang/rfcs/pull/2325
 /// [tracked]: https://github.com/rust-lang/rust/issues/48556
 ///


### PR DESCRIPTION
Hi there! So, I was glancing at https://doc.rust-lang.org/beta/std/arch/ today and noticed the "This module is currently unstable" bit. Now that some of it is stable, this is misleading, so we should remove it. Apparently that is here? If that's incorrect, please let me know! Also, backporting this change to beta would be great, but given the details here, I don't know if that's easy or hard.