### PR TITLE
Make the Feature enum unstable

### DIFF
--- a/stdsimd/arch/detect/arch/aarch64.rs
+++ b/stdsimd/arch/detect/arch/aarch64.rs
@@ -2,6 +2,7 @@
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
+#[allow_internal_unstable]
 macro_rules! is_aarch64_feature_detected {
     ("neon") => {
         // FIXME: this should be removed once we rename Aarch64 neon to asimd
@@ -74,6 +75,7 @@ macro_rules! is_aarch64_feature_detected {
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[unstable(feature = "stdsimd_internal", issue = "0")]
 pub enum Feature {
     /// ARM Advanced SIMD (ASIMD)
     asimd,

--- a/stdsimd/arch/detect/arch/arm.rs
+++ b/stdsimd/arch/detect/arch/arm.rs
@@ -2,6 +2,7 @@
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
+#[allow_internal_unstable]
 macro_rules! is_arm_feature_detected {
     ("neon") => {
         cfg!(target_feature = "neon") ||
@@ -25,6 +26,7 @@ macro_rules! is_arm_feature_detected {
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[unstable(feature = "stdsimd_internal", issue = "0")]
 pub enum Feature {
     /// ARM Advanced SIMD (NEON) - Aarch32
     neon,

--- a/stdsimd/arch/detect/arch/mips.rs
+++ b/stdsimd/arch/detect/arch/mips.rs
@@ -2,6 +2,7 @@
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
+#[allow_internal_unstable]
 macro_rules! is_mips_feature_detected {
     ("msa") => {
         cfg!(target_feature = "msa") ||
@@ -17,6 +18,7 @@ macro_rules! is_mips_feature_detected {
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[unstable(feature = "stdsimd_internal", issue = "0")]
 pub enum Feature {
     /// MIPS SIMD Architecture (MSA)
     msa,

--- a/stdsimd/arch/detect/arch/mips64.rs
+++ b/stdsimd/arch/detect/arch/mips64.rs
@@ -2,6 +2,7 @@
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
+#[allow_internal_unstable]
 macro_rules! is_mips64_feature_detected {
     ("msa") => {
         cfg!(target_feature = "msa") ||
@@ -17,6 +18,7 @@ macro_rules! is_mips64_feature_detected {
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[unstable(feature = "stdsimd_internal", issue = "0")]
 pub enum Feature {
     /// MIPS SIMD Architecture (MSA)
     msa,

--- a/stdsimd/arch/detect/arch/powerpc64.rs
+++ b/stdsimd/arch/detect/arch/powerpc64.rs
@@ -2,6 +2,7 @@
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
+#[allow_internal_unstable]
 macro_rules! is_powerpc64_feature_detected {
     ("altivec") => {
         cfg!(target_feature = "altivec") ||
@@ -26,6 +27,7 @@ macro_rules! is_powerpc64_feature_detected {
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[unstable(feature = "stdsimd_internal", issue = "0")]
 pub enum Feature {
     /// Altivec
     altivec,

--- a/stdsimd/arch/detect/arch/x86.rs
+++ b/stdsimd/arch/detect/arch/x86.rs
@@ -234,10 +234,11 @@ macro_rules! is_x86_feature_detected {
 /// X86 CPU Feature enum. Each variant denotes a position in a bitset for a
 /// particular feature.
 ///
-/// PLEASE: do not use this, it is an implementation detail subject to change.
-#[doc(hidden)]
+/// This is an unstable implementation detail subject to change.
 #[allow(non_camel_case_types)]
 #[repr(u8)]
+#[doc(hidden)]
+#[unstable(feature = "stdsimd_internal", issue = "0")]
 pub enum Feature {
     /// AES (Advanced Encryption Standard New Instructions AES-NI)
     aes,


### PR DESCRIPTION
This is cleaner than just having a #[doc(hidden)] attribute