### PR TITLE
Initial PowerPC altivec and VSX support

### DIFF
--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -8,5 +8,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         file
 
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
-    CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER="qemu-ppc -L /usr/powerpc-linux-gnu" \
+    CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER="qemu-ppc -cpu Vger -L /usr/powerpc-linux-gnu" \
     OBJDUMP=powerpc-linux-gnu-objdump

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,16 +7,26 @@ set -ex
 # Tests are all super fast anyway, and they fault often enough on travis that
 # having only one thread increases debuggability to be worth it.
 export RUST_TEST_THREADS=1
-#export RUST_BACKTRACE=full
+export RUST_BACKTRACE=full
 #export RUST_TEST_NOCAPTURE=1
 
 RUSTFLAGS="$RUSTFLAGS --cfg stdsimd_strict"
 
 # FIXME: on armv7 neon intrinsics require the neon target-feature to be
 # unconditionally enabled.
+# FIXME: powerpc (32-bit) must be compiled with altivec
+# FIXME: on powerpc (32-bit) and powerpc64 (big endian) disable
+# the instr tests.
 case ${TARGET} in
     armv7*)
         export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+neon"
+        ;;
+    powerpc-*)
+        export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+altivec"
+        export STDSIMD_DISABLE_ASSERT_INSTR=1
+        ;;
+    powerpc64-*)
+        export STDSIMD_DISABLE_ASSERT_INSTR=1
         ;;
     *)
         ;;
@@ -25,6 +35,7 @@ esac
 echo "RUSTFLAGS=${RUSTFLAGS}"
 echo "FEATURES=${FEATURES}"
 echo "OBJDUMP=${OBJDUMP}"
+echo "STDSIMD_DISABLE_ASSERT_INSTR=${STDSIMD_DISABLE_ASSERT_INSTR}"
 
 cargo_test() {
     cmd="cargo test --target=$TARGET $1"

--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -34,6 +34,8 @@ pub mod simd {
 /// * [`aarch64`]
 /// * [`mips`]
 /// * [`mips64`]
+/// * [`PowerPC`]
+/// * [`PowerPC64`]
 ///
 /// [`x86`]: https://rust-lang-nursery.github.io/stdsimd/x86/stdsimd/arch/index.html
 /// [`x86_64`]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/arch/index.html
@@ -41,6 +43,8 @@ pub mod simd {
 /// [`aarch64`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/index.html
 /// [`mips`]: https://rust-lang-nursery.github.io/stdsimd/mips/stdsimd/arch/index.html
 /// [`mips64`]: https://rust-lang-nursery.github.io/stdsimd/mips64/stdsimd/arch/index.html
+/// [`PowerPC`]: https://rust-lang-nursery.github.io/stdsimd/powerpc/stdsimd/arch/index.html
+/// [`PowerPC64`]: https://rust-lang-nursery.github.io/stdsimd/powerpc64/stdsimd/arch/index.html
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub mod arch {
     /// Platform-specific intrinsics for the `x86` platform.
@@ -116,6 +120,27 @@ pub mod arch {
     pub mod mips64 {
         pub use coresimd::mips::*;
     }
+
+    /// Platform-specific intrinsics for the `PowerPC` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
+    #[cfg(any(target_arch = "powerpc", dox))]
+    #[doc(cfg(target_arch = "powerpc"))]
+    #[unstable(feature = "stdsimd", issue = "0")]
+    pub mod powerpc {
+        pub use coresimd::powerpc::*;
+    }
+
+    /// Platform-specific intrinsics for the `PowerPC64` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
+    #[cfg(target_arch = "powerpc64")]
+    #[cfg(any(target_arch = "powerpc64", dox))]
+    #[doc(cfg(target_arch = "powerpc64"))]
+    #[unstable(feature = "stdsimd", issue = "0")]
+    pub mod powerpc64 {
+        pub use coresimd::powerpc::*;
+    }
 }
 
 mod simd_llvm;
@@ -134,5 +159,8 @@ mod wasm32;
 
 #[cfg(any(target_arch = "mips", target_arch = "mips64", dox))]
 mod mips;
+
+#[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+mod powerpc;
 
 mod nvptx;

--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -139,7 +139,7 @@ pub mod arch {
     #[doc(cfg(target_arch = "powerpc64"))]
     #[unstable(feature = "stdsimd", issue = "0")]
     pub mod powerpc64 {
-        pub use coresimd::powerpc::*;
+        pub use coresimd::powerpc64::*;
     }
 }
 
@@ -160,7 +160,10 @@ mod wasm32;
 #[cfg(any(target_arch = "mips", target_arch = "mips64", dox))]
 mod mips;
 
-#[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
+#[cfg(any(target_arch = "powerpc", target_arch = "powerpc64", dox))]
 mod powerpc;
+
+#[cfg(any(target_arch = "powerpc64", dox))]
+mod powerpc64;
 
 mod nvptx;

--- a/coresimd/powerpc/altivec.rs
+++ b/coresimd/powerpc/altivec.rs
@@ -1,0 +1,360 @@
+//! PowerPC AltiVec intrinsics.
+//!
+//! AltiVec is a brandname trademarked by Freescale (previously Motorola) for
+//! the standard `Category:Vector` part of the Power ISA v.2.03 specification.
+//! This Category is also known as VMX (used by IBM), and "Velocity Engine" (a
+//! brand name previously used by Apple).
+//!
+//! The references are: [POWER ISA v2.07B (for POWER8 & POWER8 with NVIDIA
+//! NVlink)] and [POWER ISA v3.0B (for POWER9)].
+//!
+//! [POWER ISA v2.07B (for POWER8 & POWER8 with NVIDIA NVlink)]: https://ibm.box.com/s/jd5w15gz301s5b5dt375mshpq9c3lh4u
+//! [POWER ISA v3.0B (for POWER9)]: https://ibm.box.com/s/1hzcwkwf8rbju5h9iyf44wm94amnlcrv
+
+#![allow(non_camel_case_types)]
+
+use coresimd::simd::*;
+use coresimd::simd_llvm::*;
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+pub type vector_signed_char = i8x16;
+pub type vector_unsigned_char = u8x16;
+pub type vector_bool_char = m8x16;
+pub type vector_signed_short = i16x8;
+pub type vector_unsigned_short = u16x8;
+pub type vector_bool_short = m16x8;
+// pub type vector_pixel = ???;
+pub type vector_signed_int = i32x4;
+pub type vector_unsigned_int = u32x4;
+pub type vector_bool_int = m32x4;
+pub type vector_float = f32x4;
+
+mod sealed {
+
+    use super::*;
+
+    pub trait VectorAdd<Other> {
+        type Result;
+        unsafe fn vec_add(self, other: Other) -> Self::Result;
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vaddubm))]
+    pub unsafe fn vec_add_bc_sc(
+        a: vector_bool_char, b: vector_signed_char,
+    ) -> vector_signed_char {
+        simd_add(a.into_bits(), b)
+    }
+    impl VectorAdd<vector_signed_char> for vector_bool_char {
+        type Result = vector_signed_char;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_signed_char) -> Self::Result {
+            vec_add_bc_sc(self, other)
+        }
+    }
+    impl VectorAdd<vector_bool_char> for vector_signed_char {
+        type Result = vector_signed_char;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_bool_char) -> Self::Result {
+            other.vec_add(self)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vaddubm))]
+    pub unsafe fn vec_add_sc_sc(
+        a: vector_signed_char, b: vector_signed_char,
+    ) -> vector_signed_char {
+        simd_add(a, b)
+    }
+    impl VectorAdd<vector_signed_char> for vector_signed_char {
+        type Result = vector_signed_char;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_signed_char) -> Self::Result {
+            vec_add_sc_sc(self, other)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vaddubm))]
+    pub unsafe fn vec_add_bc_uc(
+        a: vector_bool_char, b: vector_unsigned_char,
+    ) -> vector_unsigned_char {
+        simd_add(a.into_bits(), b)
+    }
+    impl VectorAdd<vector_unsigned_char> for vector_bool_char {
+        type Result = vector_unsigned_char;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_unsigned_char) -> Self::Result {
+            vec_add_bc_uc(self, other)
+        }
+    }
+    impl VectorAdd<vector_bool_char> for vector_unsigned_char {
+        type Result = vector_unsigned_char;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_bool_char) -> Self::Result {
+            other.vec_add(self)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vaddubm))]
+    pub unsafe fn vec_add_uc_uc(
+        a: vector_unsigned_char, b: vector_unsigned_char,
+    ) -> vector_unsigned_char {
+        simd_add(a, b)
+    }
+    impl VectorAdd<vector_unsigned_char> for vector_unsigned_char {
+        type Result = vector_unsigned_char;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_unsigned_char) -> Self::Result {
+            vec_add_uc_uc(self, other)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vadduhm))]
+    pub unsafe fn vec_add_bs_ss(
+        a: vector_bool_short, b: vector_signed_short,
+    ) -> vector_signed_short {
+        let a: i16x8 = a.into_bits();
+        let a: vector_signed_short = simd_cast(a);
+        simd_add(a, b)
+    }
+
+    impl VectorAdd<vector_signed_short> for vector_bool_short {
+        type Result = vector_signed_short;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_signed_short) -> Self::Result {
+            vec_add_bs_ss(self, other)
+        }
+    }
+    impl VectorAdd<vector_bool_short> for vector_signed_short {
+        type Result = vector_signed_short;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_bool_short) -> Self::Result {
+            other.vec_add(self)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vadduhm))]
+    pub unsafe fn vec_add_ss_ss(
+        a: vector_signed_short, b: vector_signed_short,
+    ) -> vector_signed_short {
+        simd_add(a, b)
+    }
+    impl VectorAdd<vector_signed_short> for vector_signed_short {
+        type Result = vector_signed_short;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_signed_short) -> Self::Result {
+            vec_add_ss_ss(self, other)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vadduhm))]
+    pub unsafe fn vec_add_bs_us(
+        a: vector_bool_short, b: vector_unsigned_short,
+    ) -> vector_unsigned_short {
+        let a: i16x8 = a.into_bits();
+        let a: vector_unsigned_short = simd_cast(a);
+        simd_add(a, b)
+    }
+    impl VectorAdd<vector_unsigned_short> for vector_bool_short {
+        type Result = vector_unsigned_short;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_unsigned_short) -> Self::Result {
+            vec_add_bs_us(self, other)
+        }
+    }
+    impl VectorAdd<vector_bool_short> for vector_unsigned_short {
+        type Result = vector_unsigned_short;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_bool_short) -> Self::Result {
+            other.vec_add(self)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vadduhm))]
+    pub unsafe fn vec_add_us_us(
+        a: vector_unsigned_short, b: vector_unsigned_short,
+    ) -> vector_unsigned_short {
+        simd_add(a, b)
+    }
+
+    impl VectorAdd<vector_unsigned_short> for vector_unsigned_short {
+        type Result = vector_unsigned_short;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_unsigned_short) -> Self::Result {
+            vec_add_us_us(self, other)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vadduwm))]
+    pub unsafe fn vec_add_bi_si(
+        a: vector_bool_int, b: vector_signed_int,
+    ) -> vector_signed_int {
+        let a: i32x4 = a.into_bits();
+        let a: vector_signed_int = simd_cast(a);
+        simd_add(a, b)
+    }
+    impl VectorAdd<vector_signed_int> for vector_bool_int {
+        type Result = vector_signed_int;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_signed_int) -> Self::Result {
+            vec_add_bi_si(self, other)
+        }
+    }
+    impl VectorAdd<vector_bool_int> for vector_signed_int {
+        type Result = vector_signed_int;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_bool_int) -> Self::Result {
+            other.vec_add(self)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vadduwm))]
+    pub unsafe fn vec_add_si_si(
+        a: vector_signed_int, b: vector_signed_int,
+    ) -> vector_signed_int {
+        simd_add(a, b)
+    }
+    impl VectorAdd<vector_signed_int> for vector_signed_int {
+        type Result = vector_signed_int;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_signed_int) -> Self::Result {
+            vec_add_si_si(self, other)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vadduwm))]
+    pub unsafe fn vec_add_bi_ui(
+        a: vector_bool_int, b: vector_unsigned_int,
+    ) -> vector_unsigned_int {
+        let a: i32x4 = a.into_bits();
+        let a: vector_unsigned_int = simd_cast(a);
+        simd_add(a, b)
+    }
+    impl VectorAdd<vector_unsigned_int> for vector_bool_int {
+        type Result = vector_unsigned_int;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_unsigned_int) -> Self::Result {
+            vec_add_bi_ui(self, other)
+        }
+    }
+    impl VectorAdd<vector_bool_int> for vector_unsigned_int {
+        type Result = vector_unsigned_int;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_bool_int) -> Self::Result {
+            other.vec_add(self)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(vadduwm))]
+    pub unsafe fn vec_add_ui_ui(
+        a: vector_unsigned_int, b: vector_unsigned_int,
+    ) -> vector_unsigned_int {
+        simd_add(a, b)
+    }
+    impl VectorAdd<vector_unsigned_int> for vector_unsigned_int {
+        type Result = vector_unsigned_int;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_unsigned_int) -> Self::Result {
+            vec_add_ui_ui(self, other)
+        }
+    }
+
+    #[inline]
+    #[target_feature(enable = "altivec")]
+    #[cfg_attr(test, assert_instr(xvaddsp))]
+    pub unsafe fn vec_add_float_float(
+        a: vector_float, b: vector_float,
+    ) -> vector_float {
+        simd_add(a, b)
+    }
+
+    impl VectorAdd<vector_float> for vector_float {
+        type Result = vector_float;
+        #[inline]
+        #[target_feature(enable = "altivec")]
+        unsafe fn vec_add(self, other: vector_float) -> Self::Result {
+            vec_add_float_float(self, other)
+        }
+    }
+}
+
+/// Vector add.
+#[inline]
+#[target_feature(enable = "altivec")]
+pub unsafe fn vec_add<T, U>(a: T, b: U) -> <T as sealed::VectorAdd<U>>::Result
+where
+    T: sealed::VectorAdd<U>,
+{
+    a.vec_add(b)
+}
+
+#[cfg(tests)]
+mod tests {
+    use coresimd::arch::powerpc::*;
+    use simd::*;
+    use stdsimd_test::simd_test;
+
+    #[simd_test = "altivec"]
+    unsafe fn endianness() {
+        let x = i32x4::new(0, 1, 2, 3);
+        for i in 0..4 {
+            assert_eq!(x.extract(i), i);
+        }
+
+        let x: i16x8 = x.into_bits();
+        let e: i16x8 = i16x8::new(0, 0, 0, 0, 0, 0, 0, 0);
+        for i in 0..8 {
+            assert_eq!(x.extract(i), e.extract(i));
+        }
+    }
+
+    #[simd_test = "altivec"]
+    unsafe fn vec_add_i32x4_i32x4() {
+        let x = i32x4::new(1, 2, 3, 4);
+        let y = i32x4::new(4, 3, 2, 1);
+        let z = vec_add(x, y);
+        assert_eq!(z, i32x4::splat(5));
+    }
+}

--- a/coresimd/powerpc/mod.rs
+++ b/coresimd/powerpc/mod.rs
@@ -1,0 +1,7 @@
+//! PowerPC intrinsics
+
+mod altivec;
+pub use self::altivec::*;
+
+mod vsx;
+pub use self::vsx::*;

--- a/coresimd/powerpc/vsx.rs
+++ b/coresimd/powerpc/vsx.rs
@@ -1,0 +1,12 @@
+//! PowerPC Vectir Scalar eXtensions (VSX) intrinsics.
+//!
+//! The references are: [POWER ISA v2.07B (for POWER8 & POWER8 with NVIDIA
+//! NVlink)] and [POWER ISA v3.0B (for POWER9)].
+//!
+//! [POWER ISA v2.07B (for POWER8 & POWER8 with NVIDIA NVlink)]: https://ibm.box.com/s/jd5w15gz301s5b5dt375mshpq9c3lh4u
+//! [POWER ISA v3.0B (for POWER9)]: https://ibm.box.com/s/1hzcwkwf8rbju5h9iyf44wm94amnlcrv
+
+//#[cfg(test)]
+//use stdsimd_test::assert_instr;
+//use coresimd::simd_llvm::simd_add;
+//use coresimd::simd::*;

--- a/coresimd/powerpc64/mod.rs
+++ b/coresimd/powerpc64/mod.rs
@@ -4,5 +4,7 @@
 //!
 //! [64-Bit ELF V2 ABI Specification - Power Architecture]: http://openpowerfoundation.org/wp-content/uploads/resources/leabi/leabi-20170510.pdf
 
+pub use coresimd::powerpc::*;
+
 mod vsx;
 pub use self::vsx::*;

--- a/coresimd/powerpc64/mod.rs
+++ b/coresimd/powerpc64/mod.rs
@@ -1,0 +1,8 @@
+//! PowerPC 64
+//!
+//! The reference is the [64-Bit ELF V2 ABI Specification - Power Architecture].
+//!
+//! [64-Bit ELF V2 ABI Specification - Power Architecture]: http://openpowerfoundation.org/wp-content/uploads/resources/leabi/leabi-20170510.pdf
+
+mod vsx;
+pub use self::vsx::*;

--- a/coresimd/powerpc64/vsx.rs
+++ b/coresimd/powerpc64/vsx.rs
@@ -6,9 +6,8 @@
 //! [POWER ISA v2.07B (for POWER8 & POWER8 with NVIDIA NVlink)]: https://ibm.box.com/s/jd5w15gz301s5b5dt375mshpq9c3lh4u
 //! [POWER ISA v3.0B (for POWER9)]: https://ibm.box.com/s/1hzcwkwf8rbju5h9iyf44wm94amnlcrv
 
-#[cfg(test)]
-use stdsimd_test::assert_instr;
-use coresimd::simd_llvm::simd_add;
+#![allow(non_camel_case_types)]
+
 use coresimd::simd::*;
 
 // pub type vector_Float16 = f16x8;

--- a/coresimd/powerpc64/vsx.rs
+++ b/coresimd/powerpc64/vsx.rs
@@ -1,0 +1,23 @@
+//! PowerPC Vectir Scalar eXtensions (VSX) intrinsics.
+//!
+//! The references are: [POWER ISA v2.07B (for POWER8 & POWER8 with NVIDIA
+//! NVlink)] and [POWER ISA v3.0B (for POWER9)].
+//!
+//! [POWER ISA v2.07B (for POWER8 & POWER8 with NVIDIA NVlink)]: https://ibm.box.com/s/jd5w15gz301s5b5dt375mshpq9c3lh4u
+//! [POWER ISA v3.0B (for POWER9)]: https://ibm.box.com/s/1hzcwkwf8rbju5h9iyf44wm94amnlcrv
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+use coresimd::simd_llvm::simd_add;
+use coresimd::simd::*;
+
+// pub type vector_Float16 = f16x8;
+pub type vector_signed_long = i64x2;
+pub type vector_unsigned_long = u64x2;
+pub type vector_bool_long = u64x2;
+pub type vector_signed_long_long = vector_signed_long;
+pub type vector_unsigned_long_long = vector_unsigned_long;
+pub type vector_bool_long_long = vector_bool_long;
+pub type vector_double = f64x2;
+// pub type vector_signed___int128 = i128x1;
+// pub type vector_unsigned___int128 = i128x1;

--- a/coresimd/ppsv/mod.rs
+++ b/coresimd/ppsv/mod.rs
@@ -65,7 +65,7 @@ impl<T, U> IntoBits<U> for T
 where
     U: FromBits<T>,
 {
-    #[inline]
+    #[inline(always)]
     fn into_bits(self) -> U {
         debug_assert!(::mem::size_of::<Self>() == ::mem::size_of::<U>());
         U::from_bits(self)
@@ -74,7 +74,7 @@ where
 
 // FromBits (and thus IntoBits) is reflexive.
 impl<T> FromBits<T> for T {
-    #[inline]
+    #[inline(always)]
     fn from_bits(t: Self) -> Self {
         t
     }

--- a/coresimd/ppsv/mod.rs
+++ b/coresimd/ppsv/mod.rs
@@ -65,7 +65,9 @@ impl<T, U> IntoBits<U> for T
 where
     U: FromBits<T>,
 {
-    #[inline(always)]
+    // FIXME: https://github.com/rust-lang-nursery/stdsimd/issues/449
+    #[cfg_attr(any(target_arch = "powerpc", target_arch = "powerpc64"), inline(always))]
+    #[cfg_attr(not(any(target_arch = "powerpc", target_arch = "powerpc64")), inline)]
     fn into_bits(self) -> U {
         debug_assert!(::mem::size_of::<Self>() == ::mem::size_of::<U>());
         U::from_bits(self)
@@ -74,7 +76,9 @@ where
 
 // FromBits (and thus IntoBits) is reflexive.
 impl<T> FromBits<T> for T {
-    #[inline(always)]
+    // FIXME: https://github.com/rust-lang-nursery/stdsimd/issues/449
+    #[cfg_attr(any(target_arch = "powerpc", target_arch = "powerpc64"), inline(always))]
+    #[cfg_attr(not(any(target_arch = "powerpc", target_arch = "powerpc64")), inline)]
     fn from_bits(t: Self) -> Self {
         t
     }

--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -62,7 +62,10 @@ pub fn assert_instr(
     for arg in func.decl.inputs.iter() {
         let capture = match *arg {
             syn::FnArg::Captured(ref c) => c,
-            _ => panic!("arguments must not have patterns"),
+            ref v => panic!(
+                "arguments must not have patterns: `{:?}`",
+                v.clone().into_tokens()
+            ),
         };
         let ident = match capture.pat {
             syn::Pat::Ident(ref i) => &i.ident,

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -16,7 +16,7 @@
            staged_api, core_float, core_slice_ext, align_offset,
            doc_cfg, mmx_target_feature, tbm_target_feature,
            sse4a_target_feature, arm_target_feature, aarch64_target_feature,
-           mips_target_feature)]
+           mips_target_feature, powerpc_target_feature)]
 #![cfg_attr(test,
             feature(proc_macro, test, attr_literals, abi_vectorcall,
                     untagged_unions))]


### PR DESCRIPTION
This PR adds a single altivec intrinsic and sets up the vsx module for the PowerPC architecture.

Due to issues with `qemu`, the `assert_instr` tests are not run on `powerpc` and `powerpc64` (big endian); they are only run on `powerpc64le`. We should fix that at some point (issue: https://github.com/rust-lang-nursery/stdsimd/issues/448).

The PowerPC C intrinsics use compiler magic to do function overloading in C, such that for example in this case `vec_add(x, y)` corresponds to different functions depending on the types of `x` and `y`. This happens for all (or most) of the `altivec` and `vsx` intrinsics.

To match the C API the `vec_add` intrinsic is implemented as:

```rust
#[inline]
#[target_feature(enable = "altivec")]
pub unsafe fn vec_add<T, U>(a: T, b: U) -> <T as sealed::VectorAdd<U>>::Result
where T: sealed::VectorAdd<U> {
    a.vec_add(b)
}
```

Where the `VectorAdd` trait is sealed (not importable by users) and implemented as follows:

```rust
mod sealed {
    pub trait VectorAdd<Other> {
        type Result;
        unsafe fn vec_add(self, other: Other) -> Self::Result;
    }

    #[inline]
    #[target_feature(enable = "altivec")]
    #[cfg_attr(test, assert_instr(vaddubm))]
    pub unsafe fn vec_add_bc_sc(
        a: vector_bool_char, b: vector_signed_char,
    ) -> vector_signed_char {
        simd_add(a.into_bits(), b)
    }
    impl VectorAdd<vector_signed_char> for vector_bool_char {
        type Result = vector_signed_char;
        #[inline]
        #[target_feature(enable = "altivec")]
        unsafe fn vec_add(self, other: vector_signed_char) -> Self::Result {
            vec_add_bc_sc(self, other)
        }
    }
    impl VectorAdd<vector_bool_char> for vector_signed_char {
        type Result = vector_signed_char;
        #[inline]
        #[target_feature(enable = "altivec")]
        unsafe fn vec_add(self, other: vector_bool_char) -> Self::Result {
            other.vec_add(self)
        }

    // ... implementations for more arguments
}
```

The intrinsics themselves are implemented as simple functions so that the `assert_instr` macro can be used on them - it currently does not support trait methods. The `assert_instr` also requires the functions to be `pub`, but that doesn't matter here since the `sealed` module is not public and nothing from this module is ever re-exported.