### PR TITLE
add run-time feature detection for powerpc

### DIFF
--- a/coresimd/powerpc/altivec.rs
+++ b/coresimd/powerpc/altivec.rs
@@ -330,10 +330,14 @@ where
     a.vec_add(b)
 }
 
-#[cfg(all(test, target_arch = "powerpc64"))]
+#[cfg(test)]
 mod tests {
+    #[cfg(target_arch = "powerpc")]
+    use coresimd::arch::powerpc::*;
+
     #[cfg(target_arch = "powerpc64")]
     use coresimd::arch::powerpc64::*;
+
     use simd::*;
     use stdsimd_test::simd_test;
 

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -68,6 +68,7 @@ pub fn simd_test(
         "i686" | "x86_64" | "i586" => "is_x86_feature_detected",
         "arm" | "armv7" => "is_arm_feature_detected",
         "aarch64" => "is_aarch64_feature_detected",
+        "powerpc" | "powerpcle" => "is_powerpc_feature_detected",
         "powerpc64" | "powerpc64le" => "is_powerpc64_feature_detected",
         "mips" | "mipsel" => {
             // FIXME:

--- a/crates/stdsimd/tests/cpu-detection.rs
+++ b/crates/stdsimd/tests/cpu-detection.rs
@@ -5,7 +5,7 @@
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64",
           target_arch = "x86", target_arch = "x86_64",
-          target_arch = "powerpc64"))]
+          target_arch = "powerpc", target_arch = "powerpc64"))]
 #[macro_use]
 extern crate stdsimd;
 
@@ -38,6 +38,20 @@ fn aarch64_linux() {
     println!(
         "dotprod: {}",
         is_aarch64_feature_detected!("dotprod")
+    );
+}
+
+#[test]
+#[cfg(all(target_arch = "powerpc", target_os = "linux"))]
+fn powerpc_linux() {
+    println!(
+        "altivec: {}",
+        is_powerpc_feature_detected!("altivec")
+    );
+    println!("vsx: {}", is_powerpc_feature_detected!("vsx"));
+    println!(
+        "power8: {}",
+        is_powerpc_feature_detected!("power8")
     );
 }
 

--- a/stdsimd/arch/detect/arch/powerpc.rs
+++ b/stdsimd/arch/detect/arch/powerpc.rs
@@ -1,9 +1,9 @@
-//! Run-time feature detection on PowerPC64.
+//! Run-time feature detection on PowerPC.
 
 #[macro_export]
 #[unstable(feature = "stdsimd", issue = "0")]
 #[allow_internal_unstable]
-macro_rules! is_powerpc64_feature_detected {
+macro_rules! is_powerpc_feature_detected {
     ("altivec") => {
         cfg!(target_feature = "altivec") ||
             $crate::arch::detect::check_for($crate::arch::detect::Feature::altivec)
@@ -16,11 +16,11 @@ macro_rules! is_powerpc64_feature_detected {
         cfg!(target_feature = "power8") ||
             $crate::arch::detect::check_for($crate::arch::detect::Feature::power8)
     };
-    ($t:tt) => { compile_error!(concat!("unknown powerpc64 target feature: ", $t)) };
+    ($t:tt) => { compile_error!(concat!("unknown powerpc target feature: ", $t)) };
 }
 
 
-/// PowerPC64 CPU Feature enum. Each variant denotes a position in a bitset
+/// PowerPC CPU Feature enum. Each variant denotes a position in a bitset
 /// for a particular feature.
 ///
 /// PLEASE: do not use this, it is an implementation detail subject to change.

--- a/stdsimd/arch/detect/error_macros.rs
+++ b/stdsimd/arch/detect/error_macros.rs
@@ -12,7 +12,7 @@ macro_rules! is_x86_feature_detected {
         is_x86_feature_detected can only be used on x86 and x86_64 targets.
         You can prevent it from being used in other architectures by
         guarding it behind a cfg(target_arch) as follows:
-            
+
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
                 if is_x86_feature_detected(...) { ... }
             }
@@ -31,7 +31,7 @@ macro_rules! is_arm_feature_detected {
         is_arm_feature_detected can only be used on ARM targets.
         You can prevent it from being used in other architectures by
         guarding it behind a cfg(target_arch) as follows:
-            
+
             #[cfg(target_arch = "arm")] {
                 if is_arm_feature_detected(...) { ... }
             }
@@ -50,12 +50,29 @@ macro_rules! is_aarch64_feature_detected {
         is_aarch64_feature_detected can only be used on AArch64 targets.
         You can prevent it from being used in other architectures by
         guarding it behind a cfg(target_arch) as follows:
-            
+
             #[cfg(target_arch = "aarch64")] {
                 if is_aarch64_feature_detected(...) { ... }
             }
         "#
         )
+    };
+}
+
+#[cfg(not(target_arch = "powerpc"))]
+#[macro_export]
+#[unstable(feature = "stdsimd", issue = "0")]
+macro_rules! is_powerpc_feature_detected {
+    ($t:tt) => {
+        compile_error!(r#"
+is_powerpc_feature_detected can only be used on PowerPC targets.
+You can prevent it from being used in other architectures by
+guarding it behind a cfg(target_arch) as follows:
+
+    #[cfg(target_arch = "powerpc")] {
+        if is_powerpc_feature_detected(...) { ... }
+    }
+"#)
     };
 }
 
@@ -86,7 +103,7 @@ macro_rules! is_mips_feature_detected {
         is_mips_feature_detected can only be used on MIPS targets.
         You can prevent it from being used in other architectures by
         guarding it behind a cfg(target_arch) as follows:
-            
+
             #[cfg(target_arch = "mips")] {
                 if is_mips_feature_detected(...) { ... }
             }
@@ -105,7 +122,7 @@ macro_rules! is_mips64_feature_detected {
         is_mips64_feature_detected can only be used on MIPS64 targets.
         You can prevent it from being used in other architectures by
         guarding it behind a cfg(target_arch) as follows:
-            
+
             #[cfg(target_arch = "mips64")] {
                 if is_mips64_feature_detected(...) { ... }
             }

--- a/stdsimd/arch/detect/mod.rs
+++ b/stdsimd/arch/detect/mod.rs
@@ -33,6 +33,10 @@ cfg_if! {
         #[path = "arch/aarch64.rs"]
         #[macro_use]
         mod arch;
+    } else if #[cfg(target_arch = "powerpc")] {
+        #[path = "arch/powerpc.rs"]
+        #[macro_use]
+        mod arch;
     } else if #[cfg(target_arch = "powerpc64")] {
         #[path = "arch/powerpc64.rs"]
         #[macro_use]

--- a/stdsimd/arch/detect/os/linux/mod.rs
+++ b/stdsimd/arch/detect/os/linux/mod.rs
@@ -13,9 +13,9 @@ cfg_if! {
     } else  if #[cfg(any(target_arch = "mips", target_arch = "mips64"))] {
         mod mips;
         pub use self::mips::check_for;
-    } else if #[cfg(target_arch = "powerpc64")] {
-        mod powerpc64;
-        pub use self::powerpc64::check_for;
+    } else if #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))] {
+        mod powerpc;
+        pub use self::powerpc::check_for;
     } else {
         use arch::detect::Feature;
         /// Performs run-time feature detection.

--- a/stdsimd/arch/detect/os/linux/powerpc.rs
+++ b/stdsimd/arch/detect/os/linux/powerpc.rs
@@ -1,4 +1,4 @@
-//! Run-time feature detection for ARM on Linux.
+//! Run-time feature detection for PowerPC on Linux.
 
 use arch::detect::Feature;
 use arch::detect::cache;

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -187,6 +187,8 @@
 /// * [`aarch64`]
 /// * [`mips`]
 /// * [`mips64`]
+/// * [`powerpc`]
+/// * [`powerpc64`]
 ///
 /// [`x86`]: https://rust-lang-nursery.github.io/stdsimd/i686/stdsimd/arch/x86/index.html
 /// [`x86_64`]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/arch/x86_64/index.html
@@ -194,6 +196,8 @@
 /// [`aarch64`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/aarch64/index.html
 /// [`mips`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/mips/index.html
 /// [`mips64`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/mips64/index.html
+/// [`powerpc`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/powerpc/index.html
+/// [`powerpc64`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/powerpc64/index.html
 ///
 /// # Examples
 ///
@@ -370,6 +374,14 @@ pub mod arch {
     #[unstable(feature = "stdsimd", issue = "0")]
     pub use coresimd::arch::mips64;
 
+    #[cfg(all(not(dox), target_arch = "powerpc"))]
+    #[unstable(feature = "stdsimd", issue = "0")]
+    pub use coresimd::arch::powerpc;
+
+    #[cfg(all(not(dox), target_arch = "powerpc64"))]
+    #[unstable(feature = "stdsimd", issue = "0")]
+    pub use coresimd::arch::powerpc64;
+
     #[doc(hidden)] // unstable implementation detail
     #[unstable(feature = "stdsimd", issue = "0")]
     pub mod detect;
@@ -445,6 +457,30 @@ pub mod arch {
     #[doc(cfg(target_arch = "mips64"))]
     #[unstable(feature = "stdsimd", issue = "0")]
     pub mod mips64 {}
+
+    /// Platform-specific intrinsics for the `powerpc` platform.
+    ///
+    /// The documentation with the full listing of `powerpc` intrinsics is
+    /// available in [libcore], but the module is re-exported here in std
+    /// as well.
+    ///
+    /// [libcore]: ../../../core/arch/powerpc/index.html
+    #[cfg(dox)]
+    #[doc(cfg(target_arch = "powerpc"))]
+    #[unstable(feature = "stdsimd", issue = "0")]
+    pub mod powerpc {}
+
+    /// Platform-specific intrinsics for the `powerpc64` platform.
+    ///
+    /// The documentation with the full listing of `powerpc64` intrinsics is
+    /// available in [libcore], but the module is re-exported here in std
+    /// as well.
+    ///
+    /// [libcore]: ../../../core/arch/powerpc64/index.html
+    #[cfg(dox)]
+    #[doc(cfg(target_arch = "powerpc64"))]
+    #[unstable(feature = "stdsimd", issue = "0")]
+    pub mod powerpc64 {}
 }
 
 #[unstable(feature = "stdsimd", issue = "0")]


### PR DESCRIPTION
This PR adds run-time feature detection for 32-bit PowerPC. The backend on Linux is the same as for PowerPC64, so this just adds the feature detection macro for PowerPC, a test, and updates the docs in `stdsimd`. It also re-enables running the tests on 32-bit PowerPC.