### PR TITLE
make powerpc vector types newtypes

### DIFF
--- a/coresimd/powerpc/altivec.rs
+++ b/coresimd/powerpc/altivec.rs
@@ -666,7 +666,9 @@ mod tests {
     unsafe fn vec_add_i32x4_i32x4() {
         let x = i32x4::new(1, 2, 3, 4);
         let y = i32x4::new(4, 3, 2, 1);
+        let x: vector_signed_int = x.into_bits();
+        let y: vector_signed_int = y.into_bits();
         let z = vec_add(x, y);
-        assert_eq!(z, i32x4::splat(5));
+        assert_eq!(i32x4::splat(5), z.into_bits());
     }
 }

--- a/coresimd/powerpc/altivec.rs
+++ b/coresimd/powerpc/altivec.rs
@@ -18,17 +18,342 @@ use coresimd::simd_llvm::*;
 #[cfg(test)]
 use stdsimd_test::assert_instr;
 
-pub type vector_signed_char = i8x16;
-pub type vector_unsigned_char = u8x16;
-pub type vector_bool_char = m8x16;
-pub type vector_signed_short = i16x8;
-pub type vector_unsigned_short = u16x8;
-pub type vector_bool_short = m16x8;
-// pub type vector_pixel = ???;
-pub type vector_signed_int = i32x4;
-pub type vector_unsigned_int = u32x4;
-pub type vector_bool_int = m32x4;
-pub type vector_float = f32x4;
+types! {
+    /// PowerPC-specific 128-bit wide vector of sixteen packed `i8`
+    pub struct vector_signed_char(i8, i8, i8, i8, i8, i8, i8, i8,
+                                  i8, i8, i8, i8, i8, i8, i8, i8);
+    /// PowerPC-specific 128-bit wide vector of sixteen packed `u8`
+    pub struct vector_unsigned_char(u8, u8, u8, u8, u8, u8, u8, u8,
+                                    u8, u8, u8, u8, u8, u8, u8, u8);
+
+    /// PowerPC-specific 128-bit wide vector mask of sixteen packed elements
+    pub struct vector_bool_char(i8, i8, i8, i8, i8, i8, i8, i8,
+                                i8, i8, i8, i8, i8, i8, i8, i8);
+    /// PowerPC-specific 128-bit wide vector of eight packed `i16`
+    pub struct vector_signed_short(i16, i16, i16, i16, i16, i16, i16, i16);
+    /// PowerPC-specific 128-bit wide vector of eight packed `u16`
+    pub struct vector_unsigned_short(u16, u16, u16, u16, u16, u16, u16, u16);
+    /// PowerPC-specific 128-bit wide vector mask of eight packed elements
+    pub struct vector_bool_short(i16, i16, i16, i16, i16, i16, i16, i16);
+    // pub struct vector_pixel(???);
+    /// PowerPC-specific 128-bit wide vector of four packed `i32`
+    pub struct vector_signed_int(i32, i32, i32, i32);
+    /// PowerPC-specific 128-bit wide vector of four packed `u32`
+    pub struct vector_unsigned_int(u32, u32, u32, u32);
+    /// PowerPC-specific 128-bit wide vector mask of four packed elements
+    pub struct vector_bool_int(i32, i32, i32, i32);
+    /// PowerPC-specific 128-bit wide vector of four packed `f32`
+    pub struct vector_float(f32, f32, f32, f32);
+}
+
+impl_from_bits_!(
+    vector_signed_char: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+impl_from_bits_!(
+    i8x16:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+
+impl_from_bits_!(
+    vector_unsigned_char: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_signed_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+impl_from_bits_!(
+    u8x16:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+
+impl_from_bits_!(
+    vector_bool_char: m64x2,
+    m32x4,
+    m16x8,
+    m8x16,
+    vector_bool_short,
+    vector_bool_int
+);
+impl_from_bits_!(
+    m8x16: vector_bool_char,
+    vector_bool_short,
+    vector_bool_int
+);
+
+impl_from_bits_!(
+    vector_signed_short: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_signed_char,
+    vector_bool_char,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+impl_from_bits_!(
+    i16x8:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+
+impl_from_bits_!(
+    vector_unsigned_short: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_signed_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+impl_from_bits_!(
+    u16x8:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+
+impl_from_bits_!(
+    vector_bool_short: m64x2,
+    m32x4,
+    m16x8,
+    m8x16,
+    vector_bool_int
+);
+impl_from_bits_!(m16x8: vector_bool_short, vector_bool_int);
+
+impl_from_bits_!(
+    vector_signed_int: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_signed_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+impl_from_bits_!(
+    i32x4:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+
+impl_from_bits_!(
+    vector_unsigned_int: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_signed_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_float,
+    vector_bool_int
+);
+impl_from_bits_!(
+    u32x4:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
+
+impl_from_bits_!(
+    vector_bool_int: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16
+);
+impl_from_bits_!(m32x4: vector_bool_int);
+
+impl_from_bits_!(
+    vector_float: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_signed_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_bool_int
+);
+impl_from_bits_!(
+    f32x4:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int
+);
 
 mod sealed {
 

--- a/coresimd/powerpc64/vsx.rs
+++ b/coresimd/powerpc64/vsx.rs
@@ -8,15 +8,211 @@
 
 #![allow(non_camel_case_types)]
 
+use coresimd::powerpc::*;
 use coresimd::simd::*;
 
-// pub type vector_Float16 = f16x8;
-pub type vector_signed_long = i64x2;
-pub type vector_unsigned_long = u64x2;
-pub type vector_bool_long = u64x2;
-pub type vector_signed_long_long = vector_signed_long;
-pub type vector_unsigned_long_long = vector_unsigned_long;
-pub type vector_bool_long_long = vector_bool_long;
-pub type vector_double = f64x2;
-// pub type vector_signed___int128 = i128x1;
-// pub type vector_unsigned___int128 = i128x1;
+types! {
+    // pub struct vector_Float16 = f16x8;
+    /// PowerPC-specific 128-bit wide vector of two packed `i64`
+    pub struct vector_signed_long(i64, i64);
+    /// PowerPC-specific 128-bit wide vector of two packed `u64`
+    pub struct vector_unsigned_long(u64, u64);
+    /// PowerPC-specific 128-bit wide vector mask of two elements
+    pub struct vector_bool_long(i64, i64);
+    /// PowerPC-specific 128-bit wide vector of two packed `f64`
+    pub struct vector_double(f64, f64);
+    // pub struct vector_signed_long_long = vector_signed_long;
+    // pub struct vector_unsigned_long_long = vector_unsigned_long;
+    // pub struct vector_bool_long_long = vector_bool_long;
+    // pub struct vector_signed___int128 = i128x1;
+    // pub struct vector_unsigned___int128 = i128x1;
+}
+
+impl_from_bits_!(
+    vector_signed_long: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+impl_from_bits_!(
+    i64x2:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int,
+    vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+
+impl_from_bits_!(
+    vector_unsigned_long: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int,
+    vector_signed_long,
+    vector_bool_long,
+    vector_double
+);
+impl_from_bits_!(
+    u64x2:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int,
+    vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+
+impl_from_bits_!(
+    vector_double: u64x2,
+    i64x2,
+    f64x2,
+    m64x2,
+    u32x4,
+    i32x4,
+    f32x4,
+    m32x4,
+    u16x8,
+    i16x8,
+    m16x8,
+    u8x16,
+    i8x16,
+    m8x16,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int,
+    vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long
+);
+impl_from_bits_!(
+    f64x2:
+    vector_signed_char,
+    vector_unsigned_char,
+    vector_bool_char,
+    vector_signed_short,
+    vector_unsigned_short,
+    vector_bool_short,
+    vector_signed_int,
+    vector_unsigned_int,
+    vector_float,
+    vector_bool_int,
+    vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+
+impl_from_bits_!(vector_bool_long: m64x2);
+impl_from_bits_!(m64x2: vector_bool_long);
+impl_from_bits_!(m32x4: vector_bool_long);
+impl_from_bits_!(m16x8: vector_bool_long);
+impl_from_bits_!(m8x16: vector_bool_long);
+impl_from_bits_!(vector_bool_char: vector_bool_long);
+impl_from_bits_!(vector_bool_short: vector_bool_long);
+impl_from_bits_!(vector_bool_int: vector_bool_long);
+
+impl_from_bits_!(
+    vector_signed_char: vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+
+impl_from_bits_!(
+    vector_unsigned_char: vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+
+impl_from_bits_!(
+    vector_signed_short: vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+
+impl_from_bits_!(
+    vector_unsigned_short: vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+
+impl_from_bits_!(
+    vector_signed_int: vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);
+
+impl_from_bits_!(
+    vector_unsigned_int: vector_signed_long,
+    vector_unsigned_long,
+    vector_bool_long,
+    vector_double
+);


### PR DESCRIPTION
This PR makes PowerPC vector types be newtypes instead of type aliases to the portable-vector types. It provides the `from_bits`/`into_bits` methods for convenience.