### PR TITLE
tag private modules with doc(cfg)

### DIFF
--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -146,24 +146,31 @@ pub mod arch {
 mod simd_llvm;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", dox))]
+#[doc(cfg(any(target_arch = "x86", target_arch = "x86_64")))]
 mod x86;
 #[cfg(any(target_arch = "x86_64", dox))]
+#[doc(cfg(target_arch = "x86_64"))]
 mod x86_64;
 
 #[cfg(any(target_arch = "aarch64", dox))]
+#[doc(cfg(target_arch = "aarch64"))]
 mod aarch64;
 #[cfg(any(target_arch = "arm", target_arch = "aarch64", dox))]
+#[doc(cfg(any(target_arch = "arm", target_arch = "aarch64")))]
 mod arm;
 #[cfg(target_arch = "wasm32")]
 mod wasm32;
 
 #[cfg(any(target_arch = "mips", target_arch = "mips64", dox))]
+#[doc(cfg(any(target_arch = "mips", target_arch = "mips64")))]
 mod mips;
 
 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64", dox))]
+#[doc(cfg(any(target_arch = "powerpc", target_arch = "powerpc64")))]
 mod powerpc;
 
 #[cfg(any(target_arch = "powerpc64", dox))]
+#[doc(cfg(target_arch = "powerpc64"))]
 mod powerpc64;
 
 mod nvptx;


### PR DESCRIPTION
Should fix https://github.com/rust-lang/rust/issues/50988, but we'll need to run doctests for libcore on a powerpc64 machine to be sure

This applies `#[doc(cfg(...))]` attributes to the internal backing modules so that if doctests are run from these private modules (which they *shouldn't*, but the linked issue implies that they are...), they still have the proper `target_arch` filtering. This will make the docs for these items much more noisy, but i have a plan to patch rustdoc to "reduce" these conditionals, at least for the case being introduced here.