### PR TITLE
Mark appropriate const fns as promotable

### DIFF
--- a/crates/stdsimd/src/lib.rs
+++ b/crates/stdsimd/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![feature(const_fn, integer_atomics, staged_api, stdsimd)]
 #![feature(doc_cfg, allow_internal_unstable)]
+#![feature(promotable_const_fn, custom_attributes)]
 #![cfg_attr(feature = "cargo-clippy", allow(shadow_reuse))]
 #![cfg_attr(target_os = "linux", feature(linkage))]
 #![no_std]

--- a/stdsimd/arch/detect/cache.rs
+++ b/stdsimd/arch/detect/cache.rs
@@ -12,11 +12,13 @@ use core::sync::atomic::AtomicU64;
 use core::sync::atomic::AtomicU32;
 
 /// Sets the `bit` of `x`.
+#[promotable_const_fn]
 pub const fn set_bit(x: u64, bit: u32) -> u64 {
     x | 1 << bit
 }
 
 /// Tests the `bit` of `x`.
+#[promotable_const_fn]
 pub const fn test_bit(x: u64, bit: u32) -> bool {
     x & (1 << bit) != 0
 }


### PR DESCRIPTION
This is in preparation for doing the same change to rustc. The feature and attribute don't exist yet, so there'll be some warnings, but they'll go away once the actual change hits nightly