### PR TITLE
"dotprot" -> "dotprod"

### DIFF
--- a/stdsimd/arch/detect/arch/aarch64.rs
+++ b/stdsimd/arch/detect/arch/aarch64.rs
@@ -50,7 +50,7 @@ macro_rules! is_aarch64_feature_detected {
             $crate::arch::detect::check_for($crate::arch::detect::Feature::rcpc)
     };
     ("dotprod") => {
-        cfg!(target_feature = "dotprot") ||
+        cfg!(target_feature = "dotprod") ||
             $crate::arch::detect::check_for($crate::arch::detect::Feature::dotprod)
     };
     ("ras") => {


### PR DESCRIPTION
Well, since I reported it I guess I should do something about it.

~~Note this is a *cough* **breaking change.**~~

**Edit:** Never mind the "breaking change," I mistakenly thought the string I changed was the macro LHS.

---

Closes #442.