### PR TITLE
Remove stray inconsistent #[cfg]

### DIFF
--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -134,7 +134,6 @@ pub mod arch {
     /// Platform-specific intrinsics for the `PowerPC64` platform.
     ///
     /// See the [module documentation](../index.html) for more details.
-    #[cfg(target_arch = "powerpc64")]
     #[cfg(any(target_arch = "powerpc64", dox))]
     #[doc(cfg(target_arch = "powerpc64"))]
     #[unstable(feature = "stdsimd", issue = "27731")]


### PR DESCRIPTION
The cfg for the target is already covered a few lines below.
This cfg meant that even with the dox feature enabled, no
documentation for powerpc64 was generated except you were
actually targetting the powerpc64 arch.