### PR TITLE
Relative links to arch modules

### DIFF
--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -188,12 +188,12 @@
 /// * [`powerpc`]
 /// * [`powerpc64`]
 ///
-/// [`x86`]: https://rust-lang-nursery.github.io/stdsimd/i686/stdsimd/arch/x86/index.html
-/// [`x86_64`]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/arch/x86_64/index.html
-/// [`arm`]: https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/arch/arm/index.html
-/// [`aarch64`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/aarch64/index.html
-/// [`mips`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/mips/index.html
-/// [`mips64`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/mips64/index.html
+/// [`x86`]: x86/index.html
+/// [`x86_64`]: x86_64/index.html
+/// [`arm`]: arm/index.html
+/// [`aarch64`]: aarch64/index.html
+/// [`mips`]: mips/index.html
+/// [`mips64`]: mips64/index.html
 /// [`powerpc`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/powerpc/index.html
 /// [`powerpc64`]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/arch/powerpc64/index.html
 ///


### PR DESCRIPTION
[Currently](https://doc.rust-lang.org/std/arch/index.html#other-architectures) `stdsimd` modules point to the documentation hosted at https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/ instead of https://doc.rust-lang.org/std/arch/ which is confusing.

Since Rust 1.27 has shipped the `stdsimd`, and its documentation is hosted on the [official site](https://doc.rust-lang.org/std/arch/), it is essential to make those links relative.

The only exception are links to `powerpc` and `powerpc64`, because they are unavailable (yet?).