### PR TITLE
deprecate read/write eflags

### DIFF
--- a/coresimd/x86/eflags.rs
+++ b/coresimd/x86/eflags.rs
@@ -6,6 +6,8 @@
 #[cfg(target_arch = "x86")]
 #[inline(always)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
+#[rustc_deprecated(since = "1.29.0", reason = "See issue #51810 - use inline assembly instead")]
+#[doc(hidden)]
 pub unsafe fn __readeflags() -> u32 {
     let eflags: u32;
     asm!("pushfd; popl $0" : "=r"(eflags) : : : "volatile");
@@ -18,6 +20,8 @@ pub unsafe fn __readeflags() -> u32 {
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
+#[rustc_deprecated(since = "1.29.0", reason = "See issue #51810 - use inline assembly instead")]
+#[doc(hidden)]
 pub unsafe fn __readeflags() -> u64 {
     let eflags: u64;
     asm!("pushfq; popq $0" : "=r"(eflags) : : : "volatile");
@@ -30,6 +34,8 @@ pub unsafe fn __readeflags() -> u64 {
 #[cfg(target_arch = "x86")]
 #[inline(always)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
+#[rustc_deprecated(since = "1.29.0", reason = "See issue #51810 - use inline assembly instead")]
+#[doc(hidden)]
 pub unsafe fn __writeeflags(eflags: u32) {
     asm!("pushl $0; popfd" : : "r"(eflags) : "cc", "flags" : "volatile");
 }
@@ -40,6 +46,8 @@ pub unsafe fn __writeeflags(eflags: u32) {
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
+#[rustc_deprecated(since = "1.29.0", reason = "See issue #51810 - use inline assembly instead")]
+#[doc(hidden)]
 pub unsafe fn __writeeflags(eflags: u64) {
     asm!("pushq $0; popfq" : : "r"(eflags) : "cc", "flags" : "volatile");
 }
@@ -49,6 +57,7 @@ mod tests {
     use coresimd::x86::*;
 
     #[test]
+    #[allow(deprecated)]
     fn test_eflags() {
         unsafe {
             // reads eflags, writes them back, reads them again,


### PR DESCRIPTION
This deprecates `__{read,write}eflags`. 