### PR TITLE
add rotate_left/right

### DIFF
--- a/coresimd/ppsv/api/mod.rs
+++ b/coresimd/ppsv/api/mod.rs
@@ -124,6 +124,8 @@ mod masks_select;
 mod scalar_shifts;
 #[macro_use]
 mod shifts;
+#[macro_use]
+mod rotates;
 
 /// Sealed trait used for constraining select implementations.
 pub trait Lanes<A> {}
@@ -191,6 +193,7 @@ macro_rules! simd_i_ty {
             [impl_bitwise_reductions, $id, $elem_ty],
             [impl_all_scalar_shifts, $id, $elem_ty],
             [impl_vector_shifts, $id, $elem_ty],
+            [impl_vector_rotates, $id, $elem_ty],
             [impl_hex_fmt, $id, $elem_ty],
             [impl_eq, $id],
             [impl_partial_eq, $id],
@@ -215,6 +218,7 @@ macro_rules! simd_i_ty {
                 test_bitwise_reductions!($id, !(0 as $elem_ty));
                 test_all_scalar_shift_ops!($id, $elem_ty);
                 test_vector_shift_ops!($id, $elem_ty);
+                test_vector_rotate_ops!($id, $elem_ty);
                 test_hex_fmt!($id, $elem_ty);
                 test_partial_eq!($id, 1 as $elem_ty, 0 as $elem_ty);
                 test_default!($id, $elem_ty);
@@ -245,6 +249,7 @@ macro_rules! simd_u_ty {
             [impl_bitwise_reductions, $id, $elem_ty],
             [impl_all_scalar_shifts, $id, $elem_ty],
             [impl_vector_shifts, $id, $elem_ty],
+            [impl_vector_rotates, $id, $elem_ty],
             [impl_hex_fmt, $id, $elem_ty],
             [impl_eq, $id],
             [impl_partial_eq, $id],
@@ -268,6 +273,7 @@ macro_rules! simd_u_ty {
                 test_bitwise_reductions!($id, !(0 as $elem_ty));
                 test_all_scalar_shift_ops!($id, $elem_ty);
                 test_vector_shift_ops!($id, $elem_ty);
+                test_vector_rotate_ops!($id, $elem_ty);
                 test_hex_fmt!($id, $elem_ty);
                 test_partial_eq!($id, 1 as $elem_ty, 0 as $elem_ty);
                 test_default!($id, $elem_ty);

--- a/coresimd/ppsv/api/rotates.rs
+++ b/coresimd/ppsv/api/rotates.rs
@@ -9,8 +9,8 @@ macro_rules! impl_vector_rotates {
             /// the end of the resulting integer.
             ///
             /// Please note this isn't the same operation as `<<`!. Also note it
-            /// isn't equivalent to `slice::rotate_left` (that can be implemented
-            /// with vector shuffles).
+            /// isn't equivalent to `slice::rotate_left`, it doesn't move the vector's
+            /// lanes around. (that can be implemented with vector shuffles).
             #[inline]
             pub fn rotate_left(self, n: $id) -> $id {
                 const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;

--- a/coresimd/ppsv/api/rotates.rs
+++ b/coresimd/ppsv/api/rotates.rs
@@ -1,0 +1,83 @@
+//! Implements integer rotates.
+#![allow(unused)]
+
+macro_rules! impl_vector_rotates {
+    ($id:ident, $elem_ty:ident) => {
+        impl $id {
+            /// Shifts the bits of each lane to the left by the specified amount in
+            /// the corresponding lane of `n`, wrapping the truncated bits to
+            /// the end of the resulting integer.
+            ///
+            /// Please note this isn't the same operation as `<<`!. Also note it
+            /// isn't equivalent to `slice::rotate_left` (that can be implemented
+            /// with vector shuffles).
+            #[inline]
+            pub fn rotate_left(self, n: $id) -> $id {
+                const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
+                // Protect against undefined behavior for over-long bit shifts
+                let n = n % LANE_WIDTH;
+                (self << n) | (self >> ((LANE_WIDTH - n) % LANE_WIDTH))
+            }
+
+            /// Shifts the bits of each lane to the right by the specified amount in
+            /// the corresponding lane of `n`, wrapping the truncated bits to
+            /// the beginning of the resulting integer.
+            ///
+            /// Please note this isn't the same operation as `>>`!. Also note it
+            /// isn't similar to `slice::rotate_right`, it doesn't move the vector's
+            /// lanes around. (that can be implemented with vector shuffles).
+            #[inline]
+            pub fn rotate_right(self, n: $id) -> $id {
+                const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
+                // Protect against undefined behavior for over-long bit shifts
+                let n = n % LANE_WIDTH;
+                (self >> n) | (self << ((LANE_WIDTH - n) % LANE_WIDTH))
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! test_vector_rotate_ops {
+    ($id:ident, $elem_ty:ident) => {
+        #[test]
+        fn rotate_ops() {
+            use coresimd::simd::$id;
+            use std::mem;
+            let z = $id::splat(0 as $elem_ty);
+            let o = $id::splat(1 as $elem_ty);
+            let t = $id::splat(2 as $elem_ty);
+            let f = $id::splat(4 as $elem_ty);
+
+            let max =
+                $id::splat((mem::size_of::<$elem_ty>() * 8 - 1) as $elem_ty);
+
+            // rotate_right
+            assert_eq!(z.rotate_right(z), z);
+            assert_eq!(z.rotate_right(o), z);
+            assert_eq!(z.rotate_right(t), z);
+
+            assert_eq!(o.rotate_right(z), o);
+            assert_eq!(t.rotate_right(z), t);
+            assert_eq!(f.rotate_right(z), f);
+            assert_eq!(f.rotate_right(max), f << 1);
+
+            assert_eq!(o.rotate_right(o), o << max);
+            assert_eq!(t.rotate_right(o), o);
+            assert_eq!(t.rotate_right(t), o << max);
+            assert_eq!(f.rotate_right(o), t);
+            assert_eq!(f.rotate_right(t), o);
+
+            // rotate_left
+            assert_eq!(z.rotate_left(z), z);
+            assert_eq!(o.rotate_left(z), o);
+            assert_eq!(t.rotate_left(z), t);
+            assert_eq!(f.rotate_left(z), f);
+            assert_eq!(f.rotate_left(max), t);
+
+            assert_eq!(o.rotate_left(o), t);
+            assert_eq!(o.rotate_left(t), f);
+            assert_eq!(t.rotate_left(o), f);
+        }
+    };
+}

--- a/coresimd/ppsv/api/rotates.rs
+++ b/coresimd/ppsv/api/rotates.rs
@@ -1,6 +1,8 @@
 //! Implements integer rotates.
 #![allow(unused)]
 
+// inline(always) to encourage the compiler to generate rotate instructions
+// where available
 macro_rules! impl_vector_rotates {
     ($id:ident, $elem_ty:ident) => {
         impl $id {
@@ -11,7 +13,7 @@ macro_rules! impl_vector_rotates {
             /// Please note this isn't the same operation as `<<`!. Also note it
             /// isn't equivalent to `slice::rotate_left`, it doesn't move the vector's
             /// lanes around. (that can be implemented with vector shuffles).
-            #[inline]
+            #[inline(always)]
             pub fn rotate_left(self, n: $id) -> $id {
                 const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
                 // Protect against undefined behavior for over-long bit shifts
@@ -26,7 +28,7 @@ macro_rules! impl_vector_rotates {
             /// Please note this isn't the same operation as `>>`!. Also note it
             /// isn't similar to `slice::rotate_right`, it doesn't move the vector's
             /// lanes around. (that can be implemented with vector shuffles).
-            #[inline]
+            #[inline(always)]
             pub fn rotate_right(self, n: $id) -> $id {
                 const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
                 // Protect against undefined behavior for over-long bit shifts

--- a/coresimd/ppsv/api/rotates.rs
+++ b/coresimd/ppsv/api/rotates.rs
@@ -16,7 +16,7 @@ macro_rules! impl_vector_rotates {
                 const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
                 // Protect against undefined behavior for over-long bit shifts
                 let n = n % LANE_WIDTH;
-                (self << n) | (self >> (LANE_WIDTH - n))
+                (self << n) | (self >> ((LANE_WIDTH - n) % LANE_WIDTH))
             }
 
             /// Shifts the bits of each lane to the right by the specified amount in
@@ -31,7 +31,7 @@ macro_rules! impl_vector_rotates {
                 const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
                 // Protect against undefined behavior for over-long bit shifts
                 let n = n % LANE_WIDTH;
-                (self >> n) | (self << (LANE_WIDTH - n))
+                (self >> n) | (self << ((LANE_WIDTH - n) % LANE_WIDTH))
             }
         }
     };

--- a/coresimd/ppsv/api/rotates.rs
+++ b/coresimd/ppsv/api/rotates.rs
@@ -16,7 +16,7 @@ macro_rules! impl_vector_rotates {
                 const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
                 // Protect against undefined behavior for over-long bit shifts
                 let n = n % LANE_WIDTH;
-                (self << n) | (self >> ((LANE_WIDTH - n) % LANE_WIDTH))
+                (self << n) | (self >> (LANE_WIDTH - n))
             }
 
             /// Shifts the bits of each lane to the right by the specified amount in
@@ -31,7 +31,7 @@ macro_rules! impl_vector_rotates {
                 const LANE_WIDTH: $elem_ty = ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
                 // Protect against undefined behavior for over-long bit shifts
                 let n = n % LANE_WIDTH;
-                (self >> n) | (self << ((LANE_WIDTH - n) % LANE_WIDTH))
+                (self >> n) | (self << (LANE_WIDTH - n))
             }
         }
     };

--- a/coresimd/ppsv/api/shifts.rs
+++ b/coresimd/ppsv/api/shifts.rs
@@ -53,7 +53,6 @@ macro_rules! test_vector_shift_ops {
             assert_eq!(z >> z, z);
             assert_eq!(z >> o, z);
             assert_eq!(z >> t, z);
-            assert_eq!(z >> t, z);
 
             assert_eq!(o >> z, o);
             assert_eq!(t >> z, t);
@@ -65,7 +64,6 @@ macro_rules! test_vector_shift_ops {
             assert_eq!(t >> t, z);
             assert_eq!(f >> o, t);
             assert_eq!(f >> t, o);
-            assert_eq!(f >> max, z);
 
             // shl
             assert_eq!(z << z, z);

--- a/crates/coresimd/tests/rotate_tests.rs
+++ b/crates/coresimd/tests/rotate_tests.rs
@@ -15,35 +15,35 @@ use stdsimd_test::assert_instr;
 
 #[inline]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
-#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprorvq))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vpro))]
 unsafe fn rotate_right_variable(x: u64x8) -> u64x8 {
     x.rotate_right(u64x8::new(0, 1, 2, 3, 4, 5, 6, 7))
 }
 
 #[inline]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
-#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprolvq))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vpro))]
 unsafe fn rotate_left_variable(x: u64x8) -> u64x8 {
     x.rotate_left(u64x8::new(0, 1, 2, 3, 4, 5, 6, 7))
 }
 
 #[inline]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
-#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprorq))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vpro))]
 unsafe fn rotate_right(x: u64x8) -> u64x8 {
     x.rotate_right(u64x8::splat(12))
 }
 
 #[inline]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
-#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprolq))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vpro))]
 unsafe fn rotate_left(x: u64x8) -> u64x8 {
     x.rotate_left(u64x8::splat(12))
 }
 
 #[inline]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
-#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprolq))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vpro))]
 unsafe fn rotate_left_x2(x: u64x2) -> u64x2 {
     x.rotate_left(u64x2::splat(12))
 }

--- a/crates/coresimd/tests/rotate_tests.rs
+++ b/crates/coresimd/tests/rotate_tests.rs
@@ -1,0 +1,49 @@
+//! rotate instruction tests
+
+#![feature(stdsimd)]
+#![feature(proc_macro)]
+#![feature(avx512_target_feature)]
+#![feature(abi_vectorcall)]
+
+extern crate stdsimd_test;
+extern crate stdsimd;
+
+use stdsimd::simd::*;
+use stdsimd_test::assert_instr;
+
+// Verify that supported hardware compiles rotates into single instructions
+
+#[inline]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprorvq))]
+unsafe fn rotate_right_variable(x: u64x8) -> u64x8 {
+    x.rotate_right(u64x8::new(0, 1, 2, 3, 4, 5, 6, 7))
+}
+
+#[inline]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprolvq))]
+unsafe fn rotate_left_variable(x: u64x8) -> u64x8 {
+    x.rotate_left(u64x8::new(0, 1, 2, 3, 4, 5, 6, 7))
+}
+
+#[inline]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprorq))]
+unsafe fn rotate_right(x: u64x8) -> u64x8 {
+    x.rotate_right(u64x8::splat(12))
+}
+
+#[inline]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprolq))]
+unsafe fn rotate_left(x: u64x8) -> u64x8 {
+    x.rotate_left(u64x8::splat(12))
+}
+
+#[inline]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vprolq))]
+unsafe fn rotate_left_x2(x: u64x2) -> u64x2 {
+    x.rotate_left(u64x2::splat(12))
+}

--- a/crates/coresimd/tests/rotate_tests.rs
+++ b/crates/coresimd/tests/rotate_tests.rs
@@ -15,6 +15,7 @@ use stdsimd_test::assert_instr;
 
 #[inline]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512vl"))]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vpro))]
 unsafe fn rotate_right_variable(x: u64x8) -> u64x8 {
     x.rotate_right(u64x8::new(0, 1, 2, 3, 4, 5, 6, 7))
@@ -22,6 +23,7 @@ unsafe fn rotate_right_variable(x: u64x8) -> u64x8 {
 
 #[inline]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512f"))]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), target_feature(enable = "avx512vl"))]
 #[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vpro))]
 unsafe fn rotate_left_variable(x: u64x8) -> u64x8 {
     x.rotate_left(u64x8::new(0, 1, 2, 3, 4, 5, 6, 7))

--- a/crates/coresimd/tests/rotate_tests.rs
+++ b/crates/coresimd/tests/rotate_tests.rs
@@ -5,8 +5,8 @@
 #![feature(avx512_target_feature)]
 #![feature(abi_vectorcall)]
 
-extern crate stdsimd_test;
 extern crate stdsimd;
+extern crate stdsimd_test;
 
 use stdsimd::simd::*;
 use stdsimd_test::assert_instr;


### PR DESCRIPTION
(also removed some duplicate tests)

It would be good to test that on supported hardware this compiles to the correct instruction, but I don't know how to do that.

Also some scalar convenience impls would be good.

(https://github.com/rust-lang-nursery/rand/issues/377)