### PR TITLE
Adds CI for S390x and fix s390x-unknown-linux-gnu build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     - env: TARGET=powerpc-unknown-linux-gnu
     - env: TARGET=powerpc64-unknown-linux-gnu
     - env: TARGET=powerpc64le-unknown-linux-gnu
+    - env: TARGET=s390x-unknown-linux-gnu NORUN=1
     - os: osx
       env: TARGET=i686-apple-darwin
       script: ci/run.sh

--- a/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:17.10
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates \
+        gcc libc6-dev \
+        gcc-s390x-linux-gnu libc6-dev-s390x-cross \
+        qemu-user \
+        make \
+        file
+
+ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
+    CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="qemu-s390x -L /usr/s390x-linux-gnu" \
+    OBJDUMP=s390x-linux-gnu-objdump

--- a/coresimd/ppsv/codegen/cos.rs
+++ b/coresimd/ppsv/codegen/cos.rs
@@ -1,9 +1,14 @@
 //! Exact vector cos
-
+#![allow(dead_code)]
 use coresimd::simd::*;
 
 #[allow(improper_ctypes)]
 extern "C" {
+    #[link_name = "llvm.cos.f32"]
+    fn cos_f32(x: f32) -> f32;
+    #[link_name = "llvm.cos.f64"]
+    fn cos_f64(x: f64) -> f64;
+
     #[link_name = "llvm.cos.v2f32"]
     fn cos_v2f32(x: f32x2) -> f32x2;
     #[link_name = "llvm.cos.v4f32"]
@@ -24,11 +29,41 @@ pub(crate) trait FloatCos {
     fn cos(self) -> Self;
 }
 
+trait RawCos {
+    fn raw_cos(self) -> Self;
+}
+
+impl RawCos for f32 {
+    fn raw_cos(self) -> Self {
+        unsafe { cos_f32(self) }
+    }
+}
+
+impl RawCos for f64 {
+    fn raw_cos(self) -> Self {
+        unsafe { cos_f64(self) }
+    }
+}
+
+
 macro_rules! impl_fcos {
     ($id:ident : $fn:ident) => {
+        #[cfg(not(target_arch = "s390x"))]
         impl FloatCos for $id {
             fn cos(self) -> Self {
                 unsafe { $fn(self) }
+            }
+        }
+
+        // FIXME: https://github.com/rust-lang-nursery/stdsimd/issues/501
+        #[cfg(target_arch = "s390x")]
+        impl FloatCos for $id {
+            fn cos(self) -> Self {
+                let mut v = $id::splat(0.);
+                for i in 0..$id::lanes() {
+                    v = v.replace(i, self.extract(i).raw_cos())
+                }
+                v
             }
         }
     };

--- a/coresimd/ppsv/codegen/fma.rs
+++ b/coresimd/ppsv/codegen/fma.rs
@@ -1,5 +1,5 @@
 //! Vector fused multiply add
-
+#![allow(dead_code)]
 use coresimd::simd::*;
 
 #[allow(improper_ctypes)]
@@ -26,9 +26,17 @@ pub(crate) trait FloatFma {
 
 macro_rules! impl_fma {
     ($id:ident : $fn:ident) => {
+        #[cfg(not(target_arch = "s390x"))]
         impl FloatFma for $id {
             fn fma(self, y: Self, z: Self) -> Self {
                 unsafe { $fn(self, y, z) }
+            }
+        }
+        // FIXME: https://github.com/rust-lang-nursery/stdsimd/issues/501
+        #[cfg(target_arch = "s390x")]
+        impl FloatFma for $id {
+            fn fma(self, y: Self, z: Self) -> Self {
+                self * y + z
             }
         }
     };

--- a/coresimd/ppsv/codegen/sin.rs
+++ b/coresimd/ppsv/codegen/sin.rs
@@ -1,9 +1,14 @@
 //! Exact vector sin
-
+#![allow(dead_code)]
 use coresimd::simd::*;
 
 #[allow(improper_ctypes)]
 extern "C" {
+    #[link_name = "llvm.sin.f32"]
+    fn sin_f32(x: f32) -> f32;
+    #[link_name = "llvm.sin.f64"]
+    fn sin_f64(x: f64) -> f64;
+
     #[link_name = "llvm.sin.v2f32"]
     fn sin_v2f32(x: f32x2) -> f32x2;
     #[link_name = "llvm.sin.v4f32"]
@@ -24,13 +29,43 @@ pub(crate) trait FloatSin {
     fn sin(self) -> Self;
 }
 
+trait RawSin {
+    fn raw_sin(self) -> Self;
+}
+
+impl RawSin for f32 {
+    fn raw_sin(self) -> Self {
+        unsafe { sin_f32(self) }
+    }
+}
+
+impl RawSin for f64 {
+    fn raw_sin(self) -> Self {
+        unsafe { sin_f64(self) }
+    }
+}
+
 macro_rules! impl_fsin {
     ($id:ident : $fn:ident) => {
+        #[cfg(not(target_arch = "s390x"))]
         impl FloatSin for $id {
             fn sin(self) -> Self {
                 unsafe { $fn(self) }
             }
         }
+
+        // FIXME: https://github.com/rust-lang-nursery/stdsimd/issues/501
+        #[cfg(target_arch = "s390x")]
+        impl FloatSin for $id {
+            fn sin(self) -> Self {
+                let mut v = $id::splat(0.);
+                for i in 0..$id::lanes() {
+                    v = v.replace(i, self.extract(i).raw_sin())
+                }
+                v
+            }
+        }
+
     };
 }
 

--- a/coresimd/ppsv/codegen/sqrt.rs
+++ b/coresimd/ppsv/codegen/sqrt.rs
@@ -1,9 +1,14 @@
 //! Exact vector square-root
-
+#![allow(dead_code)]
 use coresimd::simd::*;
 
 #[allow(improper_ctypes)]
 extern "C" {
+    #[link_name = "llvm.sqrt.f32"]
+    fn sqrt_f32(x: f32) -> f32;
+    #[link_name = "llvm.sqrt.f64"]
+    fn sqrt_f64(x: f64) -> f64;
+
     #[link_name = "llvm.sqrt.v2f32"]
     fn sqrt_v2f32(x: f32x2) -> f32x2;
     #[link_name = "llvm.sqrt.v4f32"]
@@ -24,13 +29,42 @@ pub(crate) trait FloatSqrt {
     fn sqrt(self) -> Self;
 }
 
+trait RawSqrt {
+    fn raw_sqrt(self) -> Self;
+}
+
+impl RawSqrt for f32 {
+    fn raw_sqrt(self) -> Self {
+        unsafe { sqrt_f32(self) }
+    }
+}
+
+impl RawSqrt for f64 {
+    fn raw_sqrt(self) -> Self {
+        unsafe { sqrt_f64(self) }
+    }
+}
+
 macro_rules! impl_fsqrt {
     ($id:ident : $fn:ident) => {
+        #[cfg(not(target_arch = "s390x"))]
         impl FloatSqrt for $id {
             fn sqrt(self) -> Self {
                 unsafe { $fn(self) }
             }
         }
+        // FIXME: https://github.com/rust-lang-nursery/stdsimd/issues/501
+        #[cfg(target_arch = "s390x")]
+        impl FloatSqrt for $id {
+            fn sqrt(self) -> Self {
+                let mut v = $id::splat(0.);
+                for i in 0..$id::lanes() {
+                    v = v.replace(i, self.extract(i).raw_sqrt());
+                }
+                v
+            }
+        }
+
     };
 }
 

--- a/crates/coresimd/tests/reductions.rs
+++ b/crates/coresimd/tests/reductions.rs
@@ -2,7 +2,7 @@
 #![feature(arm_target_feature)]
 #![feature(aarch64_target_feature)]
 #![feature(powerpc_target_feature)]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, dead_code, unused_imports, unused_macros)]
 
 #[macro_use]
 extern crate stdsimd;


### PR DESCRIPTION
This adds CI for s390-unknown-linux-gnu (build only) and fixes the builds by falling back to scalar code for the portable floating-point vector types. 

I've filled #501 to track using the LLVM vector intrinsics directly on `s390x`, and I've filled #503 to track enabling running the tests on CI. 

cc @malbarbo