### PR TITLE
Test vec_mradds and not vec_madds

### DIFF
--- a/coresimd/powerpc/altivec.rs
+++ b/coresimd/powerpc/altivec.rs
@@ -901,7 +901,7 @@ mod tests {
 
         let d = i16x8::new(0, 3, 6, 9, 12, 15, 18, i16::max_value());
 
-        assert_eq!(d, vec_madds(a, b, c).into_bits());
+        assert_eq!(d, vec_mradds(a, b, c).into_bits());
     }
 
     #[simd_test(enable = "altivec")]


### PR DESCRIPTION
Typo introduced in 1d6ccad0136cd1ed97dbb83b4975d8feb6fec059