### PR TITLE
Fix PartialEq issue #511 and somewhat address #457

### DIFF
--- a/coresimd/ppsv/api/partial_eq.rs
+++ b/coresimd/ppsv/api/partial_eq.rs
@@ -10,7 +10,7 @@ macro_rules! impl_partial_eq {
             }
             #[inline]
             fn ne(&self, other: &Self) -> bool {
-                $id::ne(*self, *other).all()
+                $id::ne(*self, *other).any()
             }
         }
     };
@@ -24,6 +24,18 @@ macro_rules! test_partial_eq {
             use coresimd::simd::*;
 
             let a = $id::splat($false);
+            let b = $id::splat($true);
+
+            assert!(a != b);
+            assert!(!(a == b));
+            assert!(a == a);
+            assert!(!(a != a));
+
+            // Test further to make sure comparisons work with non-splatted
+            // values.
+            // This is to test the fix for #511
+
+            let a = $id::splat($false).replace(0, $true);
             let b = $id::splat($true);
 
             assert!(a != b);


### PR DESCRIPTION
I have tested this code to work on both debug and release builds on both `x86_64-pc-windows-msvc` and `aarch64-unknown-linux-gnu` on actual hardware. Sadly my PPC box is offline and I'm remote.

The fix is quite simple and my confidence is quite high it won't affect anything negatively.

The test is a bit hacky as it would not work if in future we had single lane types, but I think this is unlikely. I tested the test against the old codebase and it correctly identified that there was an issue with `ne()` so the test supplements the existing one well.

There is probably room for improvement for making even better tests here, but this at least will prevent this mistake again.

-B