### PR TITLE
Fix compile on latest nightly

### DIFF
--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -8,8 +8,6 @@
 //! `#[test]` function to the original token stream which asserts that the
 //! function itself contains the relevant instruction.
 
-#![feature(proc_macro)]
-
 extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -20,7 +20,7 @@
 )]
 #![cfg_attr(
     test,
-    feature(proc_macro, test, attr_literals, abi_vectorcall, untagged_unions)
+    feature(use_extern_macros, test, attr_literals, abi_vectorcall, untagged_unions)
 )]
 #![cfg_attr(
     feature = "cargo-clippy",

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -3,8 +3,6 @@
 //! This macro expands to a `#[test]` function which tests the local machine
 //! for the appropriate cfg before calling the inner test function.
 
-#![feature(proc_macro)]
-
 extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]

--- a/crates/stdsimd-test/src/lib.rs
+++ b/crates/stdsimd-test/src/lib.rs
@@ -4,7 +4,7 @@
 //! output once globally and then provides the `assert` function which makes
 //! assertions about the disassembly of a function.
 
-#![feature(proc_macro)]
+#![feature(use_extern_macros)]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(missing_docs_in_private_items, print_stdout)

--- a/crates/stdsimd-verify/src/lib.rs
+++ b/crates/stdsimd-verify/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro)]
-
 extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]

--- a/crates/stdsimd-verify/tests/x86-intel.rs
+++ b/crates/stdsimd-verify/tests/x86-intel.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro)]
+#![feature(use_extern_macros)]
 #![allow(bad_style)]
 #![cfg_attr(
     feature = "cargo-clippy",


### PR DESCRIPTION
The `proc_macro` feature has stabilized in the compiler and usage of it largely
needs to switch to `use_extern_macros` now.

Closes #526