### PR TITLE
Fix x86 build on latest nightly

### DIFF
--- a/coresimd/x86/rdtsc.rs
+++ b/coresimd/x86/rdtsc.rs
@@ -59,7 +59,7 @@ extern "C" {
 
 #[cfg(test)]
 mod tests {
-    use coresimd::x86::rdtsc;
+    use coresimd::x86::*;
     use stdsimd_test::simd_test;
 
     #[simd_test(enable = "sse2")]


### PR DESCRIPTION
`cargo test --no-run` and Travis CI raise:

```
error[E0432]: unresolved import
  --> crates/coresimd/src/../../../coresimd/x86/rdtsc.rs:62:9
   |
62 |     use coresimd::x86::rdtsc;
   |        
``` ^^^^^^^^^^^^^^^^^^^^