### PR TITLE
generate docs for Cortex-M / Cortex-R intrinsics

### DIFF
--- a/coresimd/arm/cmsis.rs
+++ b/coresimd/arm/cmsis.rs
@@ -164,7 +164,7 @@ pub unsafe fn __set_PRIMASK(pri_mask: u32) {
     asm!("msr PRIMASK, $0" : : "r"(pri_mask) : : "volatile");
 }
 
-#[cfg(target_feature = "v7")]
+#[cfg(any(target_feature = "v7", dox))]
 mod v7 {
     /// Enable FIQ
     ///
@@ -245,7 +245,7 @@ mod v7 {
     }
 }
 
-#[cfg(target_feature = "v7")]
+#[cfg(any(target_feature = "v7", dox))]
 pub use self::v7::*;
 
 /* Core instruction access */

--- a/coresimd/arm/mod.rs
+++ b/coresimd/arm/mod.rs
@@ -7,9 +7,9 @@
 //! [arm_dat]: https://developer.arm.com/technologies/neon/intrinsics
 #![allow(non_camel_case_types)]
 
-#[cfg(target_feature = "mclass")]
+#[cfg(any(target_feature = "mclass", dox))]
 mod cmsis;
-#[cfg(target_feature = "mclass")]
+#[cfg(any(target_feature = "mclass", dox))]
 pub use self::cmsis::*;
 
 mod v6;
@@ -20,9 +20,9 @@ mod v7;
 #[cfg(any(target_arch = "aarch64", target_feature = "v7"))]
 pub use self::v7::*;
 
-#[cfg(all(target_feature = "v7", not(target_feature = "mclass")))]
+#[cfg(any(all(target_feature = "v7", not(target_feature = "mclass")), dox))]
 mod dsp;
-#[cfg(all(target_feature = "v7", not(target_feature = "mclass")))]
+#[cfg(any(all(target_feature = "v7", not(target_feature = "mclass")), dox))]
 pub use self::dsp::*;
 
 // NEON is supported on AArch64, and on ARM when built with the v7 and neon


### PR DESCRIPTION
This should fix doc generation for the intrinsics added in #518, #529 and #532. Or, at least the docs show up for me when I invoke `cargo rustdoc -p coresimd --open -- --cfg dox`.