### PR TITLE
Add `#` prefix to doc comment

### DIFF
--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -59,7 +59,7 @@
 ///
 /// ```ignore
 /// #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
-///       target_feature = "avx2"))]
+/// #     target_feature = "avx2"))]
 /// fn foo() {
 ///     #[cfg(target_arch = "x86")]
 ///     use std::arch::x86::_mm256_add_epi64;


### PR DESCRIPTION
This will fix broken rustfmt in CI.

cc https://github.com/rust-lang-nursery/rustfmt/issues/2787.