### PR TITLE
Rename `wasm32` memory intrinsics

### DIFF
--- a/ci/docker/wasm32-unknown-unknown/Dockerfile
+++ b/ci/docker/wasm32-unknown-unknown/Dockerfile
@@ -17,9 +17,9 @@ RUN make -C wabt -j$(nproc)
 ENV PATH=$PATH:/wabt/bin
 
 # Install `wasm-bindgen-test-runner`
-RUN curl -L https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.16/wasm-bindgen-0.2.16-x86_64-unknown-linux-musl.tar.gz \
+RUN curl -L https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.19/wasm-bindgen-0.2.19-x86_64-unknown-linux-musl.tar.gz \
   | tar xzf -
-ENV PATH=$PATH:/wasm-bindgen-0.2.16-x86_64-unknown-linux-musl
+ENV PATH=$PATH:/wasm-bindgen-0.2.19-x86_64-unknown-linux-musl
 ENV CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner
 
 # Install `node`

--- a/coresimd/wasm32/memory.rs
+++ b/coresimd/wasm32/memory.rs
@@ -1,0 +1,55 @@
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+#[cfg(test)]
+use wasm_bindgen_test::wasm_bindgen_test;
+
+extern "C" {
+    #[link_name = "llvm.wasm.memory.grow.i32"]
+    fn llvm_memory_grow(mem: i32, pages: i32) -> i32;
+    #[link_name = "llvm.wasm.memory.size.i32"]
+    fn llvm_memory_size(mem: i32) -> i32;
+}
+
+/// Corresponding intrinsic to wasm's [`memory.size` instruction][instr]
+///
+/// This function, when called, will return the current memory size in units of
+/// pages.
+///
+/// The argument `mem` is the numerical index of which memory to return the
+/// size of. Note that currently wasm only supports one memory, so specifying
+/// a nonzero value will likely result in a runtime validation error of the
+/// wasm module.
+///
+/// [instr]: https://github.com/WebAssembly/design/blob/master/Semantics.md#resizing
+#[inline]
+#[cfg_attr(test, assert_instr("memory.size", mem = 0))]
+#[rustc_args_required_const(0)]
+pub unsafe fn size(mem: i32) -> i32 {
+    if mem != 0 {
+        ::intrinsics::abort();
+    }
+    llvm_memory_size(0)
+}
+
+/// Corresponding intrinsic to wasm's [`memory.grow` instruction][instr]
+///
+/// This function, when called, will attempt to grow the default linear memory
+/// by the specified `delta` of pages. If memory is successfully grown then the
+/// previous size of memory, in pages, is returned. If memory cannot be grown
+/// then -1 is returned.
+///
+/// The argument `mem` is the numerical index of which memory to return the
+/// size of. Note that currently wasm only supports one memory, so specifying
+/// a nonzero value will likely result in a runtime validation error of the
+/// wasm module.
+///
+/// [instr]: https://github.com/WebAssembly/design/blob/master/Semantics.md#resizing
+#[inline]
+#[cfg_attr(test, assert_instr("memory.grow", mem = 0))]
+#[rustc_args_required_const(0)]
+pub unsafe fn grow(mem: i32, delta: i32) -> i32 {
+    if mem != 0 {
+        ::intrinsics::abort();
+    }
+    llvm_memory_grow(0, delta)
+}

--- a/coresimd/wasm32/mod.rs
+++ b/coresimd/wasm32/mod.rs
@@ -1,5 +1,6 @@
 //! WASM32 intrinsics
 
+#![allow(deprecated)]
 
 #[macro_use]
 #[cfg(all(not(test), feature = "wasm_simd128"))]
@@ -15,37 +16,25 @@ use stdsimd_test::assert_instr;
 #[cfg(test)]
 use wasm_bindgen_test::wasm_bindgen_test;
 
-extern "C" {
-    #[link_name = "llvm.wasm.grow.memory.i32"]
-    fn llvm_grow_memory(pages: i32) -> i32;
-    #[link_name = "llvm.wasm.current.memory.i32"]
-    fn llvm_current_memory() -> i32;
-}
-
-/// Corresponding intrinsic to wasm's [`current_memory` instruction][instr]
-///
-/// This function, when called, will return the current memory size in units of
-/// pages.
-///
-/// [instr]: https://github.com/WebAssembly/design/blob/master/Semantics.md#resizing
 #[inline]
 #[cfg_attr(test, assert_instr("memory.size"))]
+#[rustc_deprecated(reason = "renamed to memory::size", since = "1.30.0")]
+#[unstable(feature = "stdsimd", issue = "27731")]
+#[allow(deprecated)]
+#[doc(hidden)]
 pub unsafe fn current_memory() -> i32 {
-    llvm_current_memory()
+    memory::size(0)
 }
 
-/// Corresponding intrinsic to wasm's [`grow_memory` instruction][instr]
-///
-/// This function, when called, will attempt to grow the default linear memory
-/// by the specified number of pages. If memory is successfully grown then the
-/// previous size of memory, in pages, is returned. If memory cannot be grown
-/// then -1 is returned.
-///
-/// [instr]: https://github.com/WebAssembly/design/blob/master/Semantics.md#resizing
 #[inline]
 #[cfg_attr(test, assert_instr("memory.grow"))]
+#[rustc_deprecated(reason = "renamed to memory::grow", since = "1.30.0")]
+#[unstable(feature = "stdsimd", issue = "27731")]
+#[allow(deprecated)]
+#[doc(hidden)]
 pub unsafe fn grow_memory(delta: i32) -> i32 {
-    llvm_grow_memory(delta)
+    memory::grow(0, delta)
 }
 
 pub mod atomic;
+pub mod memory;

--- a/crates/coresimd/Cargo.toml
+++ b/crates/coresimd/Cargo.toml
@@ -23,7 +23,7 @@ stdsimd-test = { version = "0.*", path = "../stdsimd-test" }
 stdsimd = { version = "0.0.3", path = "../stdsimd" }
 
 [target.wasm32-unknown-unknown.dev-dependencies]
-wasm-bindgen-test = "0.2.16"
+wasm-bindgen-test = "0.2.19"
 
 [features]
 # Internal-usage only: denies all warnings.

--- a/crates/stdsimd-test/Cargo.toml
+++ b/crates/stdsimd-test/Cargo.toml
@@ -10,7 +10,7 @@ backtrace = "0.3"
 cc = "1.0"
 lazy_static = "1.0"
 rustc-demangle = "0.1.8"
-wasm-bindgen = "0.2.16"
+wasm-bindgen = "0.2.19"
 
 [features]
 default = []

--- a/examples/wasm.rs
+++ b/examples/wasm.rs
@@ -20,7 +20,7 @@ pub unsafe extern "C" fn page_alloc() -> *mut u8 {
         return ret as *mut u8;
     }
 
-    let ret = grow_memory(1);
+    let ret = memory::grow(0, 1);
 
     // if we failed to allocate a page then return null
     if ret == -1 {
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn page_free(page: *mut u8) {
 
 #[no_mangle]
 pub unsafe extern "C" fn memory_used() -> usize {
-    (page_size() * (current_memory() as u32)) as usize
+    (page_size() * (memory::size(0) as u32)) as usize
 }
 
 fn page_size() -> u32 {


### PR DESCRIPTION
The official name of the memory intrinsics has changed to `memory.size` and
`memory.grow`, so let's reflect that with our naming as well! Additionally they
have an argument of which memory to operate on with LLVM and must always be zero
currently.