### PR TITLE
add the trap instrinsic

### DIFF
--- a/coresimd/aarch64/mod.rs
+++ b/coresimd/aarch64/mod.rs
@@ -14,3 +14,13 @@ pub use self::neon::*;
 
 mod crypto;
 pub use self::crypto::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Generates the trap instruction `BRK 1`
+#[cfg_attr(test, assert_instr(brk))]
+#[inline]
+pub unsafe fn brk() -> ! {
+    ::_core::intrinsics::abort()
+}

--- a/coresimd/arm/mod.rs
+++ b/coresimd/arm/mod.rs
@@ -45,3 +45,14 @@ mod neon;
     dox
 ))]
 pub use self::neon::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Generates the trap instruction `UDF`
+#[cfg(target_arch = "arm")]
+#[cfg_attr(test, assert_instr(udf))]
+#[inline]
+pub unsafe fn udf() -> ! {
+    ::_core::intrinsics::abort()
+}

--- a/coresimd/mips/mod.rs
+++ b/coresimd/mips/mod.rs
@@ -2,3 +2,13 @@
 
 mod msa;
 pub use self::msa::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Generates the trap instruction `BREAK`
+#[cfg_attr(test, assert_instr(break))]
+#[inline]
+pub unsafe fn break_() -> ! {
+    ::_core::intrinsics::abort()
+}

--- a/coresimd/nvptx/mod.rs
+++ b/coresimd/nvptx/mod.rs
@@ -11,6 +11,9 @@
 //! [llvm_docs]:
 //! https://llvm.org/docs/NVPTXUsage.html
 
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
 #[allow(improper_ctypes)]
 extern "C" {
     #[link_name = "llvm.cuda.syncthreads"]
@@ -117,4 +120,11 @@ pub unsafe fn _thread_idx_y() -> i32 {
 #[inline]
 pub unsafe fn _thread_idx_z() -> i32 {
     thread_idx_z()
+}
+
+/// Generates the trap instruction `TRAP`
+#[cfg_attr(test, assert_instr(trap))]
+#[inline]
+pub unsafe fn trap() -> ! {
+    ::_core::intrinsics::abort()
 }

--- a/coresimd/powerpc/mod.rs
+++ b/coresimd/powerpc/mod.rs
@@ -7,3 +7,13 @@ pub use self::altivec::*;
 
 mod vsx;
 pub use self::vsx::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Generates the trap instruction `TRAP`
+#[cfg_attr(test, assert_instr(trap))]
+#[inline]
+pub unsafe fn trap() -> ! {
+    ::_core::intrinsics::abort()
+}

--- a/coresimd/wasm32/mod.rs
+++ b/coresimd/wasm32/mod.rs
@@ -38,3 +38,10 @@ pub unsafe fn grow_memory(delta: i32) -> i32 {
 
 pub mod atomic;
 pub mod memory;
+
+/// Generates the trap instruction `UNREACHABLE`
+#[cfg_attr(test, assert_instr(unreachable))]
+#[inline]
+pub unsafe fn unreachable() -> ! {
+    ::_core::intrinsics::abort()
+}

--- a/coresimd/x86/mod.rs
+++ b/coresimd/x86/mod.rs
@@ -512,3 +512,13 @@ pub use self::rdrand::*;
 
 mod sha;
 pub use self::sha::*;
+
+#[cfg(test)]
+use stdsimd_test::assert_instr;
+
+/// Generates the trap instruction `UD2`
+#[cfg_attr(test, assert_instr(ud2))]
+#[inline]
+pub unsafe fn ud2() -> ! {
+    ::_core::intrinsics::abort()
+}


### PR DESCRIPTION
as discussed in rust-lang/rfcs#2512

instead of the generic "trap" name the architecture specific name of the trap instruction has been used