### PR TITLE
Fix nightly build breakage

### DIFF
--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -17,7 +17,7 @@
     repr_simd,
     simd_ffi,
     asm,
-    proc_macro_gen,
+    proc_macro_hygiene,
     integer_atomics,
     stmt_expr_attributes,
     core_intrinsics,


### PR DESCRIPTION
Building `coresimd` is broken on the latest nightlies, due to an unstable feature being renamed. This PR fixes that.