### PR TITLE
fix _mm_castsi128_pd and _mm_castpd_si128 impls

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ environment:
 install:
   # Install rust, x86_64-pc-windows-msvc host
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly-2018-10-20
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%
   - rustc -vV

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ matrix:
   fast_finish: true
   include:
     - env: TARGET=i586-unknown-linux-gnu
+      rust: nightly-2018-10-20
     - env: TARGET=i686-unknown-linux-gnu
+      rust: nightly-2018-10-20
     - env: TARGET=x86_64-unknown-linux-gnu NO_ADD=1
+      rust: nightly-2018-10-20
     - env: TARGET=x86_64-unknown-linux-gnu-emulated NO_ADD=1 STDSIMD_TEST_EVERYTHING=1
+      rust: nightly-2018-10-20
     - env: TARGET=x86_64-linux-android
     - env: TARGET=arm-unknown-linux-gnueabihf
     - env: TARGET=arm-linux-androideabi
@@ -26,9 +30,11 @@ matrix:
     - os: osx
       env: TARGET=i686-apple-darwin
       script: ci/run.sh
+      rust: nightly-2018-10-20
     - os: osx
       env: TARGET=x86_64-apple-darwin NO_ADD=1
       script: ci/run.sh
+      rust: nightly-2018-10-20
     - env: TARGET=wasm32-unknown-unknown
     - env: TARGET=thumbv6m-none-eabi NOSTD=1
     - env: TARGET=thumbv7m-none-eabi NOSTD=1

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -33,8 +33,11 @@ case ${TARGET} in
     # instruction assertion checks to pass below the 20 instruction limit. If
     # this is the default, dynamic, then too many instructions are generated
     # when we assert the instruction for a function and it causes tests to fail.
+    #
+    # It's not clear why `-Z plt=yes` is required here. Probably a bug in LLVM.
+    # If you can remove it and CI passes, please feel free to do so!
     i686-* | i586-*)
-        export RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static"
+        export RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static -Z plt=yes"
         ;;
     *android*)
         export STDSIMD_DISABLE_ASSERT_INSTR=1

--- a/coresimd/x86/sse2.rs
+++ b/coresimd/x86/sse2.rs
@@ -2787,7 +2787,7 @@ pub unsafe fn _mm_castpd_ps(a: __m128d) -> __m128 {
 #[target_feature(enable = "sse2")]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_castpd_si128(a: __m128d) -> __m128i {
-    mem::transmute::<i64x2, _>(simd_cast(a))
+    mem::transmute(a)
 }
 
 /// Casts a 128-bit floating-point vector of `[4 x float]` into a 128-bit
@@ -2820,7 +2820,7 @@ pub unsafe fn _mm_castps_si128(a: __m128) -> __m128i {
 #[target_feature(enable = "sse2")]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_castsi128_pd(a: __m128i) -> __m128d {
-    simd_cast(a.as_i64x2())
+    mem::transmute(a)
 }
 
 /// Casts a 128-bit integer vector into a 128-bit floating-point vector

--- a/crates/stdsimd-test/Cargo.toml
+++ b/crates/stdsimd-test/Cargo.toml
@@ -14,6 +14,7 @@ cfg-if = "0.1"
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "=0.2.19"
+console_error_panic_hook = "0.1"
 
 [features]
 default = []

--- a/crates/stdsimd-test/src/lib.rs
+++ b/crates/stdsimd-test/src/lib.rs
@@ -26,6 +26,7 @@ use std::{collections::HashMap, env, str};
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
         extern crate wasm_bindgen;
+        extern crate console_error_panic_hook;
         pub mod wasm;
         use wasm::disassemble_myself;
     } else {

--- a/crates/stdsimd-test/src/wasm.rs
+++ b/crates/stdsimd-test/src/wasm.rs
@@ -33,6 +33,7 @@ macro_rules! println {
 
 pub(crate) fn disassemble_myself() -> HashMap<String, Vec<Function>> {
     use std::path::Path;
+    ::console_error_panic_hook::set_once();
     // Our wasm module in the wasm-bindgen test harness is called
     // "wasm-bindgen-test_bg". When running in node this is actually a shim JS
     // file. Ask node where that JS file is, and then we use that with a wasm
@@ -51,7 +52,7 @@ pub(crate) fn disassemble_myself() -> HashMap<String, Vec<Function>> {
         // If we found the table of function pointers, fill in the known
         // address for all our `Function` instances
         if line.starts_with("(elem") {
-            for (i, name) in line.split_whitespace().skip(3).enumerate() {
+            for (i, name) in line.split_whitespace().skip(4).enumerate() {
                 let name = name.trim_right_matches(")");
                 for f in ret.get_mut(name).expect("ret.get_mut(name) failed") {
                     f.addr = Some(i + 1);


### PR DESCRIPTION
The _mm_castX_Y SSE intrinsics are "reinterpreting" casts; LLVM's
simd_cast is a "converting" cast. Replace simd_casts with mem::transmute.
Fixes rust-lang/rust#55249