### PR TITLE
just load 64 bits with _mm_loadl_epi64

### DIFF
--- a/coresimd/x86/sse2.rs
+++ b/coresimd/x86/sse2.rs
@@ -1145,7 +1145,7 @@ pub unsafe fn _mm_setzero_si128() -> __m128i {
 )]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_loadl_epi64(mem_addr: *const __m128i) -> __m128i {
-    _mm_set_epi64x(0, simd_extract(ptr::read_unaligned(mem_addr).as_i64x2(), 0))
+    _mm_set_epi64x(0, ptr::read_unaligned(mem_addr as *const i64))
 }
 
 /// Load 128-bits of integer data from memory into a new vector.


### PR DESCRIPTION
As I mentioned in the last pull request, I tried this out and found that it does emit `movq` instead of `movdqu`. I believe these epi64 series of instructions really do only touch quadwords, not double quadwords.