### PR TITLE
[breaking change]: mask argument type of _mm_shuffle_ps

### DIFF
--- a/crates/core_arch/src/x86/sse.rs
+++ b/crates/core_arch/src/x86/sse.rs
@@ -995,7 +995,7 @@ pub const fn _MM_SHUFFLE(z: u32, y: u32, x: u32, w: u32) -> i32 {
 #[cfg_attr(test, assert_instr(shufps, mask = 3))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_shuffle_ps(a: __m128, b: __m128, mask: u32) -> __m128 {
+pub unsafe fn _mm_shuffle_ps(a: __m128, b: __m128, mask: i32) -> __m128 {
     let mask = (mask & 0xFF) as u8;
 
     macro_rules! shuffle_done {

--- a/crates/stdsimd-verify/tests/x86-intel.rs
+++ b/crates/stdsimd-verify/tests/x86-intel.rs
@@ -155,6 +155,11 @@ fn verify_all_signatures() {
             // https://github.com/rust-lang/rfcs/issues/2512
             "ud2"
                 => continue,
+            // Intel requires the mask argument for _mm_shuffle_ps to be an
+            // unsigned integer, but all other _mm_shuffle_.. intrinsics
+            // take a signed-integer. This breaks `_MM_SHUFFLE` for
+            // `_mm_shuffle_ps`:
+            "_mm_shuffle_ps" => continue,
             _ => {}
         }
 


### PR DESCRIPTION
**DO NOT MERGE**

If CI passes, I'll push this as a branch, and send a PR to rust-lang/rust to schedule a crater run. Depending on how much code this change breaks, we can re-evaluate what to do with issue #522 .