### PR TITLE
Rename `llvm.cuda.syncthreads` -> `llvm.nvvm.barrier0`

### DIFF
--- a/coresimd/nvptx/mod.rs
+++ b/coresimd/nvptx/mod.rs
@@ -13,7 +13,7 @@
 
 #[allow(improper_ctypes)]
 extern "C" {
-    #[link_name = "llvm.cuda.syncthreads"]
+    #[link_name = "llvm.nvvm.barrier0"]
     fn syncthreads() -> ();
     #[link_name = "llvm.nvvm.read.ptx.sreg.ntid.x"]
     fn block_dim_x() -> i32;


### PR DESCRIPTION
Rename the NVPTX related intrinsic `llvm.cuda.syncthreads` -> `llvm.nvvm.barrier0` to keep up with changes in LLVM.

This should provide a workaround for https://github.com/rust-lang/rust/issues/54115, although there is also an analogous NVPTX related platform-intrinsic that still references the renamed `llvm.cuda.syncthreads` intrinsic.

Thanks to @rkruppe for pointing me here from the discord.