### PR TITLE
update authors and version

### DIFF
--- a/crates/coresimd/Cargo.toml
+++ b/crates/coresimd/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "coresimd"
-version = "0.0.3"
-authors = ["Andrew Gallant <jamslam@gmail.com>"]
+version = "0.1.3"
+authors = [
+    "Alex Crichton <alex@alexcrichton.com>",
+    "Andrew Gallant <jamslam@gmail.com>",
+    "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
+]
 description = "SIMD support in Rust's core library."
 documentation = "https://docs.rs/stdsimd"
 homepage = "https://github.com/rust-lang-nursery/stdsimd"
@@ -20,7 +24,7 @@ maintenance = { status = "experimental" }
 
 [dev-dependencies]
 stdsimd-test = { version = "0.*", path = "../stdsimd-test" }
-stdsimd = { version = "0.0.3", path = "../stdsimd" }
+stdsimd = { version = "0.1.3", path = "../stdsimd" }
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "=0.2.19"

--- a/crates/stdsimd/Cargo.toml
+++ b/crates/stdsimd/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "stdsimd"
-version = "0.0.3"
-authors = ["Andrew Gallant <jamslam@gmail.com>"]
+version = "0.1.3"
+authors = [
+    "Alex Crichton <alex@alexcrichton.com>",
+    "Andrew Gallant <jamslam@gmail.com>",
+    "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
+]
 description = "SIMD support in Rust's standard library."
 documentation = "https://docs.rs/stdsimd"
 homepage = "https://github.com/rust-lang-nursery/stdsimd"
@@ -19,7 +23,7 @@ is-it-maintained-open-issues = { repository = "rust-lang-nursery/stdsimd" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-coresimd = { version = "0.0.3", path = "../coresimd" }
+coresimd = { version = "0.1.3", path = "../coresimd" }
 libc = "0.2"
 cfg-if = "0.1"
 


### PR DESCRIPTION
The next version to be released on crates.io will be 0.1.3 (0.1.2 is the last version released).