### PR TITLE
Add SGX target

### DIFF
--- a/coresimd/x86/cpuid.rs
+++ b/coresimd/x86/cpuid.rs
@@ -80,11 +80,15 @@ pub unsafe fn __cpuid(leaf: u32) -> CpuidResult {
 /// Does the host support the `cpuid` instruction?
 #[inline]
 pub fn has_cpuid() -> bool {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_env = "sgx")]
+    {
+        false
+    }
+    #[cfg(all(not(target_env = "sgx"), target_arch = "x86_64"))]
     {
         true
     }
-    #[cfg(target_arch = "x86")]
+    #[cfg(all(not(target_env = "sgx"), target_arch = "x86"))]
     {
         // Optimization for i586 and i686 Rust targets which SSE enabled
         // and support cpuid:


### PR DESCRIPTION
This adds support for the `x86_64-fortanix-unknown-sgx` target. See https://github.com/rust-lang/rust/pull/56066 for details.

CPUID is not supported inside SGX. In the future, I might want to add a way to supply CPUID information from the outside, but that can come later.