### PR TITLE
Fix build when used as a submodule

### DIFF
--- a/coresimd/aarch64/mod.rs
+++ b/coresimd/aarch64/mod.rs
@@ -22,5 +22,5 @@ use stdsimd_test::assert_instr;
 #[cfg_attr(test, assert_instr(brk))]
 #[inline]
 pub unsafe fn brk() -> ! {
-    ::_core::intrinsics::abort()
+    ::intrinsics::abort()
 }

--- a/coresimd/arm/mod.rs
+++ b/coresimd/arm/mod.rs
@@ -55,5 +55,5 @@ use stdsimd_test::assert_instr;
 #[cfg_attr(test, assert_instr(udf))]
 #[inline]
 pub unsafe fn udf() -> ! {
-    ::_core::intrinsics::abort()
+    ::intrinsics::abort()
 }

--- a/coresimd/mips/mod.rs
+++ b/coresimd/mips/mod.rs
@@ -10,5 +10,5 @@ use stdsimd_test::assert_instr;
 #[cfg_attr(test, assert_instr(break))]
 #[inline]
 pub unsafe fn break_() -> ! {
-    ::_core::intrinsics::abort()
+    ::intrinsics::abort()
 }

--- a/coresimd/nvptx/mod.rs
+++ b/coresimd/nvptx/mod.rs
@@ -122,5 +122,5 @@ pub unsafe fn _thread_idx_z() -> i32 {
 /// Generates the trap instruction `TRAP`
 #[inline]
 pub unsafe fn trap() -> ! {
-    ::_core::intrinsics::abort()
+    ::intrinsics::abort()
 }

--- a/coresimd/powerpc/mod.rs
+++ b/coresimd/powerpc/mod.rs
@@ -15,5 +15,5 @@ use stdsimd_test::assert_instr;
 #[cfg_attr(test, assert_instr(trap))]
 #[inline]
 pub unsafe fn trap() -> ! {
-    ::_core::intrinsics::abort()
+    ::intrinsics::abort()
 }

--- a/coresimd/wasm32/mod.rs
+++ b/coresimd/wasm32/mod.rs
@@ -43,5 +43,5 @@ pub mod memory;
 #[cfg_attr(test, assert_instr(unreachable))]
 #[inline]
 pub unsafe fn unreachable() -> ! {
-    ::_core::intrinsics::abort()
+    ::intrinsics::abort()
 }

--- a/coresimd/wasm32/simd128.rs
+++ b/coresimd/wasm32/simd128.rs
@@ -632,12 +632,7 @@ impl v128 {
             c: [ImmByte; 16],
         }
         // FIXME: https://github.com/rust-lang/rust/issues/53193
-        const C: [ImmByte; 16] = unsafe {
-            U {
-                v: ::_core::u128::MAX,
-            }
-            .c
-        };
+        const C: [ImmByte; 16] = unsafe { U { v: ::u128::MAX }.c };
         Self::xor(v128::const_(C), a)
     }
 
@@ -664,7 +659,7 @@ impl v128 {
     // #[target_feature(enable = "simd128")]
     // FIXME: #[cfg_attr(test, assert_instr($id.load))]
     pub unsafe fn load(m: *const v128) -> v128 {
-        ::_core::ptr::read(m)
+        ::ptr::read(m)
     }
 
     /// Store a `v128` vector to the given heap address.
@@ -672,7 +667,7 @@ impl v128 {
     // #[target_feature(enable = "simd128")]
     // FIXME: #[cfg_attr(test, assert_instr($id.store))]
     pub unsafe fn store(m: *mut v128, a: v128) {
-        ::_core::ptr::write(m, a)
+        ::ptr::write(m, a)
     }
 }
 

--- a/coresimd/x86/mod.rs
+++ b/coresimd/x86/mod.rs
@@ -520,5 +520,5 @@ use stdsimd_test::assert_instr;
 #[cfg_attr(test, assert_instr(ud2))]
 #[inline]
 pub unsafe fn ud2() -> ! {
-    ::_core::intrinsics::abort()
+    ::intrinsics::abort()
 }


### PR DESCRIPTION
I tested this with a local checkout of https://github.com/rust-lang/rust/

Ideally CI would update the submodule and run `cargo +nightly check` inside `src/libstd`.