### PR TITLE
Remove all usages of mem::uninitialized

### DIFF
--- a/coresimd/x86/avx.rs
+++ b/coresimd/x86/avx.rs
@@ -2875,7 +2875,8 @@ pub unsafe fn _mm256_zextpd128_pd256(a: __m128d) -> __m256d {
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_undefined_ps() -> __m256 {
-    _mm256_set1_ps(mem::uninitialized())
+    // FIXME: this function should return MaybeUninit<__m256>
+    mem::MaybeUninit::<__m256>::uninitialized().into_inner()
 }
 
 /// Return vector of type `__m256d` with undefined elements.
@@ -2886,7 +2887,8 @@ pub unsafe fn _mm256_undefined_ps() -> __m256 {
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_undefined_pd() -> __m256d {
-    _mm256_set1_pd(mem::uninitialized())
+    // FIXME: this function should return MaybeUninit<__m256d>
+    mem::MaybeUninit::<__m256d>::uninitialized().into_inner()
 }
 
 /// Return vector of type __m256i with undefined elements.
@@ -2897,7 +2899,8 @@ pub unsafe fn _mm256_undefined_pd() -> __m256d {
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_undefined_si256() -> __m256i {
-    _mm256_set1_epi8(mem::uninitialized())
+    // FIXME: this function should return MaybeUninit<__m256i>
+    mem::MaybeUninit::<__m256i>::uninitialized().into_inner()
 }
 
 /// Set packed __m256 returned vector with the supplied values.

--- a/coresimd/x86/sse.rs
+++ b/coresimd/x86/sse.rs
@@ -1952,12 +1952,8 @@ pub unsafe fn _mm_prefetch(p: *const i8, strategy: i32) {
 #[target_feature(enable = "sse")]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_undefined_ps() -> __m128 {
-    __m128(
-        mem::uninitialized(),
-        mem::uninitialized(),
-        mem::uninitialized(),
-        mem::uninitialized(),
-    )
+    // FIXME: this function should return MaybeUninit<__m128>
+    mem::MaybeUninit::<__m128>::uninitialized().into_inner()
 }
 
 /// Transpose the 4x4 matrix formed by 4 rows of __m128 in place.

--- a/coresimd/x86/sse2.rs
+++ b/coresimd/x86/sse2.rs
@@ -2847,7 +2847,8 @@ pub unsafe fn _mm_castsi128_ps(a: __m128i) -> __m128 {
 #[target_feature(enable = "sse2")]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_undefined_pd() -> __m128d {
-    _mm_set1_pd(mem::uninitialized())
+    // FIXME: this function should return MaybeUninit<__m128d>
+    mem::MaybeUninit::<__m128d>::uninitialized().into_inner()
 }
 
 /// Return vector of type __m128i with undefined elements.
@@ -2857,7 +2858,8 @@ pub unsafe fn _mm_undefined_pd() -> __m128d {
 #[target_feature(enable = "sse2")]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_undefined_si128() -> __m128i {
-    _mm_set1_epi8(mem::uninitialized())
+    // FIXME: this function should return MaybeUninit<__m128i>
+    mem::MaybeUninit::<__m128i>::uninitialized().into_inner()
 }
 
 /// The resulting `__m128d` element is composed by the low-order values of

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -26,6 +26,7 @@
     stdsimd,
     staged_api,
     align_offset,
+    maybe_uninit,
     doc_cfg,
     mmx_target_feature,
     tbm_target_feature,


### PR DESCRIPTION
Once MaybeUninit becomes stable we should update these APIs to return MaybeUninit instead if a crater run allow us to do so.

It is trivial to introduce UB with the current APIs:

```rust
unsafe { 
    let mut a = _mm_undefined_xy();
    foo(&mut a); // UB: reference to uninitialized memory
}
```