### PR TITLE
Update x86 codegen

### DIFF
--- a/coresimd/macros.rs
+++ b/coresimd/macros.rs
@@ -1,5 +1,6 @@
 //! Utility macros.
 
+#[allow(unused)]
 macro_rules! constify_imm8 {
     ($imm8:expr, $expand:ident) => {
         #[allow(overflowing_literals)]


### PR DESCRIPTION
The regresion on i686 codegen has been fixed with the latest LLVM update, but i586 remains broken on these two intrinsics.