### PR TITLE
Stabilize wasm32 memory-related intrinsics

### DIFF
--- a/coresimd/mod.rs
+++ b/coresimd/mod.rs
@@ -90,8 +90,9 @@ pub mod arch {
     /// See the [module documentation](../index.html) for more details.
     #[cfg(any(target_arch = "wasm32", dox))]
     #[doc(cfg(target_arch = "wasm32"))]
-    #[unstable(feature = "stdsimd", issue = "27731")]
+    #[stable(feature = "simd_wasm32", since = "1.33.0")]
     pub mod wasm32 {
+        #[stable(feature = "simd_wasm32", since = "1.33.0")]
         pub use coresimd::wasm32::*;
     }
 

--- a/coresimd/wasm32/memory.rs
+++ b/coresimd/wasm32/memory.rs
@@ -13,43 +13,52 @@ extern "C" {
 /// Corresponding intrinsic to wasm's [`memory.size` instruction][instr]
 ///
 /// This function, when called, will return the current memory size in units of
-/// pages.
+/// pages. The current WebAssembly page size is 65536 bytes (64 KB).
 ///
 /// The argument `mem` is the numerical index of which memory to return the
-/// size of. Note that currently wasm only supports one memory, so specifying
-/// a nonzero value will likely result in a runtime validation error of the
-/// wasm module.
+/// size of. Note that currently the WebAssembly specification only supports one
+/// memory, so it is required that zero is passed in. The argument is present to
+/// be forward-compatible with future WebAssembly revisions. If a nonzero
+/// argument is passed to this function it will currently unconditionally abort.
 ///
-/// [instr]: https://github.com/WebAssembly/design/blob/master/Semantics.md#resizing
+/// [instr]: http://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-size
 #[inline]
 #[cfg_attr(test, assert_instr("memory.size", mem = 0))]
 #[rustc_args_required_const(0)]
-pub unsafe fn size(mem: i32) -> i32 {
-    if mem != 0 {
-        ::intrinsics::abort();
+#[stable(feature = "simd_wasm32", since = "1.33.0")]
+pub fn memory_size(mem: u32) -> usize {
+    unsafe {
+        if mem != 0 {
+            ::intrinsics::abort();
+        }
+        llvm_memory_size(0) as usize
     }
-    llvm_memory_size(0)
 }
 
 /// Corresponding intrinsic to wasm's [`memory.grow` instruction][instr]
 ///
 /// This function, when called, will attempt to grow the default linear memory
-/// by the specified `delta` of pages. If memory is successfully grown then the
-/// previous size of memory, in pages, is returned. If memory cannot be grown
-/// then -1 is returned.
+/// by the specified `delta` of pages. The current WebAssembly page size is
+/// 65536 bytes (64 KB). If memory is successfully grown then the previous size
+/// of memory, in pages, is returned. If memory cannot be grown then
+/// `usize::max_value()` is returned.
 ///
 /// The argument `mem` is the numerical index of which memory to return the
-/// size of. Note that currently wasm only supports one memory, so specifying
-/// a nonzero value will likely result in a runtime validation error of the
-/// wasm module.
+/// size of. Note that currently the WebAssembly specification only supports one
+/// memory, so it is required that zero is passed in. The argument is present to
+/// be forward-compatible with future WebAssembly revisions. If a nonzero
+/// argument is passed to this function it will currently unconditionally abort.
 ///
-/// [instr]: https://github.com/WebAssembly/design/blob/master/Semantics.md#resizing
+/// [instr]: http://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-grow
 #[inline]
 #[cfg_attr(test, assert_instr("memory.grow", mem = 0))]
 #[rustc_args_required_const(0)]
-pub unsafe fn grow(mem: i32, delta: i32) -> i32 {
-    if mem != 0 {
-        ::intrinsics::abort();
+#[stable(feature = "simd_wasm32", since = "1.33.0")]
+pub fn memory_grow(mem: u32, delta: usize) -> usize {
+    unsafe {
+        if mem != 0 {
+            ::intrinsics::abort();
+        }
+        llvm_memory_grow(0, delta as i32) as isize as usize
     }
-    llvm_memory_grow(0, delta)
 }

--- a/coresimd/wasm32/mod.rs
+++ b/coresimd/wasm32/mod.rs
@@ -16,28 +16,10 @@ use stdsimd_test::assert_instr;
 #[cfg(test)]
 use wasm_bindgen_test::wasm_bindgen_test;
 
-#[inline]
-#[cfg_attr(test, assert_instr("memory.size"))]
-#[rustc_deprecated(reason = "renamed to memory::size", since = "1.30.0")]
-#[unstable(feature = "stdsimd", issue = "27731")]
-#[allow(deprecated)]
-#[doc(hidden)]
-pub unsafe fn current_memory() -> i32 {
-    memory::size(0)
-}
-
-#[inline]
-#[cfg_attr(test, assert_instr("memory.grow"))]
-#[rustc_deprecated(reason = "renamed to memory::grow", since = "1.30.0")]
-#[unstable(feature = "stdsimd", issue = "27731")]
-#[allow(deprecated)]
-#[doc(hidden)]
-pub unsafe fn grow_memory(delta: i32) -> i32 {
-    memory::grow(0, delta)
-}
-
 pub mod atomic;
-pub mod memory;
+
+mod memory;
+pub use self::memory::*;
 
 /// Generates the trap instruction `UNREACHABLE`
 #[cfg_attr(test, assert_instr(unreachable))]


### PR DESCRIPTION
This commit stabilizes the wasm32 memory-related intrinsics, as
specified in rust-lang/rust#56292. The old intrinsics were removed and
the current intrinsics were updated in place, but it's the last breaking
change!