### PR TITLE
Derive Debug for CpuidResult

### DIFF
--- a/coresimd/x86/cpuid.rs
+++ b/coresimd/x86/cpuid.rs
@@ -6,7 +6,7 @@
 use stdsimd_test::assert_instr;
 
 /// Result of the `cpuid` instruction.
-#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::stutter))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub struct CpuidResult {


### PR DESCRIPTION
Being able to `println!("{:#?}", cpuid_result)` and seeing all the registers in one go is nice to have.