### PR TITLE
Run rustfmt on stable, delete rustfmt.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ matrix:
     - name: "rustfmt"
       install: rustup component add rustfmt-preview
       script: cargo fmt --all -- --check
+      rust: stable
     - name: "clippy"
       install: true
       script: |
@@ -113,7 +114,7 @@ matrix:
     - env: TARGET=i686-pc-windows-gnu
 
 install: rustup target add $TARGET
-script: 
+script:
   - cargo generate-lockfile
   - ci/run-docker.sh $TARGET $FEATURES
 

--- a/coresimd/aarch64/crc.rs
+++ b/coresimd/aarch64/crc.rs
@@ -1,4 +1,3 @@
-
 extern "C" {
     #[link_name = "llvm.aarch64.crc32b"]
     fn crc32b_(crc: u32, data: u32) -> u32;

--- a/coresimd/aarch64/crypto.rs
+++ b/coresimd/aarch64/crypto.rs
@@ -15,38 +15,24 @@ extern "C" {
     #[link_name = "llvm.aarch64.crypto.sha1h"]
     fn vsha1h_u32_(hash_e: u32) -> u32;
     #[link_name = "llvm.aarch64.crypto.sha1su0"]
-    fn vsha1su0q_u32_(
-        w0_3: uint32x4_t, w4_7: uint32x4_t, w8_11: uint32x4_t,
-    ) -> uint32x4_t;
+    fn vsha1su0q_u32_(w0_3: uint32x4_t, w4_7: uint32x4_t, w8_11: uint32x4_t) -> uint32x4_t;
     #[link_name = "llvm.aarch64.crypto.sha1su1"]
     fn vsha1su1q_u32_(tw0_3: uint32x4_t, w12_15: uint32x4_t) -> uint32x4_t;
     #[link_name = "llvm.aarch64.crypto.sha1c"]
-    fn vsha1cq_u32_(
-        hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t,
-    ) -> uint32x4_t;
+    fn vsha1cq_u32_(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t;
     #[link_name = "llvm.aarch64.crypto.sha1p"]
-    fn vsha1pq_u32_(
-        hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t,
-    ) -> uint32x4_t;
+    fn vsha1pq_u32_(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t;
     #[link_name = "llvm.aarch64.crypto.sha1m"]
-    fn vsha1mq_u32_(
-        hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t,
-    ) -> uint32x4_t;
+    fn vsha1mq_u32_(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t;
 
     #[link_name = "llvm.aarch64.crypto.sha256h"]
-    fn vsha256hq_u32_(
-        hash_abcd: uint32x4_t, hash_efgh: uint32x4_t, wk: uint32x4_t,
-    ) -> uint32x4_t;
+    fn vsha256hq_u32_(hash_abcd: uint32x4_t, hash_efgh: uint32x4_t, wk: uint32x4_t) -> uint32x4_t;
     #[link_name = "llvm.aarch64.crypto.sha256h2"]
-    fn vsha256h2q_u32_(
-        hash_efgh: uint32x4_t, hash_abcd: uint32x4_t, wk: uint32x4_t,
-    ) -> uint32x4_t;
+    fn vsha256h2q_u32_(hash_efgh: uint32x4_t, hash_abcd: uint32x4_t, wk: uint32x4_t) -> uint32x4_t;
     #[link_name = "llvm.aarch64.crypto.sha256su0"]
     fn vsha256su0q_u32_(w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t;
     #[link_name = "llvm.aarch64.crypto.sha256su1"]
-    fn vsha256su1q_u32_(
-        tw0_3: uint32x4_t, w8_11: uint32x4_t, w12_15: uint32x4_t,
-    ) -> uint32x4_t;
+    fn vsha256su1q_u32_(tw0_3: uint32x4_t, w8_11: uint32x4_t, w12_15: uint32x4_t) -> uint32x4_t;
 }
 
 #[cfg(test)]
@@ -96,9 +82,7 @@ pub unsafe fn vsha1h_u32(hash_e: u32) -> u32 {
 #[inline]
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha1c))]
-pub unsafe fn vsha1cq_u32(
-    hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t,
-) -> uint32x4_t {
+pub unsafe fn vsha1cq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t {
     vsha1cq_u32_(hash_abcd, hash_e, wk)
 }
 
@@ -106,9 +90,7 @@ pub unsafe fn vsha1cq_u32(
 #[inline]
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha1m))]
-pub unsafe fn vsha1mq_u32(
-    hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t,
-) -> uint32x4_t {
+pub unsafe fn vsha1mq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t {
     vsha1mq_u32_(hash_abcd, hash_e, wk)
 }
 
@@ -116,9 +98,7 @@ pub unsafe fn vsha1mq_u32(
 #[inline]
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha1p))]
-pub unsafe fn vsha1pq_u32(
-    hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t,
-) -> uint32x4_t {
+pub unsafe fn vsha1pq_u32(hash_abcd: uint32x4_t, hash_e: u32, wk: uint32x4_t) -> uint32x4_t {
     vsha1pq_u32_(hash_abcd, hash_e, wk)
 }
 
@@ -126,9 +106,7 @@ pub unsafe fn vsha1pq_u32(
 #[inline]
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha1su0))]
-pub unsafe fn vsha1su0q_u32(
-    w0_3: uint32x4_t, w4_7: uint32x4_t, w8_11: uint32x4_t,
-) -> uint32x4_t {
+pub unsafe fn vsha1su0q_u32(w0_3: uint32x4_t, w4_7: uint32x4_t, w8_11: uint32x4_t) -> uint32x4_t {
     vsha1su0q_u32_(w0_3, w4_7, w8_11)
 }
 
@@ -136,9 +114,7 @@ pub unsafe fn vsha1su0q_u32(
 #[inline]
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha1su1))]
-pub unsafe fn vsha1su1q_u32(
-    tw0_3: uint32x4_t, w12_15: uint32x4_t,
-) -> uint32x4_t {
+pub unsafe fn vsha1su1q_u32(tw0_3: uint32x4_t, w12_15: uint32x4_t) -> uint32x4_t {
     vsha1su1q_u32_(tw0_3, w12_15)
 }
 
@@ -147,7 +123,9 @@ pub unsafe fn vsha1su1q_u32(
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha256h))]
 pub unsafe fn vsha256hq_u32(
-    hash_abcd: uint32x4_t, hash_efgh: uint32x4_t, wk: uint32x4_t,
+    hash_abcd: uint32x4_t,
+    hash_efgh: uint32x4_t,
+    wk: uint32x4_t,
 ) -> uint32x4_t {
     vsha256hq_u32_(hash_abcd, hash_efgh, wk)
 }
@@ -157,7 +135,9 @@ pub unsafe fn vsha256hq_u32(
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha256h2))]
 pub unsafe fn vsha256h2q_u32(
-    hash_efgh: uint32x4_t, hash_abcd: uint32x4_t, wk: uint32x4_t,
+    hash_efgh: uint32x4_t,
+    hash_abcd: uint32x4_t,
+    wk: uint32x4_t,
 ) -> uint32x4_t {
     vsha256h2q_u32_(hash_efgh, hash_abcd, wk)
 }
@@ -166,9 +146,7 @@ pub unsafe fn vsha256h2q_u32(
 #[inline]
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha256su0))]
-pub unsafe fn vsha256su0q_u32(
-    w0_3: uint32x4_t, w4_7: uint32x4_t,
-) -> uint32x4_t {
+pub unsafe fn vsha256su0q_u32(w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t {
     vsha256su0q_u32_(w0_3, w4_7)
 }
 
@@ -177,7 +155,9 @@ pub unsafe fn vsha256su0q_u32(
 #[target_feature(enable = "crypto")]
 #[cfg_attr(test, assert_instr(sha256su1))]
 pub unsafe fn vsha256su1q_u32(
-    tw0_3: uint32x4_t, w8_11: uint32x4_t, w12_15: uint32x4_t,
+    tw0_3: uint32x4_t,
+    w8_11: uint32x4_t,
+    w12_15: uint32x4_t,
 ) -> uint32x4_t {
     vsha256su1q_u32_(tw0_3, w8_11, w12_15)
 }
@@ -191,44 +171,31 @@ mod tests {
 
     #[simd_test(enable = "crypto")]
     unsafe fn test_vaeseq_u8() {
-        let data = ::mem::transmute(u8x16::new(
-            1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
-        ));
-        let key = ::mem::transmute(u8x16::new(
-            0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
-        ));
+        let data = ::mem::transmute(u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8));
+        let key = ::mem::transmute(u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
         let r: u8x16 = ::mem::transmute(vaeseq_u8(data, key));
         assert_eq!(
             r,
             u8x16::new(
-                124, 123, 124, 118, 124, 123, 124, 197, 124, 123, 124, 118,
-                124, 123, 124, 197
+                124, 123, 124, 118, 124, 123, 124, 197, 124, 123, 124, 118, 124, 123, 124, 197
             )
         );
     }
 
     #[simd_test(enable = "crypto")]
     unsafe fn test_vaesdq_u8() {
-        let data = ::mem::transmute(u8x16::new(
-            1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
-        ));
-        let key = ::mem::transmute(u8x16::new(
-            0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
-        ));
+        let data = ::mem::transmute(u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8));
+        let key = ::mem::transmute(u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
         let r: u8x16 = ::mem::transmute(vaesdq_u8(data, key));
         assert_eq!(
             r,
-            u8x16::new(
-                9, 213, 9, 251, 9, 213, 9, 56, 9, 213, 9, 251, 9, 213, 9, 56
-            )
+            u8x16::new(9, 213, 9, 251, 9, 213, 9, 56, 9, 213, 9, 251, 9, 213, 9, 56)
         );
     }
 
     #[simd_test(enable = "crypto")]
     unsafe fn test_vaesmcq_u8() {
-        let data = ::mem::transmute(u8x16::new(
-            1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
-        ));
+        let data = ::mem::transmute(u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8));
         let r: u8x16 = ::mem::transmute(vaesmcq_u8(data));
         assert_eq!(
             r,
@@ -238,16 +205,11 @@ mod tests {
 
     #[simd_test(enable = "crypto")]
     unsafe fn test_vaesimcq_u8() {
-        let data = ::mem::transmute(u8x16::new(
-            1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
-        ));
+        let data = ::mem::transmute(u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8));
         let r: u8x16 = ::mem::transmute(vaesimcq_u8(data));
         assert_eq!(
             r,
-            u8x16::new(
-                43, 60, 33, 50, 103, 80, 125, 70, 43, 60, 33, 50, 103, 80,
-                125, 70
-            )
+            u8x16::new(43, 60, 33, 50, 103, 80, 125, 70, 43, 60, 33, 50, 103, 80, 125, 70)
         );
     }
 
@@ -260,15 +222,9 @@ mod tests {
     #[simd_test(enable = "crypto")]
     unsafe fn test_vsha1su0q_u32() {
         let r: u32x4 = ::mem::transmute(vsha1su0q_u32(
-            ::mem::transmute(u32x4::new(
-                0x1234_u32, 0x5678_u32, 0x9abc_u32, 0xdef0_u32,
-            )),
-            ::mem::transmute(u32x4::new(
-                0x1234_u32, 0x5678_u32, 0x9abc_u32, 0xdef0_u32,
-            )),
-            ::mem::transmute(u32x4::new(
-                0x1234_u32, 0x5678_u32, 0x9abc_u32, 0xdef0_u32,
-            )),
+            ::mem::transmute(u32x4::new(0x1234_u32, 0x5678_u32, 0x9abc_u32, 0xdef0_u32)),
+            ::mem::transmute(u32x4::new(0x1234_u32, 0x5678_u32, 0x9abc_u32, 0xdef0_u32)),
+            ::mem::transmute(u32x4::new(0x1234_u32, 0x5678_u32, 0x9abc_u32, 0xdef0_u32)),
         ));
         assert_eq!(r, u32x4::new(0x9abc, 0xdef0, 0x1234, 0x5678));
     }

--- a/coresimd/aarch64/neon.rs
+++ b/coresimd/aarch64/neon.rs
@@ -28,12 +28,7 @@ pub struct int8x16x2_t(pub int8x16_t, pub int8x16_t);
 pub struct int8x16x3_t(pub int8x16_t, pub int8x16_t, pub int8x16_t);
 /// ARM-specific type containing four `int8x16_t` vectors.
 #[derive(Copy, Clone)]
-pub struct int8x16x4_t(
-    pub int8x16_t,
-    pub int8x16_t,
-    pub int8x16_t,
-    pub int8x16_t,
-);
+pub struct int8x16x4_t(pub int8x16_t, pub int8x16_t, pub int8x16_t, pub int8x16_t);
 
 /// ARM-specific type containing two `uint8x16_t` vectors.
 #[derive(Copy, Clone)]
@@ -183,53 +178,55 @@ extern "C" {
     fn vqtbl2q(a0: int8x16_t, a1: int8x16_t, b: uint8x16_t) -> int8x16_t;
 
     #[link_name = "llvm.aarch64.neon.tbx2.v8i8"]
-    fn vqtbx2(
-        a: int8x8_t, b0: int8x16_t, b1: int8x16_t, c: uint8x8_t,
-    ) -> int8x8_t;
+    fn vqtbx2(a: int8x8_t, b0: int8x16_t, b1: int8x16_t, c: uint8x8_t) -> int8x8_t;
     #[link_name = "llvm.aarch64.neon.tbx2.v16i8"]
-    fn vqtbx2q(
-        a: int8x16_t, b0: int8x16_t, b1: int8x16_t, c: uint8x16_t,
-    ) -> int8x16_t;
+    fn vqtbx2q(a: int8x16_t, b0: int8x16_t, b1: int8x16_t, c: uint8x16_t) -> int8x16_t;
 
     #[link_name = "llvm.aarch64.neon.tbl3.v8i8"]
-    fn vqtbl3(
-        a0: int8x16_t, a1: int8x16_t, a2: int8x16_t, b: uint8x8_t,
-    ) -> int8x8_t;
+    fn vqtbl3(a0: int8x16_t, a1: int8x16_t, a2: int8x16_t, b: uint8x8_t) -> int8x8_t;
     #[link_name = "llvm.aarch64.neon.tbl3.v16i8"]
-    fn vqtbl3q(
-        a0: int8x16_t, a1: int8x16_t, a2: int8x16_t, b: uint8x16_t,
-    ) -> int8x16_t;
+    fn vqtbl3q(a0: int8x16_t, a1: int8x16_t, a2: int8x16_t, b: uint8x16_t) -> int8x16_t;
 
     #[link_name = "llvm.aarch64.neon.tbx3.v8i8"]
-    fn vqtbx3(
-        a: int8x8_t, b0: int8x16_t, b1: int8x16_t, b2: int8x16_t, c: uint8x8_t,
-    ) -> int8x8_t;
+    fn vqtbx3(a: int8x8_t, b0: int8x16_t, b1: int8x16_t, b2: int8x16_t, c: uint8x8_t) -> int8x8_t;
     #[link_name = "llvm.aarch64.neon.tbx3.v16i8"]
     fn vqtbx3q(
-        a: int8x16_t, b0: int8x16_t, b1: int8x16_t, b2: int8x16_t,
+        a: int8x16_t,
+        b0: int8x16_t,
+        b1: int8x16_t,
+        b2: int8x16_t,
         c: uint8x16_t,
     ) -> int8x16_t;
 
     #[link_name = "llvm.aarch64.neon.tbl4.v8i8"]
-    fn vqtbl4(
-        a0: int8x16_t, a1: int8x16_t, a2: int8x16_t, a3: int8x16_t,
-        b: uint8x8_t,
-    ) -> int8x8_t;
+    fn vqtbl4(a0: int8x16_t, a1: int8x16_t, a2: int8x16_t, a3: int8x16_t, b: uint8x8_t)
+        -> int8x8_t;
     #[link_name = "llvm.aarch64.neon.tbl4.v16i8"]
     fn vqtbl4q(
-        a0: int8x16_t, a1: int8x16_t, a2: int8x16_t, a3: int8x16_t,
+        a0: int8x16_t,
+        a1: int8x16_t,
+        a2: int8x16_t,
+        a3: int8x16_t,
         b: uint8x16_t,
     ) -> int8x16_t;
 
     #[link_name = "llvm.aarch64.neon.tbx4.v8i8"]
     fn vqtbx4(
-        a: int8x8_t, b0: int8x16_t, b1: int8x16_t, b2: int8x16_t,
-        b3: int8x16_t, c: uint8x8_t,
+        a: int8x8_t,
+        b0: int8x16_t,
+        b1: int8x16_t,
+        b2: int8x16_t,
+        b3: int8x16_t,
+        c: uint8x8_t,
     ) -> int8x8_t;
     #[link_name = "llvm.aarch64.neon.tbx4.v16i8"]
     fn vqtbx4q(
-        a: int8x16_t, b0: int8x16_t, b1: int8x16_t, b2: int8x16_t,
-        b3: int8x16_t, c: uint8x16_t,
+        a: int8x16_t,
+        b0: int8x16_t,
+        b1: int8x16_t,
+        b2: int8x16_t,
+        b3: int8x16_t,
+        c: uint8x16_t,
     ) -> int8x16_t;
 }
 
@@ -727,9 +724,7 @@ pub unsafe fn vcombine_f16 ( low: float16x4_t,  high: float16x4_t) -> float16x8_
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(mov))]
-pub unsafe fn vcombine_f32(
-    low: float32x2_t, high: float32x2_t,
-) -> float32x4_t {
+pub unsafe fn vcombine_f32(low: float32x2_t, high: float32x2_t) -> float32x4_t {
     simd_shuffle4(low, high, [0, 1, 2, 3])
 }
 
@@ -757,9 +752,7 @@ pub unsafe fn vcombine_p16(low: poly16x4_t, high: poly16x4_t) -> poly16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(mov))]
-pub unsafe fn vcombine_f64(
-    low: float64x1_t, high: float64x1_t,
-) -> float64x2_t {
+pub unsafe fn vcombine_f64(low: float64x1_t, high: float64x1_t) -> float64x2_t {
     simd_shuffle2(low, high, [0, 1])
 }
 
@@ -939,9 +932,7 @@ pub unsafe fn vtbx2_s8(a: int8x8_t, b: int8x8x2_t, c: int8x8_t) -> int8x8_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vtbx2_u8(
-    a: uint8x8_t, b: uint8x8x2_t, c: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vtbx2_u8(a: uint8x8_t, b: uint8x8x2_t, c: uint8x8_t) -> uint8x8_t {
     vqtbx1_u8(a, vcombine_u8(b.0, b.1), c)
 }
 
@@ -950,9 +941,7 @@ pub unsafe fn vtbx2_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vtbx2_p8(
-    a: poly8x8_t, b: poly8x8x2_t, c: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vtbx2_p8(a: poly8x8_t, b: poly8x8x2_t, c: uint8x8_t) -> poly8x8_t {
     vqtbx1_p8(a, vcombine_p8(b.0, b.1), c)
 }
 
@@ -977,9 +966,7 @@ pub unsafe fn vtbx3_s8(a: int8x8_t, b: int8x8x3_t, c: int8x8_t) -> int8x8_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vtbx3_u8(
-    a: uint8x8_t, b: uint8x8x3_t, c: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vtbx3_u8(a: uint8x8_t, b: uint8x8x3_t, c: uint8x8_t) -> uint8x8_t {
     use coresimd::simd::u8x8;
     let r = vqtbx2_u8(
         a,
@@ -995,9 +982,7 @@ pub unsafe fn vtbx3_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vtbx3_p8(
-    a: poly8x8_t, b: poly8x8x3_t, c: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vtbx3_p8(a: poly8x8_t, b: poly8x8x3_t, c: uint8x8_t) -> poly8x8_t {
     use coresimd::simd::u8x8;
     let r = vqtbx2_p8(
         a,
@@ -1026,9 +1011,7 @@ pub unsafe fn vtbx4_s8(a: int8x8_t, b: int8x8x4_t, c: int8x8_t) -> int8x8_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vtbx4_u8(
-    a: uint8x8_t, b: uint8x8x4_t, c: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vtbx4_u8(a: uint8x8_t, b: uint8x8x4_t, c: uint8x8_t) -> uint8x8_t {
     vqtbx2_u8(
         a,
         uint8x16x2_t(vcombine_u8(b.0, b.1), vcombine_u8(b.2, b.3)),
@@ -1041,9 +1024,7 @@ pub unsafe fn vtbx4_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vtbx4_p8(
-    a: poly8x8_t, b: poly8x8x4_t, c: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vtbx4_p8(a: poly8x8_t, b: poly8x8x4_t, c: uint8x8_t) -> poly8x8_t {
     vqtbx2_p8(
         a,
         poly8x16x2_t(vcombine_p8(b.0, b.1), vcombine_p8(b.2, b.3)),
@@ -1104,9 +1085,7 @@ pub unsafe fn vqtbl1q_p8(t: poly8x16_t, idx: uint8x16_t) -> poly8x16_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx1_s8(
-    a: int8x8_t, t: int8x16_t, idx: uint8x8_t,
-) -> int8x8_t {
+pub unsafe fn vqtbx1_s8(a: int8x8_t, t: int8x16_t, idx: uint8x8_t) -> int8x8_t {
     vqtbx1(a, t, idx)
 }
 /// Extended table look-up
@@ -1114,9 +1093,7 @@ pub unsafe fn vqtbx1_s8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx1q_s8(
-    a: int8x16_t, t: int8x16_t, idx: uint8x16_t,
-) -> int8x16_t {
+pub unsafe fn vqtbx1q_s8(a: int8x16_t, t: int8x16_t, idx: uint8x16_t) -> int8x16_t {
     vqtbx1q(a, t, idx)
 }
 /// Extended table look-up
@@ -1124,9 +1101,7 @@ pub unsafe fn vqtbx1q_s8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx1_u8(
-    a: uint8x8_t, t: uint8x16_t, idx: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vqtbx1_u8(a: uint8x8_t, t: uint8x16_t, idx: uint8x8_t) -> uint8x8_t {
     ::mem::transmute(vqtbx1(
         ::mem::transmute(a),
         ::mem::transmute(t),
@@ -1138,9 +1113,7 @@ pub unsafe fn vqtbx1_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx1q_u8(
-    a: uint8x16_t, t: uint8x16_t, idx: uint8x16_t,
-) -> uint8x16_t {
+pub unsafe fn vqtbx1q_u8(a: uint8x16_t, t: uint8x16_t, idx: uint8x16_t) -> uint8x16_t {
     ::mem::transmute(vqtbx1q(
         ::mem::transmute(a),
         ::mem::transmute(t),
@@ -1152,9 +1125,7 @@ pub unsafe fn vqtbx1q_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx1_p8(
-    a: poly8x8_t, t: poly8x16_t, idx: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vqtbx1_p8(a: poly8x8_t, t: poly8x16_t, idx: uint8x8_t) -> poly8x8_t {
     ::mem::transmute(vqtbx1(
         ::mem::transmute(a),
         ::mem::transmute(t),
@@ -1166,9 +1137,7 @@ pub unsafe fn vqtbx1_p8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx1q_p8(
-    a: poly8x16_t, t: poly8x16_t, idx: uint8x16_t,
-) -> poly8x16_t {
+pub unsafe fn vqtbx1q_p8(a: poly8x16_t, t: poly8x16_t, idx: uint8x16_t) -> poly8x16_t {
     ::mem::transmute(vqtbx1q(
         ::mem::transmute(a),
         ::mem::transmute(t),
@@ -1245,9 +1214,7 @@ pub unsafe fn vqtbl2q_p8(t: poly8x16x2_t, idx: uint8x16_t) -> poly8x16_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx2_s8(
-    a: int8x8_t, t: int8x16x2_t, idx: uint8x8_t,
-) -> int8x8_t {
+pub unsafe fn vqtbx2_s8(a: int8x8_t, t: int8x16x2_t, idx: uint8x8_t) -> int8x8_t {
     vqtbx2(a, t.0, t.1, idx)
 }
 /// Extended table look-up
@@ -1255,9 +1222,7 @@ pub unsafe fn vqtbx2_s8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx2q_s8(
-    a: int8x16_t, t: int8x16x2_t, idx: uint8x16_t,
-) -> int8x16_t {
+pub unsafe fn vqtbx2q_s8(a: int8x16_t, t: int8x16x2_t, idx: uint8x16_t) -> int8x16_t {
     vqtbx2q(a, t.0, t.1, idx)
 }
 /// Extended table look-up
@@ -1265,9 +1230,7 @@ pub unsafe fn vqtbx2q_s8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx2_u8(
-    a: uint8x8_t, t: uint8x16x2_t, idx: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vqtbx2_u8(a: uint8x8_t, t: uint8x16x2_t, idx: uint8x8_t) -> uint8x8_t {
     ::mem::transmute(vqtbx2(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1280,9 +1243,7 @@ pub unsafe fn vqtbx2_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx2q_u8(
-    a: uint8x16_t, t: uint8x16x2_t, idx: uint8x16_t,
-) -> uint8x16_t {
+pub unsafe fn vqtbx2q_u8(a: uint8x16_t, t: uint8x16x2_t, idx: uint8x16_t) -> uint8x16_t {
     ::mem::transmute(vqtbx2q(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1295,9 +1256,7 @@ pub unsafe fn vqtbx2q_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx2_p8(
-    a: poly8x8_t, t: poly8x16x2_t, idx: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vqtbx2_p8(a: poly8x8_t, t: poly8x16x2_t, idx: uint8x8_t) -> poly8x8_t {
     ::mem::transmute(vqtbx2(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1310,9 +1269,7 @@ pub unsafe fn vqtbx2_p8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx2q_p8(
-    a: poly8x16_t, t: poly8x16x2_t, idx: uint8x16_t,
-) -> poly8x16_t {
+pub unsafe fn vqtbx2q_p8(a: poly8x16_t, t: poly8x16x2_t, idx: uint8x16_t) -> poly8x16_t {
     ::mem::transmute(vqtbx2q(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1394,9 +1351,7 @@ pub unsafe fn vqtbl3q_p8(t: poly8x16x3_t, idx: uint8x16_t) -> poly8x16_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx3_s8(
-    a: int8x8_t, t: int8x16x3_t, idx: uint8x8_t,
-) -> int8x8_t {
+pub unsafe fn vqtbx3_s8(a: int8x8_t, t: int8x16x3_t, idx: uint8x8_t) -> int8x8_t {
     vqtbx3(a, t.0, t.1, t.2, idx)
 }
 /// Extended table look-up
@@ -1404,9 +1359,7 @@ pub unsafe fn vqtbx3_s8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx3q_s8(
-    a: int8x16_t, t: int8x16x3_t, idx: uint8x16_t,
-) -> int8x16_t {
+pub unsafe fn vqtbx3q_s8(a: int8x16_t, t: int8x16x3_t, idx: uint8x16_t) -> int8x16_t {
     vqtbx3q(a, t.0, t.1, t.2, idx)
 }
 /// Extended table look-up
@@ -1414,9 +1367,7 @@ pub unsafe fn vqtbx3q_s8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx3_u8(
-    a: uint8x8_t, t: uint8x16x3_t, idx: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vqtbx3_u8(a: uint8x8_t, t: uint8x16x3_t, idx: uint8x8_t) -> uint8x8_t {
     ::mem::transmute(vqtbx3(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1430,9 +1381,7 @@ pub unsafe fn vqtbx3_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx3q_u8(
-    a: uint8x16_t, t: uint8x16x3_t, idx: uint8x16_t,
-) -> uint8x16_t {
+pub unsafe fn vqtbx3q_u8(a: uint8x16_t, t: uint8x16x3_t, idx: uint8x16_t) -> uint8x16_t {
     ::mem::transmute(vqtbx3q(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1446,9 +1395,7 @@ pub unsafe fn vqtbx3q_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx3_p8(
-    a: poly8x8_t, t: poly8x16x3_t, idx: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vqtbx3_p8(a: poly8x8_t, t: poly8x16x3_t, idx: uint8x8_t) -> poly8x8_t {
     ::mem::transmute(vqtbx3(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1462,9 +1409,7 @@ pub unsafe fn vqtbx3_p8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx3q_p8(
-    a: poly8x16_t, t: poly8x16x3_t, idx: uint8x16_t,
-) -> poly8x16_t {
+pub unsafe fn vqtbx3q_p8(a: poly8x16_t, t: poly8x16x3_t, idx: uint8x16_t) -> poly8x16_t {
     ::mem::transmute(vqtbx3q(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1551,9 +1496,7 @@ pub unsafe fn vqtbl4q_p8(t: poly8x16x4_t, idx: uint8x16_t) -> poly8x16_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx4_s8(
-    a: int8x8_t, t: int8x16x4_t, idx: uint8x8_t,
-) -> int8x8_t {
+pub unsafe fn vqtbx4_s8(a: int8x8_t, t: int8x16x4_t, idx: uint8x8_t) -> int8x8_t {
     vqtbx4(a, t.0, t.1, t.2, t.3, idx)
 }
 /// Extended table look-up
@@ -1561,9 +1504,7 @@ pub unsafe fn vqtbx4_s8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx4q_s8(
-    a: int8x16_t, t: int8x16x4_t, idx: uint8x16_t,
-) -> int8x16_t {
+pub unsafe fn vqtbx4q_s8(a: int8x16_t, t: int8x16x4_t, idx: uint8x16_t) -> int8x16_t {
     vqtbx4q(a, t.0, t.1, t.2, t.3, idx)
 }
 /// Extended table look-up
@@ -1571,9 +1512,7 @@ pub unsafe fn vqtbx4q_s8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx4_u8(
-    a: uint8x8_t, t: uint8x16x4_t, idx: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vqtbx4_u8(a: uint8x8_t, t: uint8x16x4_t, idx: uint8x8_t) -> uint8x8_t {
     ::mem::transmute(vqtbx4(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1588,9 +1527,7 @@ pub unsafe fn vqtbx4_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx4q_u8(
-    a: uint8x16_t, t: uint8x16x4_t, idx: uint8x16_t,
-) -> uint8x16_t {
+pub unsafe fn vqtbx4q_u8(a: uint8x16_t, t: uint8x16x4_t, idx: uint8x16_t) -> uint8x16_t {
     ::mem::transmute(vqtbx4q(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1605,9 +1542,7 @@ pub unsafe fn vqtbx4q_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx4_p8(
-    a: poly8x8_t, t: poly8x16x4_t, idx: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vqtbx4_p8(a: poly8x8_t, t: poly8x16x4_t, idx: uint8x8_t) -> poly8x8_t {
     ::mem::transmute(vqtbx4(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1622,9 +1557,7 @@ pub unsafe fn vqtbx4_p8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[cfg_attr(test, assert_instr(tbx))]
-pub unsafe fn vqtbx4q_p8(
-    a: poly8x16_t, t: poly8x16x4_t, idx: uint8x16_t,
-) -> poly8x16_t {
+pub unsafe fn vqtbx4q_p8(a: poly8x16_t, t: poly8x16x4_t, idx: uint8x16_t) -> poly8x16_t {
     ::mem::transmute(vqtbx4q(
         ::mem::transmute(a),
         ::mem::transmute(t.0),
@@ -1647,8 +1580,7 @@ mod tests {
         let a = 1.;
         let b = 8.;
         let e = 9.;
-        let r: f64 =
-            mem::transmute(vadd_f64(mem::transmute(a), mem::transmute(b)));
+        let r: f64 = mem::transmute(vadd_f64(mem::transmute(a), mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1657,10 +1589,7 @@ mod tests {
         let a = f64x2::new(1., 2.);
         let b = f64x2::new(8., 7.);
         let e = f64x2::new(9., 9.);
-        let r: f64x2 = ::mem::transmute(vaddq_f64(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f64x2 = ::mem::transmute(vaddq_f64(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1669,8 +1598,7 @@ mod tests {
         let a = 1_i64;
         let b = 8_i64;
         let e = 9_i64;
-        let r: i64 =
-            mem::transmute(vaddd_s64(mem::transmute(a), mem::transmute(b)));
+        let r: i64 = mem::transmute(vaddd_s64(mem::transmute(a), mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1679,8 +1607,7 @@ mod tests {
         let a = 1_u64;
         let b = 8_u64;
         let e = 9_u64;
-        let r: u64 =
-            mem::transmute(vaddd_u64(mem::transmute(a), mem::transmute(b)));
+        let r: u64 = mem::transmute(vaddd_u64(mem::transmute(a), mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1710,8 +1637,7 @@ mod tests {
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vmaxvq_s16() {
-        let r =
-            vmaxvq_s16(::mem::transmute(i16x8::new(1, 2, 7, 4, -16, 6, 7, 5)));
+        let r = vmaxvq_s16(::mem::transmute(i16x8::new(1, 2, 7, 4, -16, 6, 7, 5)));
         assert_eq!(r, 7_i16);
     }
 
@@ -1753,8 +1679,7 @@ mod tests {
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vmaxvq_u16() {
-        let r =
-            vmaxvq_u16(::mem::transmute(u16x8::new(1, 2, 7, 4, 16, 6, 7, 5)));
+        let r = vmaxvq_u16(::mem::transmute(u16x8::new(1, 2, 7, 4, 16, 6, 7, 5)));
         assert_eq!(r, 16_u16);
     }
 
@@ -1814,8 +1739,7 @@ mod tests {
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vminvq_s16() {
-        let r =
-            vminvq_s16(::mem::transmute(i16x8::new(1, 2, 7, 4, -16, 6, 7, 5)));
+        let r = vminvq_s16(::mem::transmute(i16x8::new(1, 2, 7, 4, -16, 6, 7, 5)));
         assert_eq!(r, -16_i16);
     }
 
@@ -1857,8 +1781,7 @@ mod tests {
 
     #[simd_test(enable = "neon")]
     unsafe fn test_vminvq_u16() {
-        let r =
-            vminvq_u16(::mem::transmute(u16x8::new(1, 2, 7, 4, 16, 6, 7, 5)));
+        let r = vminvq_u16(::mem::transmute(u16x8::new(1, 2, 7, 4, 16, 6, 7, 5)));
         assert_eq!(r, 1_u16);
     }
 
@@ -1900,10 +1823,7 @@ mod tests {
         let b = i8x16::new(0, 3, 2, 5, 4, 7, 6, 9, 0, 3, 2, 5, 4, 7, 6, 9);
         #[cfg_attr(rustfmt, skip)]
         let e = i8x16::new(-2, -4, 5, 7, 1, 3, 5, 7, 0, 2, 4, 6, 0, 2, 4, 6);
-        let r: i8x16 = ::mem::transmute(vpminq_s8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i8x16 = ::mem::transmute(vpminq_s8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1912,10 +1832,7 @@ mod tests {
         let a = i16x8::new(1, -2, 3, 4, 5, 6, 7, 8);
         let b = i16x8::new(0, 3, 2, 5, 4, 7, 6, 9);
         let e = i16x8::new(-2, 3, 5, 7, 0, 2, 4, 6);
-        let r: i16x8 = ::mem::transmute(vpminq_s16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i16x8 = ::mem::transmute(vpminq_s16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1924,10 +1841,7 @@ mod tests {
         let a = i32x4::new(1, -2, 3, 4);
         let b = i32x4::new(0, 3, 2, 5);
         let e = i32x4::new(-2, 3, 0, 2);
-        let r: i32x4 = ::mem::transmute(vpminq_s32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i32x4 = ::mem::transmute(vpminq_s32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1939,10 +1853,7 @@ mod tests {
         let b = u8x16::new(0, 3, 2, 5, 4, 7, 6, 9, 0, 3, 2, 5, 4, 7, 6, 9);
         #[cfg_attr(rustfmt, skip)]
         let e = u8x16::new(1, 3, 5, 7, 1, 3, 5, 7, 0, 2, 4, 6, 0, 2, 4, 6);
-        let r: u8x16 = ::mem::transmute(vpminq_u8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u8x16 = ::mem::transmute(vpminq_u8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1951,10 +1862,7 @@ mod tests {
         let a = u16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
         let b = u16x8::new(0, 3, 2, 5, 4, 7, 6, 9);
         let e = u16x8::new(1, 3, 5, 7, 0, 2, 4, 6);
-        let r: u16x8 = ::mem::transmute(vpminq_u16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u16x8 = ::mem::transmute(vpminq_u16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1963,10 +1871,7 @@ mod tests {
         let a = u32x4::new(1, 2, 3, 4);
         let b = u32x4::new(0, 3, 2, 5);
         let e = u32x4::new(1, 3, 0, 2);
-        let r: u32x4 = ::mem::transmute(vpminq_u32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u32x4 = ::mem::transmute(vpminq_u32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1975,10 +1880,7 @@ mod tests {
         let a = f32x4::new(1., -2., 3., 4.);
         let b = f32x4::new(0., 3., 2., 5.);
         let e = f32x4::new(-2., 3., 0., 2.);
-        let r: f32x4 = ::mem::transmute(vpminq_f32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f32x4 = ::mem::transmute(vpminq_f32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1987,10 +1889,7 @@ mod tests {
         let a = f64x2::new(1., -2.);
         let b = f64x2::new(0., 3.);
         let e = f64x2::new(-2., 0.);
-        let r: f64x2 = ::mem::transmute(vpminq_f64(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f64x2 = ::mem::transmute(vpminq_f64(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -2002,10 +1901,7 @@ mod tests {
         let b = i8x16::new(0, 3, 2, 5, 4, 7, 6, 9, 0, 3, 2, 5, 4, 7, 6, 9);
         #[cfg_attr(rustfmt, skip)]
         let e = i8x16::new(1, 3, 6, 8, 2, 4, 6, 8, 3, 5, 7, 9, 3, 5, 7, 9);
-        let r: i8x16 = ::mem::transmute(vpmaxq_s8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i8x16 = ::mem::transmute(vpmaxq_s8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -2014,10 +1910,7 @@ mod tests {
         let a = i16x8::new(1, -2, 3, 4, 5, 6, 7, 8);
         let b = i16x8::new(0, 3, 2, 5, 4, 7, 6, 9);
         let e = i16x8::new(1, 4, 6, 8, 3, 5, 7, 9);
-        let r: i16x8 = ::mem::transmute(vpmaxq_s16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i16x8 = ::mem::transmute(vpmaxq_s16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -2026,10 +1919,7 @@ mod tests {
         let a = i32x4::new(1, -2, 3, 4);
         let b = i32x4::new(0, 3, 2, 5);
         let e = i32x4::new(1, 4, 3, 5);
-        let r: i32x4 = ::mem::transmute(vpmaxq_s32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i32x4 = ::mem::transmute(vpmaxq_s32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -2041,10 +1931,7 @@ mod tests {
         let b = u8x16::new(0, 3, 2, 5, 4, 7, 6, 9, 0, 3, 2, 5, 4, 7, 6, 9);
         #[cfg_attr(rustfmt, skip)]
         let e = u8x16::new(2, 4, 6, 8, 2, 4, 6, 8, 3, 5, 7, 9, 3, 5, 7, 9);
-        let r: u8x16 = ::mem::transmute(vpmaxq_u8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u8x16 = ::mem::transmute(vpmaxq_u8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -2053,10 +1940,7 @@ mod tests {
         let a = u16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
         let b = u16x8::new(0, 3, 2, 5, 4, 7, 6, 9);
         let e = u16x8::new(2, 4, 6, 8, 3, 5, 7, 9);
-        let r: u16x8 = ::mem::transmute(vpmaxq_u16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u16x8 = ::mem::transmute(vpmaxq_u16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -2065,10 +1949,7 @@ mod tests {
         let a = u32x4::new(1, 2, 3, 4);
         let b = u32x4::new(0, 3, 2, 5);
         let e = u32x4::new(2, 4, 3, 5);
-        let r: u32x4 = ::mem::transmute(vpmaxq_u32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u32x4 = ::mem::transmute(vpmaxq_u32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -2077,10 +1958,7 @@ mod tests {
         let a = f32x4::new(1., -2., 3., 4.);
         let b = f32x4::new(0., 3., 2., 5.);
         let e = f32x4::new(1., 4., 3., 5.);
-        let r: f32x4 = ::mem::transmute(vpmaxq_f32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f32x4 = ::mem::transmute(vpmaxq_f32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -2089,10 +1967,7 @@ mod tests {
         let a = f64x2::new(1., -2.);
         let b = f64x2::new(0., 3.);
         let e = f64x2::new(1., 3.);
-        let r: f64x2 = ::mem::transmute(vpmaxq_f64(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f64x2 = ::mem::transmute(vpmaxq_f64(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 

--- a/coresimd/arm/mod.rs
+++ b/coresimd/arm/mod.rs
@@ -26,10 +26,7 @@ pub use self::v7::*;
 
 #[cfg(any(all(target_feature = "v7", not(target_feature = "mclass")), dox))]
 mod dsp;
-#[cfg(any(
-    all(target_feature = "v7", not(target_feature = "mclass")),
-    dox
-))]
+#[cfg(any(all(target_feature = "v7", not(target_feature = "mclass")), dox))]
 pub use self::dsp::*;
 
 // NEON is supported on AArch64, and on ARM when built with the v7 and neon

--- a/coresimd/arm/neon.rs
+++ b/coresimd/arm/neon.rs
@@ -83,12 +83,7 @@ pub struct uint8x8x2_t(pub uint8x8_t, pub uint8x8_t);
 pub struct uint8x8x3_t(pub uint8x8_t, pub uint8x8_t, pub uint8x8_t);
 /// ARM-specific type containing four `uint8x8_t` vectors.
 #[derive(Copy, Clone)]
-pub struct uint8x8x4_t(
-    pub uint8x8_t,
-    pub uint8x8_t,
-    pub uint8x8_t,
-    pub uint8x8_t,
-);
+pub struct uint8x8x4_t(pub uint8x8_t, pub uint8x8_t, pub uint8x8_t, pub uint8x8_t);
 
 /// ARM-specific type containing two `poly8x8_t` vectors.
 #[derive(Copy, Clone)]
@@ -98,106 +93,56 @@ pub struct poly8x8x2_t(pub poly8x8_t, pub poly8x8_t);
 pub struct poly8x8x3_t(pub poly8x8_t, pub poly8x8_t, pub poly8x8_t);
 /// ARM-specific type containing four `poly8x8_t` vectors.
 #[derive(Copy, Clone)]
-pub struct poly8x8x4_t(
-    pub poly8x8_t,
-    pub poly8x8_t,
-    pub poly8x8_t,
-    pub poly8x8_t,
-);
+pub struct poly8x8x4_t(pub poly8x8_t, pub poly8x8_t, pub poly8x8_t, pub poly8x8_t);
 
 #[allow(improper_ctypes)]
 extern "C" {
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.frsqrte.v2f32"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.frsqrte.v2f32")]
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vrsqrte.v2f32")]
     fn frsqrte_v2f32(a: float32x2_t) -> float32x2_t;
 
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmins.v8i8")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.sminp.v8i8"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.sminp.v8i8")]
     fn vpmins_v8i8(a: int8x8_t, b: int8x8_t) -> int8x8_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmins.v4i16")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.sminp.v4i16"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.sminp.v4i16")]
     fn vpmins_v4i16(a: int16x4_t, b: int16x4_t) -> int16x4_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmins.v2i32")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.sminp.v2i32"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.sminp.v2i32")]
     fn vpmins_v2i32(a: int32x2_t, b: int32x2_t) -> int32x2_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpminu.v8i8")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.uminp.v8i8"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.uminp.v8i8")]
     fn vpminu_v8i8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpminu.v4i16")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.uminp.v4i16"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.uminp.v4i16")]
     fn vpminu_v4i16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpminu.v2i32")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.uminp.v2i32"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.uminp.v2i32")]
     fn vpminu_v2i32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmins.v2f32")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.fminp.v2f32"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.fminp.v2f32")]
     fn vpminf_v2f32(a: float32x2_t, b: float32x2_t) -> float32x2_t;
 
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmaxs.v8i8")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.smaxp.v8i8"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.smaxp.v8i8")]
     fn vpmaxs_v8i8(a: int8x8_t, b: int8x8_t) -> int8x8_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmaxs.v4i16")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.smaxp.v4i16"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.smaxp.v4i16")]
     fn vpmaxs_v4i16(a: int16x4_t, b: int16x4_t) -> int16x4_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmaxs.v2i32")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.smaxp.v2i32"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.smaxp.v2i32")]
     fn vpmaxs_v2i32(a: int32x2_t, b: int32x2_t) -> int32x2_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmaxu.v8i8")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.umaxp.v8i8"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.umaxp.v8i8")]
     fn vpmaxu_v8i8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmaxu.v4i16")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.umaxp.v4i16"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.umaxp.v4i16")]
     fn vpmaxu_v4i16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmaxu.v2i32")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.umaxp.v2i32"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.umaxp.v2i32")]
     fn vpmaxu_v2i32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t;
     #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vpmaxs.v2f32")]
-    #[cfg_attr(
-        target_arch = "aarch64",
-        link_name = "llvm.aarch64.neon.fmaxp.v2f32"
-    )]
+    #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.neon.fmaxp.v2f32")]
     fn vpmaxf_v2f32(a: float32x2_t, b: float32x2_t) -> float32x2_t;
 }
 
@@ -211,21 +156,21 @@ extern "C" {
     #[link_name = "llvm.arm.neon.vtbl3"]
     fn vtbl3(a: int8x8_t, b: int8x8_t, b: int8x8_t, c: int8x8_t) -> int8x8_t;
     #[link_name = "llvm.arm.neon.vtbl4"]
-    fn vtbl4(
-        a: int8x8_t, b: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t,
-    ) -> int8x8_t;
+    fn vtbl4(a: int8x8_t, b: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t) -> int8x8_t;
 
     #[link_name = "llvm.arm.neon.vtbx1"]
     fn vtbx1(a: int8x8_t, b: int8x8_t, b: int8x8_t) -> int8x8_t;
     #[link_name = "llvm.arm.neon.vtbx2"]
     fn vtbx2(a: int8x8_t, b: int8x8_t, b: int8x8_t, c: int8x8_t) -> int8x8_t;
     #[link_name = "llvm.arm.neon.vtbx3"]
-    fn vtbx3(
-        a: int8x8_t, b: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t,
-    ) -> int8x8_t;
+    fn vtbx3(a: int8x8_t, b: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t) -> int8x8_t;
     #[link_name = "llvm.arm.neon.vtbx4"]
     fn vtbx4(
-        a: int8x8_t, b: int8x8_t, b: int8x8_t, c: int8x8_t, d: int8x8_t,
+        a: int8x8_t,
+        b: int8x8_t,
+        b: int8x8_t,
+        c: int8x8_t,
+        d: int8x8_t,
         e: int8x8_t,
     ) -> int8x8_t;
 }
@@ -935,9 +880,7 @@ pub unsafe fn vtbx2_s8(a: int8x8_t, b: int8x8x2_t, c: int8x8_t) -> int8x8_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,v7")]
 #[cfg_attr(test, assert_instr(vtbx))]
-pub unsafe fn vtbx2_u8(
-    a: uint8x8_t, b: uint8x8x2_t, c: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vtbx2_u8(a: uint8x8_t, b: uint8x8x2_t, c: uint8x8_t) -> uint8x8_t {
     ::mem::transmute(vtbx2(
         ::mem::transmute(a),
         ::mem::transmute(b.0),
@@ -952,9 +895,7 @@ pub unsafe fn vtbx2_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,v7")]
 #[cfg_attr(test, assert_instr(vtbx))]
-pub unsafe fn vtbx2_p8(
-    a: poly8x8_t, b: poly8x8x2_t, c: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vtbx2_p8(a: poly8x8_t, b: poly8x8x2_t, c: uint8x8_t) -> poly8x8_t {
     ::mem::transmute(vtbx2(
         ::mem::transmute(a),
         ::mem::transmute(b.0),
@@ -979,9 +920,7 @@ pub unsafe fn vtbx3_s8(a: int8x8_t, b: int8x8x3_t, c: int8x8_t) -> int8x8_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,v7")]
 #[cfg_attr(test, assert_instr(vtbx))]
-pub unsafe fn vtbx3_u8(
-    a: uint8x8_t, b: uint8x8x3_t, c: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vtbx3_u8(a: uint8x8_t, b: uint8x8x3_t, c: uint8x8_t) -> uint8x8_t {
     ::mem::transmute(vtbx3(
         ::mem::transmute(a),
         ::mem::transmute(b.0),
@@ -997,9 +936,7 @@ pub unsafe fn vtbx3_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,v7")]
 #[cfg_attr(test, assert_instr(vtbx))]
-pub unsafe fn vtbx3_p8(
-    a: poly8x8_t, b: poly8x8x3_t, c: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vtbx3_p8(a: poly8x8_t, b: poly8x8x3_t, c: uint8x8_t) -> poly8x8_t {
     ::mem::transmute(vtbx3(
         ::mem::transmute(a),
         ::mem::transmute(b.0),
@@ -1025,9 +962,7 @@ pub unsafe fn vtbx4_s8(a: int8x8_t, b: int8x8x4_t, c: int8x8_t) -> int8x8_t {
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,v7")]
 #[cfg_attr(test, assert_instr(vtbx))]
-pub unsafe fn vtbx4_u8(
-    a: uint8x8_t, b: uint8x8x4_t, c: uint8x8_t,
-) -> uint8x8_t {
+pub unsafe fn vtbx4_u8(a: uint8x8_t, b: uint8x8x4_t, c: uint8x8_t) -> uint8x8_t {
     ::mem::transmute(vtbx4(
         ::mem::transmute(a),
         ::mem::transmute(b.0),
@@ -1044,9 +979,7 @@ pub unsafe fn vtbx4_u8(
 #[cfg(target_endian = "little")]
 #[target_feature(enable = "neon,v7")]
 #[cfg_attr(test, assert_instr(vtbx))]
-pub unsafe fn vtbx4_p8(
-    a: poly8x8_t, b: poly8x8x4_t, c: uint8x8_t,
-) -> poly8x8_t {
+pub unsafe fn vtbx4_p8(a: poly8x8_t, b: poly8x8x4_t, c: uint8x8_t) -> poly8x8_t {
     ::mem::transmute(vtbx4(
         ::mem::transmute(a),
         ::mem::transmute(b.0),
@@ -1069,10 +1002,7 @@ mod tests {
         let a = i8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
         let b = i8x8::new(8, 7, 6, 5, 4, 3, 2, 1);
         let e = i8x8::new(9, 9, 9, 9, 9, 9, 9, 9);
-        let r: i8x8 = ::mem::transmute(vadd_s8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i8x8 = ::mem::transmute(vadd_s8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1081,10 +1011,7 @@ mod tests {
         let a = i8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
         let b = i8x16::new(8, 7, 6, 5, 4, 3, 2, 1, 8, 7, 6, 5, 4, 3, 2, 1);
         let e = i8x16::new(9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9);
-        let r: i8x16 = ::mem::transmute(vaddq_s8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i8x16 = ::mem::transmute(vaddq_s8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1093,10 +1020,7 @@ mod tests {
         let a = i16x4::new(1, 2, 3, 4);
         let b = i16x4::new(8, 7, 6, 5);
         let e = i16x4::new(9, 9, 9, 9);
-        let r: i16x4 = ::mem::transmute(vadd_s16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i16x4 = ::mem::transmute(vadd_s16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1105,10 +1029,7 @@ mod tests {
         let a = i16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
         let b = i16x8::new(8, 7, 6, 5, 4, 3, 2, 1);
         let e = i16x8::new(9, 9, 9, 9, 9, 9, 9, 9);
-        let r: i16x8 = ::mem::transmute(vaddq_s16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i16x8 = ::mem::transmute(vaddq_s16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1117,10 +1038,7 @@ mod tests {
         let a = i32x2::new(1, 2);
         let b = i32x2::new(8, 7);
         let e = i32x2::new(9, 9);
-        let r: i32x2 = ::mem::transmute(vadd_s32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i32x2 = ::mem::transmute(vadd_s32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1129,10 +1047,7 @@ mod tests {
         let a = i32x4::new(1, 2, 3, 4);
         let b = i32x4::new(8, 7, 6, 5);
         let e = i32x4::new(9, 9, 9, 9);
-        let r: i32x4 = ::mem::transmute(vaddq_s32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i32x4 = ::mem::transmute(vaddq_s32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1141,10 +1056,7 @@ mod tests {
         let a = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
         let b = u8x8::new(8, 7, 6, 5, 4, 3, 2, 1);
         let e = u8x8::new(9, 9, 9, 9, 9, 9, 9, 9);
-        let r: u8x8 = ::mem::transmute(vadd_u8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u8x8 = ::mem::transmute(vadd_u8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1153,10 +1065,7 @@ mod tests {
         let a = u8x16::new(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
         let b = u8x16::new(8, 7, 6, 5, 4, 3, 2, 1, 8, 7, 6, 5, 4, 3, 2, 1);
         let e = u8x16::new(9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9);
-        let r: u8x16 = ::mem::transmute(vaddq_u8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u8x16 = ::mem::transmute(vaddq_u8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1165,10 +1074,7 @@ mod tests {
         let a = u16x4::new(1, 2, 3, 4);
         let b = u16x4::new(8, 7, 6, 5);
         let e = u16x4::new(9, 9, 9, 9);
-        let r: u16x4 = ::mem::transmute(vadd_u16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u16x4 = ::mem::transmute(vadd_u16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1177,10 +1083,7 @@ mod tests {
         let a = u16x8::new(1, 2, 3, 4, 5, 6, 7, 8);
         let b = u16x8::new(8, 7, 6, 5, 4, 3, 2, 1);
         let e = u16x8::new(9, 9, 9, 9, 9, 9, 9, 9);
-        let r: u16x8 = ::mem::transmute(vaddq_u16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u16x8 = ::mem::transmute(vaddq_u16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1189,10 +1092,7 @@ mod tests {
         let a = u32x2::new(1, 2);
         let b = u32x2::new(8, 7);
         let e = u32x2::new(9, 9);
-        let r: u32x2 = ::mem::transmute(vadd_u32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u32x2 = ::mem::transmute(vadd_u32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1201,10 +1101,7 @@ mod tests {
         let a = u32x4::new(1, 2, 3, 4);
         let b = u32x4::new(8, 7, 6, 5);
         let e = u32x4::new(9, 9, 9, 9);
-        let r: u32x4 = ::mem::transmute(vaddq_u32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u32x4 = ::mem::transmute(vaddq_u32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1213,10 +1110,7 @@ mod tests {
         let a = f32x2::new(1., 2.);
         let b = f32x2::new(8., 7.);
         let e = f32x2::new(9., 9.);
-        let r: f32x2 = ::mem::transmute(vadd_f32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f32x2 = ::mem::transmute(vadd_f32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1225,10 +1119,7 @@ mod tests {
         let a = f32x4::new(1., 2., 3., 4.);
         let b = f32x4::new(8., 7., 6., 5.);
         let e = f32x4::new(9., 9., 9., 9.);
-        let r: f32x4 = ::mem::transmute(vaddq_f32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f32x4 = ::mem::transmute(vaddq_f32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1238,10 +1129,7 @@ mod tests {
         let a = i8x8::new(v, v, v, v, v, v, v, v);
         let v = 2 * (v as i16);
         let e = i16x8::new(v, v, v, v, v, v, v, v);
-        let r: i16x8 = ::mem::transmute(vaddl_s8(
-            ::mem::transmute(a),
-            ::mem::transmute(a),
-        ));
+        let r: i16x8 = ::mem::transmute(vaddl_s8(::mem::transmute(a), ::mem::transmute(a)));
         assert_eq!(r, e);
     }
 
@@ -1251,10 +1139,7 @@ mod tests {
         let a = i16x4::new(v, v, v, v);
         let v = 2 * (v as i32);
         let e = i32x4::new(v, v, v, v);
-        let r: i32x4 = ::mem::transmute(vaddl_s16(
-            ::mem::transmute(a),
-            ::mem::transmute(a),
-        ));
+        let r: i32x4 = ::mem::transmute(vaddl_s16(::mem::transmute(a), ::mem::transmute(a)));
         assert_eq!(r, e);
     }
 
@@ -1264,10 +1149,7 @@ mod tests {
         let a = i32x2::new(v, v);
         let v = 2 * (v as i64);
         let e = i64x2::new(v, v);
-        let r: i64x2 = ::mem::transmute(vaddl_s32(
-            ::mem::transmute(a),
-            ::mem::transmute(a),
-        ));
+        let r: i64x2 = ::mem::transmute(vaddl_s32(::mem::transmute(a), ::mem::transmute(a)));
         assert_eq!(r, e);
     }
 
@@ -1277,10 +1159,7 @@ mod tests {
         let a = u8x8::new(v, v, v, v, v, v, v, v);
         let v = 2 * (v as u16);
         let e = u16x8::new(v, v, v, v, v, v, v, v);
-        let r: u16x8 = ::mem::transmute(vaddl_u8(
-            ::mem::transmute(a),
-            ::mem::transmute(a),
-        ));
+        let r: u16x8 = ::mem::transmute(vaddl_u8(::mem::transmute(a), ::mem::transmute(a)));
         assert_eq!(r, e);
     }
 
@@ -1290,10 +1169,7 @@ mod tests {
         let a = u16x4::new(v, v, v, v);
         let v = 2 * (v as u32);
         let e = u32x4::new(v, v, v, v);
-        let r: u32x4 = ::mem::transmute(vaddl_u16(
-            ::mem::transmute(a),
-            ::mem::transmute(a),
-        ));
+        let r: u32x4 = ::mem::transmute(vaddl_u16(::mem::transmute(a), ::mem::transmute(a)));
         assert_eq!(r, e);
     }
 
@@ -1303,10 +1179,7 @@ mod tests {
         let a = u32x2::new(v, v);
         let v = 2 * (v as u64);
         let e = u64x2::new(v, v);
-        let r: u64x2 = ::mem::transmute(vaddl_u32(
-            ::mem::transmute(a),
-            ::mem::transmute(a),
-        ));
+        let r: u64x2 = ::mem::transmute(vaddl_u32(::mem::transmute(a), ::mem::transmute(a)));
         assert_eq!(r, e);
     }
 
@@ -1419,10 +1292,7 @@ mod tests {
         let a = i8x8::new(1, -2, 3, -4, 5, 6, 7, 8);
         let b = i8x8::new(0, 3, 2, 5, 4, 7, 6, 9);
         let e = i8x8::new(-2, -4, 5, 7, 0, 2, 4, 6);
-        let r: i8x8 = ::mem::transmute(vpmin_s8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i8x8 = ::mem::transmute(vpmin_s8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1431,10 +1301,7 @@ mod tests {
         let a = i16x4::new(1, 2, 3, -4);
         let b = i16x4::new(0, 3, 2, 5);
         let e = i16x4::new(1, -4, 0, 2);
-        let r: i16x4 = ::mem::transmute(vpmin_s16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i16x4 = ::mem::transmute(vpmin_s16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1443,10 +1310,7 @@ mod tests {
         let a = i32x2::new(1, -2);
         let b = i32x2::new(0, 3);
         let e = i32x2::new(-2, 0);
-        let r: i32x2 = ::mem::transmute(vpmin_s32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i32x2 = ::mem::transmute(vpmin_s32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1455,10 +1319,7 @@ mod tests {
         let a = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
         let b = u8x8::new(0, 3, 2, 5, 4, 7, 6, 9);
         let e = u8x8::new(1, 3, 5, 7, 0, 2, 4, 6);
-        let r: u8x8 = ::mem::transmute(vpmin_u8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u8x8 = ::mem::transmute(vpmin_u8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1467,10 +1328,7 @@ mod tests {
         let a = u16x4::new(1, 2, 3, 4);
         let b = u16x4::new(0, 3, 2, 5);
         let e = u16x4::new(1, 3, 0, 2);
-        let r: u16x4 = ::mem::transmute(vpmin_u16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u16x4 = ::mem::transmute(vpmin_u16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1479,10 +1337,7 @@ mod tests {
         let a = u32x2::new(1, 2);
         let b = u32x2::new(0, 3);
         let e = u32x2::new(1, 0);
-        let r: u32x2 = ::mem::transmute(vpmin_u32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u32x2 = ::mem::transmute(vpmin_u32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1491,10 +1346,7 @@ mod tests {
         let a = f32x2::new(1., -2.);
         let b = f32x2::new(0., 3.);
         let e = f32x2::new(-2., 0.);
-        let r: f32x2 = ::mem::transmute(vpmin_f32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f32x2 = ::mem::transmute(vpmin_f32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1503,10 +1355,7 @@ mod tests {
         let a = i8x8::new(1, -2, 3, -4, 5, 6, 7, 8);
         let b = i8x8::new(0, 3, 2, 5, 4, 7, 6, 9);
         let e = i8x8::new(1, 3, 6, 8, 3, 5, 7, 9);
-        let r: i8x8 = ::mem::transmute(vpmax_s8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i8x8 = ::mem::transmute(vpmax_s8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1515,10 +1364,7 @@ mod tests {
         let a = i16x4::new(1, 2, 3, -4);
         let b = i16x4::new(0, 3, 2, 5);
         let e = i16x4::new(2, 3, 3, 5);
-        let r: i16x4 = ::mem::transmute(vpmax_s16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i16x4 = ::mem::transmute(vpmax_s16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1527,10 +1373,7 @@ mod tests {
         let a = i32x2::new(1, -2);
         let b = i32x2::new(0, 3);
         let e = i32x2::new(1, 3);
-        let r: i32x2 = ::mem::transmute(vpmax_s32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: i32x2 = ::mem::transmute(vpmax_s32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1539,10 +1382,7 @@ mod tests {
         let a = u8x8::new(1, 2, 3, 4, 5, 6, 7, 8);
         let b = u8x8::new(0, 3, 2, 5, 4, 7, 6, 9);
         let e = u8x8::new(2, 4, 6, 8, 3, 5, 7, 9);
-        let r: u8x8 = ::mem::transmute(vpmax_u8(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u8x8 = ::mem::transmute(vpmax_u8(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1551,10 +1391,7 @@ mod tests {
         let a = u16x4::new(1, 2, 3, 4);
         let b = u16x4::new(0, 3, 2, 5);
         let e = u16x4::new(2, 4, 3, 5);
-        let r: u16x4 = ::mem::transmute(vpmax_u16(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u16x4 = ::mem::transmute(vpmax_u16(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1563,10 +1400,7 @@ mod tests {
         let a = u32x2::new(1, 2);
         let b = u32x2::new(0, 3);
         let e = u32x2::new(2, 3);
-        let r: u32x2 = ::mem::transmute(vpmax_u32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: u32x2 = ::mem::transmute(vpmax_u32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 
@@ -1575,10 +1409,7 @@ mod tests {
         let a = f32x2::new(1., -2.);
         let b = f32x2::new(0., 3.);
         let e = f32x2::new(1., 3.);
-        let r: f32x2 = ::mem::transmute(vpmax_f32(
-            ::mem::transmute(a),
-            ::mem::transmute(b),
-        ));
+        let r: f32x2 = ::mem::transmute(vpmax_f32(::mem::transmute(a), ::mem::transmute(b)));
         assert_eq!(r, e);
     }
 }

--- a/coresimd/powerpc/altivec.rs
+++ b/coresimd/powerpc/altivec.rs
@@ -53,99 +53,86 @@ types! {
 extern "C" {
     #[link_name = "llvm.ppc.altivec.vperm"]
     fn vperm(
-        a: vector_signed_int, b: vector_signed_int, c: vector_unsigned_char,
+        a: vector_signed_int,
+        b: vector_signed_int,
+        c: vector_unsigned_char,
     ) -> vector_signed_int;
     #[link_name = "llvm.ppc.altivec.vmhaddshs"]
     fn vmhaddshs(
-        a: vector_signed_short, b: vector_signed_short, c: vector_signed_short,
+        a: vector_signed_short,
+        b: vector_signed_short,
+        c: vector_signed_short,
     ) -> vector_signed_short;
     #[link_name = "llvm.ppc.altivec.vmhraddshs"]
     fn vmhraddshs(
-        a: vector_signed_short, b: vector_signed_short, c: vector_signed_short,
+        a: vector_signed_short,
+        b: vector_signed_short,
+        c: vector_signed_short,
     ) -> vector_signed_short;
     #[link_name = "llvm.ppc.altivec.vmsumuhs"]
     fn vmsumuhs(
-        a: vector_unsigned_short, b: vector_unsigned_short,
+        a: vector_unsigned_short,
+        b: vector_unsigned_short,
         c: vector_unsigned_int,
     ) -> vector_unsigned_int;
     #[link_name = "llvm.ppc.altivec.vmsumshs"]
     fn vmsumshs(
-        a: vector_signed_short, b: vector_signed_short, c: vector_signed_int,
+        a: vector_signed_short,
+        b: vector_signed_short,
+        c: vector_signed_int,
     ) -> vector_signed_int;
     #[link_name = "llvm.ppc.altivec.vmsumubm"]
     fn vmsumubm(
-        a: vector_unsigned_char, b: vector_unsigned_char,
+        a: vector_unsigned_char,
+        b: vector_unsigned_char,
         c: vector_unsigned_int,
     ) -> vector_unsigned_int;
     #[link_name = "llvm.ppc.altivec.vmsummbm"]
     fn vmsummbm(
-        a: vector_signed_char, b: vector_unsigned_char, c: vector_signed_int,
+        a: vector_signed_char,
+        b: vector_unsigned_char,
+        c: vector_signed_int,
     ) -> vector_signed_int;
     #[link_name = "llvm.ppc.altivec.vmsumuhm"]
     fn vmsumuhm(
-        a: vector_unsigned_short, b: vector_unsigned_short,
+        a: vector_unsigned_short,
+        b: vector_unsigned_short,
         c: vector_unsigned_int,
     ) -> vector_unsigned_int;
     #[link_name = "llvm.ppc.altivec.vmsumshm"]
     fn vmsumshm(
-        a: vector_signed_short, b: vector_signed_short, c: vector_signed_int,
+        a: vector_signed_short,
+        b: vector_signed_short,
+        c: vector_signed_int,
     ) -> vector_signed_int;
     #[link_name = "llvm.ppc.altivec.vmaddfp"]
-    fn vmaddfp(
-        a: vector_float, b: vector_float, c: vector_float,
-    ) -> vector_float;
+    fn vmaddfp(a: vector_float, b: vector_float, c: vector_float) -> vector_float;
     #[link_name = "llvm.ppc.altivec.vnmsubfp"]
-    fn vnmsubfp(
-        a: vector_float, b: vector_float, c: vector_float,
-    ) -> vector_float;
+    fn vnmsubfp(a: vector_float, b: vector_float, c: vector_float) -> vector_float;
     #[link_name = "llvm.ppc.altivec.vsum2sws"]
-    fn vsum2sws(
-        a: vector_signed_int, b: vector_signed_int,
-    ) -> vector_signed_int;
+    fn vsum2sws(a: vector_signed_int, b: vector_signed_int) -> vector_signed_int;
     #[link_name = "llvm.ppc.altivec.vsum4ubs"]
-    fn vsum4ubs(
-        a: vector_unsigned_char, b: vector_unsigned_int,
-    ) -> vector_unsigned_int;
+    fn vsum4ubs(a: vector_unsigned_char, b: vector_unsigned_int) -> vector_unsigned_int;
     #[link_name = "llvm.ppc.altivec.vsum4sbs"]
-    fn vsum4sbs(
-        a: vector_signed_char, b: vector_signed_int,
-    ) -> vector_signed_int;
+    fn vsum4sbs(a: vector_signed_char, b: vector_signed_int) -> vector_signed_int;
     #[link_name = "llvm.ppc.altivec.vsum4shs"]
-    fn vsum4shs(
-        a: vector_signed_short, b: vector_signed_int,
-    ) -> vector_signed_int;
+    fn vsum4shs(a: vector_signed_short, b: vector_signed_int) -> vector_signed_int;
     #[link_name = "llvm.ppc.altivec.vmuleub"]
-    fn vmuleub(
-        a: vector_unsigned_char, b: vector_unsigned_char,
-    ) -> vector_unsigned_short;
+    fn vmuleub(a: vector_unsigned_char, b: vector_unsigned_char) -> vector_unsigned_short;
     #[link_name = "llvm.ppc.altivec.vmulesb"]
-    fn vmulesb(
-        a: vector_signed_char, b: vector_signed_char,
-    ) -> vector_signed_short;
+    fn vmulesb(a: vector_signed_char, b: vector_signed_char) -> vector_signed_short;
     #[link_name = "llvm.ppc.altivec.vmuleuh"]
-    fn vmuleuh(
-        a: vector_unsigned_short, b: vector_unsigned_short,
-    ) -> vector_unsigned_int;
+    fn vmuleuh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_unsigned_int;
     #[link_name = "llvm.ppc.altivec.vmulesh"]
-    fn vmulesh(
-        a: vector_signed_short, b: vector_signed_short,
-    ) -> vector_signed_int;
+    fn vmulesh(a: vector_signed_short, b: vector_signed_short) -> vector_signed_int;
     #[link_name = "llvm.ppc.altivec.vmuloub"]
-    fn vmuloub(
-        a: vector_unsigned_char, b: vector_unsigned_char,
-    ) -> vector_unsigned_short;
+    fn vmuloub(a: vector_unsigned_char, b: vector_unsigned_char) -> vector_unsigned_short;
     #[link_name = "llvm.ppc.altivec.vmulosb"]
-    fn vmulosb(
-        a: vector_signed_char, b: vector_signed_char,
-    ) -> vector_signed_short;
+    fn vmulosb(a: vector_signed_char, b: vector_signed_char) -> vector_signed_short;
     #[link_name = "llvm.ppc.altivec.vmulouh"]
-    fn vmulouh(
-        a: vector_unsigned_short, b: vector_unsigned_short,
-    ) -> vector_unsigned_int;
+    fn vmulouh(a: vector_unsigned_short, b: vector_unsigned_short) -> vector_unsigned_int;
     #[link_name = "llvm.ppc.altivec.vmulosh"]
-    fn vmulosh(
-        a: vector_signed_short, b: vector_signed_short,
-    ) -> vector_signed_int;
+    fn vmulosh(a: vector_signed_short, b: vector_signed_short) -> vector_signed_int;
 }
 
 mod sealed {
@@ -156,32 +143,30 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmuleub))]
     unsafe fn vec_vmuleub(
-        a: vector_unsigned_char, b: vector_unsigned_char,
+        a: vector_unsigned_char,
+        b: vector_unsigned_char,
     ) -> vector_unsigned_short {
         vmuleub(a, b)
     }
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmulesb))]
-    unsafe fn vec_vmulesb(
-        a: vector_signed_char, b: vector_signed_char,
-    ) -> vector_signed_short {
+    unsafe fn vec_vmulesb(a: vector_signed_char, b: vector_signed_char) -> vector_signed_short {
         vmulesb(a, b)
     }
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmuleuh))]
     unsafe fn vec_vmuleuh(
-        a: vector_unsigned_short, b: vector_unsigned_short,
+        a: vector_unsigned_short,
+        b: vector_unsigned_short,
     ) -> vector_unsigned_int {
         vmuleuh(a, b)
     }
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmulesh))]
-    unsafe fn vec_vmulesh(
-        a: vector_signed_short, b: vector_signed_short,
-    ) -> vector_signed_int {
+    unsafe fn vec_vmulesh(a: vector_signed_short, b: vector_signed_short) -> vector_signed_int {
         vmulesh(a, b)
     }
 
@@ -222,32 +207,30 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmuloub))]
     unsafe fn vec_vmuloub(
-        a: vector_unsigned_char, b: vector_unsigned_char,
+        a: vector_unsigned_char,
+        b: vector_unsigned_char,
     ) -> vector_unsigned_short {
         vmuloub(a, b)
     }
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmulosb))]
-    unsafe fn vec_vmulosb(
-        a: vector_signed_char, b: vector_signed_char,
-    ) -> vector_signed_short {
+    unsafe fn vec_vmulosb(a: vector_signed_char, b: vector_signed_char) -> vector_signed_short {
         vmulosb(a, b)
     }
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmulouh))]
     unsafe fn vec_vmulouh(
-        a: vector_unsigned_short, b: vector_unsigned_short,
+        a: vector_unsigned_short,
+        b: vector_unsigned_short,
     ) -> vector_unsigned_int {
         vmulouh(a, b)
     }
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmulosh))]
-    unsafe fn vec_vmulosh(
-        a: vector_signed_short, b: vector_signed_short,
-    ) -> vector_signed_int {
+    unsafe fn vec_vmulosh(a: vector_signed_short, b: vector_signed_short) -> vector_signed_int {
         vmulosh(a, b)
     }
 
@@ -287,27 +270,21 @@ mod sealed {
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vsum4ubs))]
-    unsafe fn vec_vsum4ubs(
-        a: vector_unsigned_char, b: vector_unsigned_int,
-    ) -> vector_unsigned_int {
+    unsafe fn vec_vsum4ubs(a: vector_unsigned_char, b: vector_unsigned_int) -> vector_unsigned_int {
         vsum4ubs(a, b)
     }
 
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vsum4sbs))]
-    unsafe fn vec_vsum4sbs(
-        a: vector_signed_char, b: vector_signed_int,
-    ) -> vector_signed_int {
+    unsafe fn vec_vsum4sbs(a: vector_signed_char, b: vector_signed_int) -> vector_signed_int {
         vsum4sbs(a, b)
     }
 
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vsum4shs))]
-    unsafe fn vec_vsum4shs(
-        a: vector_signed_short, b: vector_signed_int,
-    ) -> vector_signed_int {
+    unsafe fn vec_vsum4shs(a: vector_signed_short, b: vector_signed_int) -> vector_signed_int {
         vsum4shs(a, b)
     }
 
@@ -318,9 +295,7 @@ mod sealed {
     impl VectorSum4s<vector_unsigned_int> for vector_unsigned_char {
         #[inline]
         #[target_feature(enable = "altivec")]
-        unsafe fn vec_sum4s(
-            self, b: vector_unsigned_int,
-        ) -> vector_unsigned_int {
+        unsafe fn vec_sum4s(self, b: vector_unsigned_int) -> vector_unsigned_int {
             vsum4ubs(self, b)
         }
     }
@@ -344,27 +319,21 @@ mod sealed {
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vsum2sws))]
-    unsafe fn vec_vsum2sws(
-        a: vector_signed_int, b: vector_signed_int,
-    ) -> vector_signed_int {
+    unsafe fn vec_vsum2sws(a: vector_signed_int, b: vector_signed_int) -> vector_signed_int {
         vsum2sws(a, b)
     }
 
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vnmsubfp))]
-    unsafe fn vec_vnmsubfp(
-        a: vector_float, b: vector_float, c: vector_float,
-    ) -> vector_float {
+    unsafe fn vec_vnmsubfp(a: vector_float, b: vector_float, c: vector_float) -> vector_float {
         vnmsubfp(a, b, c)
     }
 
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmaddfp))]
-    unsafe fn vec_vmaddfp(
-        a: vector_float, b: vector_float, c: vector_float,
-    ) -> vector_float {
+    unsafe fn vec_vmaddfp(a: vector_float, b: vector_float, c: vector_float) -> vector_float {
         vmaddfp(a, b, c)
     }
 
@@ -372,7 +341,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmsumubm))]
     unsafe fn vec_vmsumubm(
-        a: vector_unsigned_char, b: vector_unsigned_char,
+        a: vector_unsigned_char,
+        b: vector_unsigned_char,
         c: vector_unsigned_int,
     ) -> vector_unsigned_int {
         vmsumubm(a, b, c)
@@ -382,7 +352,9 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmsummbm))]
     unsafe fn vec_vmsummbm(
-        a: vector_signed_char, b: vector_unsigned_char, c: vector_signed_int,
+        a: vector_signed_char,
+        b: vector_unsigned_char,
+        c: vector_signed_int,
     ) -> vector_signed_int {
         vmsummbm(a, b, c)
     }
@@ -391,7 +363,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmsumuhm))]
     unsafe fn vec_vmsumuhm(
-        a: vector_unsigned_short, b: vector_unsigned_short,
+        a: vector_unsigned_short,
+        b: vector_unsigned_short,
         c: vector_unsigned_int,
     ) -> vector_unsigned_int {
         vmsumuhm(a, b, c)
@@ -401,7 +374,9 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmsumshm))]
     unsafe fn vec_vmsumshm(
-        a: vector_signed_short, b: vector_signed_short, c: vector_signed_int,
+        a: vector_signed_short,
+        b: vector_signed_short,
+        c: vector_signed_int,
     ) -> vector_signed_int {
         vmsumshm(a, b, c)
     }
@@ -410,49 +385,49 @@ mod sealed {
         unsafe fn vec_msum(self, b: B, c: Other) -> Other;
     }
 
-    impl VectorMsum<vector_unsigned_char, vector_unsigned_int>
-        for vector_unsigned_char
-    {
+    impl VectorMsum<vector_unsigned_char, vector_unsigned_int> for vector_unsigned_char {
         #[inline]
         #[target_feature(enable = "altivec")]
         unsafe fn vec_msum(
-            self, b: vector_unsigned_char, c: vector_unsigned_int,
+            self,
+            b: vector_unsigned_char,
+            c: vector_unsigned_int,
         ) -> vector_unsigned_int {
             vmsumubm(self, b, c)
         }
     }
 
-    impl VectorMsum<vector_unsigned_char, vector_signed_int>
-        for vector_signed_char
-    {
+    impl VectorMsum<vector_unsigned_char, vector_signed_int> for vector_signed_char {
         #[inline]
         #[target_feature(enable = "altivec")]
         unsafe fn vec_msum(
-            self, b: vector_unsigned_char, c: vector_signed_int,
+            self,
+            b: vector_unsigned_char,
+            c: vector_signed_int,
         ) -> vector_signed_int {
             vmsummbm(self, b, c)
         }
     }
 
-    impl VectorMsum<vector_unsigned_short, vector_unsigned_int>
-        for vector_unsigned_short
-    {
+    impl VectorMsum<vector_unsigned_short, vector_unsigned_int> for vector_unsigned_short {
         #[inline]
         #[target_feature(enable = "altivec")]
         unsafe fn vec_msum(
-            self, b: vector_unsigned_short, c: vector_unsigned_int,
+            self,
+            b: vector_unsigned_short,
+            c: vector_unsigned_int,
         ) -> vector_unsigned_int {
             vmsumuhm(self, b, c)
         }
     }
 
-    impl VectorMsum<vector_signed_short, vector_signed_int>
-        for vector_signed_short
-    {
+    impl VectorMsum<vector_signed_short, vector_signed_int> for vector_signed_short {
         #[inline]
         #[target_feature(enable = "altivec")]
         unsafe fn vec_msum(
-            self, b: vector_signed_short, c: vector_signed_int,
+            self,
+            b: vector_signed_short,
+            c: vector_signed_int,
         ) -> vector_signed_int {
             vmsumshm(self, b, c)
         }
@@ -462,7 +437,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmsumuhs))]
     unsafe fn vec_vmsumuhs(
-        a: vector_unsigned_short, b: vector_unsigned_short,
+        a: vector_unsigned_short,
+        b: vector_unsigned_short,
         c: vector_unsigned_int,
     ) -> vector_unsigned_int {
         vmsumuhs(a, b, c)
@@ -472,7 +448,9 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vmsumshs))]
     unsafe fn vec_vmsumshs(
-        a: vector_signed_short, b: vector_signed_short, c: vector_signed_int,
+        a: vector_signed_short,
+        b: vector_signed_short,
+        c: vector_signed_int,
     ) -> vector_signed_int {
         vmsumshs(a, b, c)
     }
@@ -484,9 +462,7 @@ mod sealed {
     impl VectorMsums<vector_unsigned_int> for vector_unsigned_short {
         #[inline]
         #[target_feature(enable = "altivec")]
-        unsafe fn vec_msums(
-            self, b: Self, c: vector_unsigned_int,
-        ) -> vector_unsigned_int {
+        unsafe fn vec_msums(self, b: Self, c: vector_unsigned_int) -> vector_unsigned_int {
             vmsumuhs(self, b, c)
         }
     }
@@ -494,9 +470,7 @@ mod sealed {
     impl VectorMsums<vector_signed_int> for vector_signed_short {
         #[inline]
         #[target_feature(enable = "altivec")]
-        unsafe fn vec_msums(
-            self, b: Self, c: vector_signed_int,
-        ) -> vector_signed_int {
+        unsafe fn vec_msums(self, b: Self, c: vector_signed_int) -> vector_signed_int {
             vmsumshs(self, b, c)
         }
     }
@@ -505,7 +479,9 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vperm))]
     unsafe fn vec_vperm(
-        a: vector_signed_int, b: vector_signed_int, c: vector_unsigned_char,
+        a: vector_signed_int,
+        b: vector_signed_int,
+        c: vector_unsigned_char,
     ) -> vector_signed_int {
         vperm(a, b, c)
     }
@@ -548,9 +524,7 @@ mod sealed {
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vaddubm))]
-    pub unsafe fn vec_add_bc_sc(
-        a: vector_bool_char, b: vector_signed_char,
-    ) -> vector_signed_char {
+    pub unsafe fn vec_add_bc_sc(a: vector_bool_char, b: vector_signed_char) -> vector_signed_char {
         simd_add(::mem::transmute(a), b)
     }
     impl VectorAdd<vector_signed_char> for vector_bool_char {
@@ -574,7 +548,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vaddubm))]
     pub unsafe fn vec_add_sc_sc(
-        a: vector_signed_char, b: vector_signed_char,
+        a: vector_signed_char,
+        b: vector_signed_char,
     ) -> vector_signed_char {
         simd_add(a, b)
     }
@@ -591,7 +566,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vaddubm))]
     pub unsafe fn vec_add_bc_uc(
-        a: vector_bool_char, b: vector_unsigned_char,
+        a: vector_bool_char,
+        b: vector_unsigned_char,
     ) -> vector_unsigned_char {
         simd_add(::mem::transmute(a), b)
     }
@@ -616,7 +592,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vaddubm))]
     pub unsafe fn vec_add_uc_uc(
-        a: vector_unsigned_char, b: vector_unsigned_char,
+        a: vector_unsigned_char,
+        b: vector_unsigned_char,
     ) -> vector_unsigned_char {
         simd_add(a, b)
     }
@@ -633,7 +610,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vadduhm))]
     pub unsafe fn vec_add_bs_ss(
-        a: vector_bool_short, b: vector_signed_short,
+        a: vector_bool_short,
+        b: vector_signed_short,
     ) -> vector_signed_short {
         let a: i16x8 = ::mem::transmute(a);
         let a: vector_signed_short = simd_cast(a);
@@ -661,7 +639,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vadduhm))]
     pub unsafe fn vec_add_ss_ss(
-        a: vector_signed_short, b: vector_signed_short,
+        a: vector_signed_short,
+        b: vector_signed_short,
     ) -> vector_signed_short {
         simd_add(a, b)
     }
@@ -678,7 +657,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vadduhm))]
     pub unsafe fn vec_add_bs_us(
-        a: vector_bool_short, b: vector_unsigned_short,
+        a: vector_bool_short,
+        b: vector_unsigned_short,
     ) -> vector_unsigned_short {
         let a: i16x8 = ::mem::transmute(a);
         let a: vector_unsigned_short = simd_cast(a);
@@ -705,7 +685,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vadduhm))]
     pub unsafe fn vec_add_us_us(
-        a: vector_unsigned_short, b: vector_unsigned_short,
+        a: vector_unsigned_short,
+        b: vector_unsigned_short,
     ) -> vector_unsigned_short {
         simd_add(a, b)
     }
@@ -722,9 +703,7 @@ mod sealed {
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vadduwm))]
-    pub unsafe fn vec_add_bi_si(
-        a: vector_bool_int, b: vector_signed_int,
-    ) -> vector_signed_int {
+    pub unsafe fn vec_add_bi_si(a: vector_bool_int, b: vector_signed_int) -> vector_signed_int {
         let a: i32x4 = ::mem::transmute(a);
         let a: vector_signed_int = simd_cast(a);
         simd_add(a, b)
@@ -749,9 +728,7 @@ mod sealed {
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vadduwm))]
-    pub unsafe fn vec_add_si_si(
-        a: vector_signed_int, b: vector_signed_int,
-    ) -> vector_signed_int {
+    pub unsafe fn vec_add_si_si(a: vector_signed_int, b: vector_signed_int) -> vector_signed_int {
         simd_add(a, b)
     }
     impl VectorAdd<vector_signed_int> for vector_signed_int {
@@ -766,9 +743,7 @@ mod sealed {
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vadduwm))]
-    pub unsafe fn vec_add_bi_ui(
-        a: vector_bool_int, b: vector_unsigned_int,
-    ) -> vector_unsigned_int {
+    pub unsafe fn vec_add_bi_ui(a: vector_bool_int, b: vector_unsigned_int) -> vector_unsigned_int {
         let a: i32x4 = ::mem::transmute(a);
         let a: vector_unsigned_int = simd_cast(a);
         simd_add(a, b)
@@ -794,7 +769,8 @@ mod sealed {
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(vadduwm))]
     pub unsafe fn vec_add_ui_ui(
-        a: vector_unsigned_int, b: vector_unsigned_int,
+        a: vector_unsigned_int,
+        b: vector_unsigned_int,
     ) -> vector_unsigned_int {
         simd_add(a, b)
     }
@@ -810,9 +786,7 @@ mod sealed {
     #[inline]
     #[target_feature(enable = "altivec")]
     #[cfg_attr(test, assert_instr(xvaddsp))]
-    pub unsafe fn vec_add_float_float(
-        a: vector_float, b: vector_float,
-    ) -> vector_float {
+    pub unsafe fn vec_add_float_float(a: vector_float, b: vector_float) -> vector_float {
         simd_add(a, b)
     }
 
@@ -885,8 +859,7 @@ mod endian {
         //
         // Xor the mask and flip the arguments
         let d = ::mem::transmute(u8x16::new(
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         ));
         let c = simd_xor(c, d);
 
@@ -896,9 +869,7 @@ mod endian {
     /// Vector Sum Across Partial (1/2) Saturated
     #[inline]
     #[target_feature(enable = "altivec")]
-    pub unsafe fn vec_sum2s(
-        a: vector_signed_int, b: vector_signed_int,
-    ) -> vector_signed_int {
+    pub unsafe fn vec_sum2s(a: vector_signed_int, b: vector_signed_int) -> vector_signed_int {
         // vsum2sws has big-endian bias
         //
         // swap the even b elements with the odd ones
@@ -937,7 +908,9 @@ mod endian {
 #[target_feature(enable = "altivec")]
 #[cfg_attr(test, assert_instr(vmhaddshs))]
 pub unsafe fn vec_madds(
-    a: vector_signed_short, b: vector_signed_short, c: vector_signed_short,
+    a: vector_signed_short,
+    b: vector_signed_short,
+    c: vector_signed_short,
 ) -> vector_signed_short {
     vmhaddshs(a, b, c)
 }
@@ -945,9 +918,7 @@ pub unsafe fn vec_madds(
 /// Vector Multiply Low and Add Unsigned Half Word
 #[inline]
 #[target_feature(enable = "altivec")]
-pub unsafe fn vec_mladd<T, U>(
-    a: T, b: U, c: U,
-) -> <T as sealed::VectorMladd<U>>::Result
+pub unsafe fn vec_mladd<T, U>(a: T, b: U, c: U) -> <T as sealed::VectorMladd<U>>::Result
 where
     T: sealed::VectorMladd<U>,
 {
@@ -959,7 +930,9 @@ where
 #[target_feature(enable = "altivec")]
 #[cfg_attr(test, assert_instr(vmhraddshs))]
 pub unsafe fn vec_mradds(
-    a: vector_signed_short, b: vector_signed_short, c: vector_signed_short,
+    a: vector_signed_short,
+    b: vector_signed_short,
+    c: vector_signed_short,
 ) -> vector_signed_short {
     vmhraddshs(a, b, c)
 }
@@ -987,18 +960,14 @@ where
 /// Vector Multiply Add
 #[inline]
 #[target_feature(enable = "altivec")]
-pub unsafe fn vec_madd(
-    a: vector_float, b: vector_float, c: vector_float,
-) -> vector_float {
+pub unsafe fn vec_madd(a: vector_float, b: vector_float, c: vector_float) -> vector_float {
     vmaddfp(a, b, c)
 }
 
 /// Vector Negative Multiply Subtract
 #[inline]
 #[target_feature(enable = "altivec")]
-pub unsafe fn vec_nmsub(
-    a: vector_float, b: vector_float, c: vector_float,
-) -> vector_float {
+pub unsafe fn vec_nmsub(a: vector_float, b: vector_float, c: vector_float) -> vector_float {
     vnmsubfp(a, b, c)
 }
 
@@ -1028,9 +997,7 @@ mod endian {
     /// Vector Sum Across Partial (1/2) Saturated
     #[inline]
     #[target_feature(enable = "altivec")]
-    pub unsafe fn vec_sum2s(
-        a: vector_signed_int, b: vector_signed_int,
-    ) -> vector_signed_int {
+    pub unsafe fn vec_sum2s(a: vector_signed_int, b: vector_signed_int) -> vector_signed_int {
         vsum2sws(a, b)
     }
 
@@ -1170,11 +1137,9 @@ mod tests {
             6 * 256,
             7 * 256,
         ));
-        let b: vector_signed_short = ::mem::transmute(i16x8::new(
-            256, 256, 256, 256, 256, 256, 256, 256,
-        ));
-        let c: vector_signed_short =
-            ::mem::transmute(i16x8::new(0, 1, 2, 3, 4, 5, 6, 7));
+        let b: vector_signed_short =
+            ::mem::transmute(i16x8::new(256, 256, 256, 256, 256, 256, 256, 256));
+        let c: vector_signed_short = ::mem::transmute(i16x8::new(0, 1, 2, 3, 4, 5, 6, 7));
 
         let d = i16x8::new(0, 3, 6, 9, 12, 15, 18, 21);
 
@@ -1222,19 +1187,10 @@ mod tests {
             6 * 256,
             7 * 256,
         ));
-        let b: vector_signed_short = ::mem::transmute(i16x8::new(
-            256, 256, 256, 256, 256, 256, 256, 256,
-        ));
-        let c: vector_signed_short = ::mem::transmute(i16x8::new(
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            i16::max_value() - 1,
-        ));
+        let b: vector_signed_short =
+            ::mem::transmute(i16x8::new(256, 256, 256, 256, 256, 256, 256, 256));
+        let c: vector_signed_short =
+            ::mem::transmute(i16x8::new(0, 1, 2, 3, 4, 5, 6, i16::max_value() - 1));
 
         let d = i16x8::new(0, 3, 6, 9, 12, 15, 18, i16::max_value());
 
@@ -1271,12 +1227,10 @@ mod tests {
 
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_msum_unsigned_char() {
-        let a: vector_unsigned_char = ::mem::transmute(u8x16::new(
-            0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
-        ));
+        let a: vector_unsigned_char =
+            ::mem::transmute(u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
         let b: vector_unsigned_char = ::mem::transmute(u8x16::new(
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         ));
         let c: vector_unsigned_int = ::mem::transmute(u32x4::new(0, 1, 2, 3));
         let d = u32x4::new(
@@ -1294,9 +1248,8 @@ mod tests {
         let a: vector_signed_char = ::mem::transmute(i8x16::new(
             0, -1, 2, -3, 1, -1, 1, -1, 0, 1, 2, 3, 4, -5, -6, -7,
         ));
-        let b: vector_unsigned_char = ::mem::transmute(i8x16::new(
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-        ));
+        let b: vector_unsigned_char =
+            ::mem::transmute(i8x16::new(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
         let c: vector_signed_int = ::mem::transmute(u32x4::new(0, 1, 2, 3));
         let d = i32x4::new(
             (0 - 1 + 2 - 3) + 0,
@@ -1319,9 +1272,8 @@ mod tests {
             6 * 256,
             7 * 256,
         ));
-        let b: vector_unsigned_short = ::mem::transmute(u16x8::new(
-            256, 256, 256, 256, 256, 256, 256, 256,
-        ));
+        let b: vector_unsigned_short =
+            ::mem::transmute(u16x8::new(256, 256, 256, 256, 256, 256, 256, 256));
         let c: vector_unsigned_int = ::mem::transmute(u32x4::new(0, 1, 2, 3));
         let d = u32x4::new(
             (0 + 1) * 256 * 256 + 0,
@@ -1345,9 +1297,8 @@ mod tests {
             6 * 256,
             -7 * 256,
         ));
-        let b: vector_signed_short = ::mem::transmute(i16x8::new(
-            256, 256, 256, 256, 256, 256, 256, 256,
-        ));
+        let b: vector_signed_short =
+            ::mem::transmute(i16x8::new(256, 256, 256, 256, 256, 256, 256, 256));
         let c: vector_signed_int = ::mem::transmute(i32x4::new(0, 1, 2, 3));
         let d = i32x4::new(
             (0 - 1) * 256 * 256 + 0,
@@ -1371,9 +1322,8 @@ mod tests {
             6 * 256,
             7 * 256,
         ));
-        let b: vector_unsigned_short = ::mem::transmute(u16x8::new(
-            256, 256, 256, 256, 256, 256, 256, 256,
-        ));
+        let b: vector_unsigned_short =
+            ::mem::transmute(u16x8::new(256, 256, 256, 256, 256, 256, 256, 256));
         let c: vector_unsigned_int = ::mem::transmute(u32x4::new(0, 1, 2, 3));
         let d = u32x4::new(
             (0 + 1) * 256 * 256 + 0,
@@ -1397,9 +1347,8 @@ mod tests {
             6 * 256,
             -7 * 256,
         ));
-        let b: vector_signed_short = ::mem::transmute(i16x8::new(
-            256, 256, 256, 256, 256, 256, 256, 256,
-        ));
+        let b: vector_signed_short =
+            ::mem::transmute(i16x8::new(256, 256, 256, 256, 256, 256, 256, 256));
         let c: vector_signed_int = ::mem::transmute(i32x4::new(0, 1, 2, 3));
         let d = i32x4::new(
             (0 - 1) * 256 * 256 + 0,
@@ -1422,9 +1371,8 @@ mod tests {
 
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_sum4s_unsigned_char() {
-        let a: vector_unsigned_char = ::mem::transmute(u8x16::new(
-            0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
-        ));
+        let a: vector_unsigned_char =
+            ::mem::transmute(u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
         let b: vector_unsigned_int = ::mem::transmute(u32x4::new(0, 1, 2, 3));
         let d = u32x4::new(
             0 + 1 + 2 + 3 + 0,
@@ -1437,9 +1385,8 @@ mod tests {
     }
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_sum4s_signed_char() {
-        let a: vector_signed_char = ::mem::transmute(i8x16::new(
-            0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
-        ));
+        let a: vector_signed_char =
+            ::mem::transmute(i8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
         let b: vector_signed_int = ::mem::transmute(i32x4::new(0, 1, 2, 3));
         let d = i32x4::new(
             0 + 1 + 2 + 3 + 0,
@@ -1452,8 +1399,7 @@ mod tests {
     }
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_sum4s_signed_short() {
-        let a: vector_signed_short =
-            ::mem::transmute(i16x8::new(0, 1, 2, 3, 4, 5, 6, 7));
+        let a: vector_signed_short = ::mem::transmute(i16x8::new(0, 1, 2, 3, 4, 5, 6, 7));
         let b: vector_signed_int = ::mem::transmute(i32x4::new(0, 1, 2, 3));
         let d = i32x4::new(0 + 1 + 0, 2 + 3 + 1, 4 + 5 + 2, 6 + 7 + 3);
 
@@ -1462,11 +1408,9 @@ mod tests {
 
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_mule_unsigned_char() {
-        let a: vector_unsigned_char = ::mem::transmute(u8x16::new(
-            0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
-        ));
-        let d =
-            u16x8::new(0 * 0, 2 * 2, 4 * 4, 6 * 6, 0 * 0, 2 * 2, 4 * 4, 6 * 6);
+        let a: vector_unsigned_char =
+            ::mem::transmute(u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
+        let d = u16x8::new(0 * 0, 2 * 2, 4 * 4, 6 * 6, 0 * 0, 2 * 2, 4 * 4, 6 * 6);
 
         assert_eq!(d, ::mem::transmute(vec_mule(a, a)));
     }
@@ -1476,16 +1420,14 @@ mod tests {
         let a: vector_signed_char = ::mem::transmute(i8x16::new(
             0, 1, -2, 3, -4, 5, -6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
         ));
-        let d =
-            i16x8::new(0 * 0, 2 * 2, 4 * 4, 6 * 6, 0 * 0, 2 * 2, 4 * 4, 6 * 6);
+        let d = i16x8::new(0 * 0, 2 * 2, 4 * 4, 6 * 6, 0 * 0, 2 * 2, 4 * 4, 6 * 6);
 
         assert_eq!(d, ::mem::transmute(vec_mule(a, a)));
     }
 
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_mule_unsigned_short() {
-        let a: vector_unsigned_short =
-            ::mem::transmute(u16x8::new(0, 1, 2, 3, 4, 5, 6, 7));
+        let a: vector_unsigned_short = ::mem::transmute(u16x8::new(0, 1, 2, 3, 4, 5, 6, 7));
         let d = u32x4::new(0 * 0, 2 * 2, 4 * 4, 6 * 6);
 
         assert_eq!(d, ::mem::transmute(vec_mule(a, a)));
@@ -1493,8 +1435,7 @@ mod tests {
 
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_mule_signed_short() {
-        let a: vector_signed_short =
-            ::mem::transmute(i16x8::new(0, 1, -2, 3, -4, 5, -6, 7));
+        let a: vector_signed_short = ::mem::transmute(i16x8::new(0, 1, -2, 3, -4, 5, -6, 7));
         let d = i32x4::new(0 * 0, 2 * 2, 4 * 4, 6 * 6);
 
         assert_eq!(d, ::mem::transmute(vec_mule(a, a)));
@@ -1502,11 +1443,9 @@ mod tests {
 
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_mulo_unsigned_char() {
-        let a: vector_unsigned_char = ::mem::transmute(u8x16::new(
-            0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
-        ));
-        let d =
-            u16x8::new(1 * 1, 3 * 3, 5 * 5, 7 * 7, 1 * 1, 3 * 3, 5 * 5, 7 * 7);
+        let a: vector_unsigned_char =
+            ::mem::transmute(u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7));
+        let d = u16x8::new(1 * 1, 3 * 3, 5 * 5, 7 * 7, 1 * 1, 3 * 3, 5 * 5, 7 * 7);
 
         assert_eq!(d, ::mem::transmute(vec_mulo(a, a)));
     }
@@ -1516,16 +1455,14 @@ mod tests {
         let a: vector_signed_char = ::mem::transmute(i8x16::new(
             0, 1, -2, 3, -4, 5, -6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
         ));
-        let d =
-            i16x8::new(1 * 1, 3 * 3, 5 * 5, 7 * 7, 1 * 1, 3 * 3, 5 * 5, 7 * 7);
+        let d = i16x8::new(1 * 1, 3 * 3, 5 * 5, 7 * 7, 1 * 1, 3 * 3, 5 * 5, 7 * 7);
 
         assert_eq!(d, ::mem::transmute(vec_mulo(a, a)));
     }
 
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_mulo_unsigned_short() {
-        let a: vector_unsigned_short =
-            ::mem::transmute(u16x8::new(0, 1, 2, 3, 4, 5, 6, 7));
+        let a: vector_unsigned_short = ::mem::transmute(u16x8::new(0, 1, 2, 3, 4, 5, 6, 7));
         let d = u32x4::new(1 * 1, 3 * 3, 5 * 5, 7 * 7);
 
         assert_eq!(d, ::mem::transmute(vec_mulo(a, a)));
@@ -1533,8 +1470,7 @@ mod tests {
 
     #[simd_test(enable = "altivec")]
     unsafe fn test_vec_mulo_signed_short() {
-        let a: vector_signed_short =
-            ::mem::transmute(i16x8::new(0, 1, -2, 3, -4, 5, -6, 7));
+        let a: vector_signed_short = ::mem::transmute(i16x8::new(0, 1, -2, 3, -4, 5, -6, 7));
         let d = i32x4::new(1 * 1, 3 * 3, 5 * 5, 7 * 7);
 
         assert_eq!(d, ::mem::transmute(vec_mulo(a, a)));

--- a/coresimd/powerpc/vsx.rs
+++ b/coresimd/powerpc/vsx.rs
@@ -43,14 +43,8 @@ mod sealed {
     // xxpermdi has an big-endian bias and extended mnemonics
     #[inline]
     #[target_feature(enable = "vsx")]
-    #[cfg_attr(
-        all(test, target_endian = "little"),
-        assert_instr(xxmrgld, dm = 0x0)
-    )]
-    #[cfg_attr(
-        all(test, target_endian = "big"),
-        assert_instr(xxspltd, dm = 0x0)
-    )]
+    #[cfg_attr(all(test, target_endian = "little"), assert_instr(xxmrgld, dm = 0x0))]
+    #[cfg_attr(all(test, target_endian = "big"), assert_instr(xxspltd, dm = 0x0))]
     unsafe fn xxpermdi(a: i64x2, b: i64x2, dm: u8) -> i64x2 {
         match dm & 0b11 {
             0 => simd_shuffle2(a, b, [0b00, 0b10]),

--- a/coresimd/wasm32/atomic.rs
+++ b/coresimd/wasm32/atomic.rs
@@ -53,9 +53,7 @@ extern "C" {
 /// [instr]: https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#wait
 #[inline]
 #[cfg_attr(test, assert_instr("i32.atomic.wait"))]
-pub unsafe fn i32_atomic_wait(
-    ptr: *mut i32, expression: i32, timeout_ns: i64,
-) -> i32 {
+pub unsafe fn i32_atomic_wait(ptr: *mut i32, expression: i32, timeout_ns: i64) -> i32 {
     llvm_atomic_wait_i32(ptr, expression, timeout_ns)
 }
 
@@ -90,9 +88,7 @@ pub unsafe fn i32_atomic_wait(
 /// [instr]: https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#wait
 #[inline]
 #[cfg_attr(test, assert_instr("i64.atomic.wait"))]
-pub unsafe fn i64_atomic_wait(
-    ptr: *mut i64, expression: i64, timeout_ns: i64,
-) -> i32 {
+pub unsafe fn i64_atomic_wait(ptr: *mut i64, expression: i64, timeout_ns: i64) -> i32 {
     llvm_atomic_wait_i64(ptr, expression, timeout_ns)
 }
 

--- a/coresimd/wasm32/simd128.rs
+++ b/coresimd/wasm32/simd128.rs
@@ -150,10 +150,7 @@ macro_rules! impl_extract_lane {
                 a: v128,
             }
             // the vectors store a signed integer => extract into it
-            let v: $selem_ty = simd_extract(
-                U { a }.vec,
-                imm as u32, /* zero-extends index */
-            );
+            let v: $selem_ty = simd_extract(U { a }.vec, imm as u32 /* zero-extends index */);
             v as $x_ty
         }
 
@@ -173,10 +170,7 @@ macro_rules! impl_extract_lane {
                 a: v128,
             }
             // the vectors store a signed integer => extract into it
-            let v: $selem_ty = simd_extract(
-                U { a }.vec,
-                imm as u32, /* zero-extends index */
-            );
+            let v: $selem_ty = simd_extract(U { a }.vec, imm as u32 /* zero-extends index */);
             // re-interpret the signed integer as an unsigned one of the
             // same size (no-op)
             let v: $uelem_ty = ::mem::transmute(v);
@@ -845,11 +839,8 @@ pub mod tests {
 
     #[wasm_bindgen_test]
     fn v128_const() {
-        const A: v128 = unsafe {
-            v128::const_([
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-            ])
-        };
+        const A: v128 =
+            unsafe { v128::const_([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]) };
         compare_bytes(A, A);
     }
 
@@ -942,8 +933,7 @@ pub mod tests {
         unsafe {
             let a = [0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
             let b = [
-                16_u8, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-                31,
+                16_u8, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
             ];
 
             let vec_a: v128 = mem::transmute(a);
@@ -955,8 +945,7 @@ pub mod tests {
                 [0, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30]
             );
 
-            let e =
-                [0_u8, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30];
+            let e = [0_u8, 16, 2, 18, 4, 20, 6, 22, 8, 24, 10, 26, 12, 28, 14, 30];
             let vec_e: v128 = mem::transmute(e);
             compare_bytes(vec_r, vec_e);
         }
@@ -1225,14 +1214,9 @@ pub mod tests {
             | [1_i16, 0, 1, 0, 1, 0, 1, 0]
     );
     test_bool_red!(
-        i32x4[i32x4_boolean_reductions]
-            | [1_i32, 1, 1, 1]
-            | [0_i32, 0, 0, 0]
-            | [1_i32, 0, 1, 0]
+        i32x4[i32x4_boolean_reductions] | [1_i32, 1, 1, 1] | [0_i32, 0, 0, 0] | [1_i32, 0, 1, 0]
     );
-    test_bool_red!(
-        i64x2[i64x2_boolean_reductions] | [1_i64, 1] | [0_i64, 0] | [1_i64, 0]
-    );
+    test_bool_red!(i64x2[i64x2_boolean_reductions] | [1_i64, 1] | [0_i64, 0] | [1_i64, 0]);
 
     test_bop!(i8x16[i8; 16] | eq[i8x16_eq_test]:
               ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
@@ -1395,10 +1379,7 @@ pub mod tests {
         [1_f32, 2., 3., 4.]
     );
     test_conv!(
-        f32x4_convert_u_i32x4
-            | convert_u_i32x4
-            | f32x4
-            | [u32::max_value(), 2, 3, 4],
+        f32x4_convert_u_i32x4 | convert_u_i32x4 | f32x4 | [u32::max_value(), 2, 3, 4],
         [u32::max_value() as f32, 2., 3., 4.]
     );
     test_conv!(
@@ -1406,10 +1387,7 @@ pub mod tests {
         [1_f64, 2.]
     );
     test_conv!(
-        f64x2_convert_u_i64x2
-            | convert_u_i64x2
-            | f64x2
-            | [u64::max_value(), 2],
+        f64x2_convert_u_i64x2 | convert_u_i64x2 | f64x2 | [u64::max_value(), 2],
         [18446744073709552000.0, 2.]
     );
 

--- a/coresimd/x86/avx.rs
+++ b/coresimd/x86/avx.rs
@@ -1398,9 +1398,7 @@ pub unsafe fn _mm_permute_pd(a: __m128d, imm8: i32) -> __m128d {
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x5))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_permute2f128_ps(
-    a: __m256, b: __m256, imm8: i32,
-) -> __m256 {
+pub unsafe fn _mm256_permute2f128_ps(a: __m256, b: __m256, imm8: i32) -> __m256 {
     macro_rules! call {
         ($imm8:expr) => {
             vperm2f128ps256(a, b, $imm8)
@@ -1418,9 +1416,7 @@ pub unsafe fn _mm256_permute2f128_ps(
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x31))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_permute2f128_pd(
-    a: __m256d, b: __m256d, imm8: i32,
-) -> __m256d {
+pub unsafe fn _mm256_permute2f128_pd(a: __m256d, b: __m256d, imm8: i32) -> __m256d {
     macro_rules! call {
         ($imm8:expr) => {
             vperm2f128pd256(a, b, $imm8)
@@ -1438,9 +1434,7 @@ pub unsafe fn _mm256_permute2f128_pd(
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 0x31))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_permute2f128_si256(
-    a: __m256i, b: __m256i, imm8: i32,
-) -> __m256i {
+pub unsafe fn _mm256_permute2f128_si256(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i32x8();
     let b = b.as_i32x8();
     macro_rules! call {
@@ -1460,10 +1454,7 @@ pub unsafe fn _mm256_permute2f128_si256(
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-#[cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::trivially_copy_pass_by_ref)
-)]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::trivially_copy_pass_by_ref))]
 pub unsafe fn _mm256_broadcast_ss(f: &f32) -> __m256 {
     _mm256_set1_ps(*f)
 }
@@ -1476,10 +1467,7 @@ pub unsafe fn _mm256_broadcast_ss(f: &f32) -> __m256 {
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vbroadcastss))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-#[cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::trivially_copy_pass_by_ref)
-)]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::trivially_copy_pass_by_ref))]
 pub unsafe fn _mm_broadcast_ss(f: &f32) -> __m128 {
     _mm_set1_ps(*f)
 }
@@ -1492,10 +1480,7 @@ pub unsafe fn _mm_broadcast_ss(f: &f32) -> __m128 {
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vbroadcastsd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-#[cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::trivially_copy_pass_by_ref)
-)]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::trivially_copy_pass_by_ref))]
 pub unsafe fn _mm256_broadcast_sd(f: &f64) -> __m256d {
     _mm256_set1_pd(*f)
 }
@@ -1558,9 +1543,7 @@ pub unsafe fn _mm256_insertf128_ps(a: __m256, b: __m128, imm8: i32) -> __m256 {
 )]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_insertf128_pd(
-    a: __m256d, b: __m128d, imm8: i32,
-) -> __m256d {
+pub unsafe fn _mm256_insertf128_pd(a: __m256d, b: __m128d, imm8: i32) -> __m256d {
     match imm8 & 1 {
         0 => simd_shuffle4(a, _mm256_castpd128_pd256(b), [4, 5, 2, 3]),
         _ => simd_shuffle4(a, _mm256_castpd128_pd256(b), [0, 1, 4, 5]),
@@ -1579,9 +1562,7 @@ pub unsafe fn _mm256_insertf128_pd(
 )]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_insertf128_si256(
-    a: __m256i, b: __m128i, imm8: i32,
-) -> __m256i {
+pub unsafe fn _mm256_insertf128_si256(a: __m256i, b: __m128i, imm8: i32) -> __m256i {
     let b = _mm256_castsi128_si256(b).as_i64x4();
     let dst: i64x4 = match imm8 & 1 {
         0 => simd_shuffle4(a.as_i64x4(), b, [4, 5, 2, 3]),
@@ -1818,9 +1799,7 @@ pub unsafe fn _mm256_storeu_si256(mem_addr: *mut __m256i, a: __m256i) {
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_maskload_pd(
-    mem_addr: *const f64, mask: __m256i,
-) -> __m256d {
+pub unsafe fn _mm256_maskload_pd(mem_addr: *const f64, mask: __m256i) -> __m256d {
     maskloadpd256(mem_addr as *const i8, mask.as_i64x4())
 }
 
@@ -1832,9 +1811,7 @@ pub unsafe fn _mm256_maskload_pd(
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_maskstore_pd(
-    mem_addr: *mut f64, mask: __m256i, a: __m256d,
-) {
+pub unsafe fn _mm256_maskstore_pd(mem_addr: *mut f64, mask: __m256i, a: __m256d) {
     maskstorepd256(mem_addr as *mut i8, mask.as_i64x4(), a);
 }
 
@@ -1872,9 +1849,7 @@ pub unsafe fn _mm_maskstore_pd(mem_addr: *mut f64, mask: __m128i, a: __m128d) {
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_maskload_ps(
-    mem_addr: *const f32, mask: __m256i,
-) -> __m256 {
+pub unsafe fn _mm256_maskload_ps(mem_addr: *const f32, mask: __m256i) -> __m256 {
     maskloadps256(mem_addr as *const i8, mask.as_i32x8())
 }
 
@@ -1886,9 +1861,7 @@ pub unsafe fn _mm256_maskload_ps(
 #[target_feature(enable = "avx")]
 #[cfg_attr(test, assert_instr(vmaskmovps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_maskstore_ps(
-    mem_addr: *mut f32, mask: __m256i, a: __m256,
-) {
+pub unsafe fn _mm256_maskstore_ps(mem_addr: *mut f32, mask: __m256i, a: __m256) {
     maskstoreps256(mem_addr as *mut i8, mask.as_i32x8(), a);
 }
 
@@ -2414,7 +2387,14 @@ pub unsafe fn _mm256_set_pd(a: f64, b: f64, c: f64, d: f64) -> __m256d {
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_set_ps(
-    a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32, h: f32,
+    a: f32,
+    b: f32,
+    c: f32,
+    d: f32,
+    e: f32,
+    f: f32,
+    g: f32,
+    h: f32,
 ) -> __m256 {
     _mm256_setr_ps(h, g, f, e, d, c, b, a)
 }
@@ -2428,10 +2408,38 @@ pub unsafe fn _mm256_set_ps(
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_set_epi8(
-    e00: i8, e01: i8, e02: i8, e03: i8, e04: i8, e05: i8, e06: i8, e07: i8,
-    e08: i8, e09: i8, e10: i8, e11: i8, e12: i8, e13: i8, e14: i8, e15: i8,
-    e16: i8, e17: i8, e18: i8, e19: i8, e20: i8, e21: i8, e22: i8, e23: i8,
-    e24: i8, e25: i8, e26: i8, e27: i8, e28: i8, e29: i8, e30: i8, e31: i8,
+    e00: i8,
+    e01: i8,
+    e02: i8,
+    e03: i8,
+    e04: i8,
+    e05: i8,
+    e06: i8,
+    e07: i8,
+    e08: i8,
+    e09: i8,
+    e10: i8,
+    e11: i8,
+    e12: i8,
+    e13: i8,
+    e14: i8,
+    e15: i8,
+    e16: i8,
+    e17: i8,
+    e18: i8,
+    e19: i8,
+    e20: i8,
+    e21: i8,
+    e22: i8,
+    e23: i8,
+    e24: i8,
+    e25: i8,
+    e26: i8,
+    e27: i8,
+    e28: i8,
+    e29: i8,
+    e30: i8,
+    e31: i8,
 ) -> __m256i {
     #[rustfmt::skip]
     _mm256_setr_epi8(
@@ -2450,9 +2458,22 @@ pub unsafe fn _mm256_set_epi8(
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_set_epi16(
-    e00: i16, e01: i16, e02: i16, e03: i16, e04: i16, e05: i16, e06: i16,
-    e07: i16, e08: i16, e09: i16, e10: i16, e11: i16, e12: i16, e13: i16,
-    e14: i16, e15: i16,
+    e00: i16,
+    e01: i16,
+    e02: i16,
+    e03: i16,
+    e04: i16,
+    e05: i16,
+    e06: i16,
+    e07: i16,
+    e08: i16,
+    e09: i16,
+    e10: i16,
+    e11: i16,
+    e12: i16,
+    e13: i16,
+    e14: i16,
+    e15: i16,
 ) -> __m256i {
     #[rustfmt::skip]
     _mm256_setr_epi16(
@@ -2471,7 +2492,14 @@ pub unsafe fn _mm256_set_epi16(
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_set_epi32(
-    e0: i32, e1: i32, e2: i32, e3: i32, e4: i32, e5: i32, e6: i32, e7: i32,
+    e0: i32,
+    e1: i32,
+    e2: i32,
+    e3: i32,
+    e4: i32,
+    e5: i32,
+    e6: i32,
+    e7: i32,
 ) -> __m256i {
     _mm256_setr_epi32(e7, e6, e5, e4, e3, e2, e1, e0)
 }
@@ -2508,7 +2536,14 @@ pub unsafe fn _mm256_setr_pd(a: f64, b: f64, c: f64, d: f64) -> __m256d {
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_setr_ps(
-    a: f32, b: f32, c: f32, d: f32, e: f32, f: f32, g: f32, h: f32,
+    a: f32,
+    b: f32,
+    c: f32,
+    d: f32,
+    e: f32,
+    f: f32,
+    g: f32,
+    h: f32,
 ) -> __m256 {
     __m256(a, b, c, d, e, f, g, h)
 }
@@ -2522,10 +2557,38 @@ pub unsafe fn _mm256_setr_ps(
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_setr_epi8(
-    e00: i8, e01: i8, e02: i8, e03: i8, e04: i8, e05: i8, e06: i8, e07: i8,
-    e08: i8, e09: i8, e10: i8, e11: i8, e12: i8, e13: i8, e14: i8, e15: i8,
-    e16: i8, e17: i8, e18: i8, e19: i8, e20: i8, e21: i8, e22: i8, e23: i8,
-    e24: i8, e25: i8, e26: i8, e27: i8, e28: i8, e29: i8, e30: i8, e31: i8,
+    e00: i8,
+    e01: i8,
+    e02: i8,
+    e03: i8,
+    e04: i8,
+    e05: i8,
+    e06: i8,
+    e07: i8,
+    e08: i8,
+    e09: i8,
+    e10: i8,
+    e11: i8,
+    e12: i8,
+    e13: i8,
+    e14: i8,
+    e15: i8,
+    e16: i8,
+    e17: i8,
+    e18: i8,
+    e19: i8,
+    e20: i8,
+    e21: i8,
+    e22: i8,
+    e23: i8,
+    e24: i8,
+    e25: i8,
+    e26: i8,
+    e27: i8,
+    e28: i8,
+    e29: i8,
+    e30: i8,
+    e31: i8,
 ) -> __m256i {
     #[rustfmt::skip]
     mem::transmute(i8x32::new(
@@ -2545,9 +2608,22 @@ pub unsafe fn _mm256_setr_epi8(
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_setr_epi16(
-    e00: i16, e01: i16, e02: i16, e03: i16, e04: i16, e05: i16, e06: i16,
-    e07: i16, e08: i16, e09: i16, e10: i16, e11: i16, e12: i16, e13: i16,
-    e14: i16, e15: i16,
+    e00: i16,
+    e01: i16,
+    e02: i16,
+    e03: i16,
+    e04: i16,
+    e05: i16,
+    e06: i16,
+    e07: i16,
+    e08: i16,
+    e09: i16,
+    e10: i16,
+    e11: i16,
+    e12: i16,
+    e13: i16,
+    e14: i16,
+    e15: i16,
 ) -> __m256i {
     #[rustfmt::skip]
     mem::transmute(i16x16::new(
@@ -2567,7 +2643,14 @@ pub unsafe fn _mm256_setr_epi16(
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_setr_epi32(
-    e0: i32, e1: i32, e2: i32, e3: i32, e4: i32, e5: i32, e6: i32, e7: i32,
+    e0: i32,
+    e1: i32,
+    e2: i32,
+    e3: i32,
+    e4: i32,
+    e5: i32,
+    e6: i32,
+    e7: i32,
 ) -> __m256i {
     mem::transmute(i32x8::new(e0, e1, e2, e3, e4, e5, e6, e7))
 }
@@ -2983,9 +3066,7 @@ pub unsafe fn _mm256_setr_m128i(lo: __m128i, hi: __m128i) -> __m256i {
 #[target_feature(enable = "avx,sse")]
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_loadu2_m128(
-    hiaddr: *const f32, loaddr: *const f32,
-) -> __m256 {
+pub unsafe fn _mm256_loadu2_m128(hiaddr: *const f32, loaddr: *const f32) -> __m256 {
     let a = _mm256_castps128_ps256(_mm_loadu_ps(loaddr));
     _mm256_insertf128_ps(a, _mm_loadu_ps(hiaddr), 1)
 }
@@ -3000,9 +3081,7 @@ pub unsafe fn _mm256_loadu2_m128(
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_loadu2_m128d(
-    hiaddr: *const f64, loaddr: *const f64,
-) -> __m256d {
+pub unsafe fn _mm256_loadu2_m128d(hiaddr: *const f64, loaddr: *const f64) -> __m256d {
     let a = _mm256_castpd128_pd256(_mm_loadu_pd(loaddr));
     _mm256_insertf128_pd(a, _mm_loadu_pd(hiaddr), 1)
 }
@@ -3016,9 +3095,7 @@ pub unsafe fn _mm256_loadu2_m128d(
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_loadu2_m128i(
-    hiaddr: *const __m128i, loaddr: *const __m128i,
-) -> __m256i {
+pub unsafe fn _mm256_loadu2_m128i(hiaddr: *const __m128i, loaddr: *const __m128i) -> __m256i {
     let a = _mm256_castsi128_si256(_mm_loadu_si128(loaddr));
     _mm256_insertf128_si256(a, _mm_loadu_si128(hiaddr), 1)
 }
@@ -3033,9 +3110,7 @@ pub unsafe fn _mm256_loadu2_m128i(
 #[target_feature(enable = "avx,sse")]
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_storeu2_m128(
-    hiaddr: *mut f32, loaddr: *mut f32, a: __m256,
-) {
+pub unsafe fn _mm256_storeu2_m128(hiaddr: *mut f32, loaddr: *mut f32, a: __m256) {
     let lo = _mm256_castps256_ps128(a);
     _mm_storeu_ps(loaddr, lo);
     let hi = _mm256_extractf128_ps(a, 1);
@@ -3052,9 +3127,7 @@ pub unsafe fn _mm256_storeu2_m128(
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_storeu2_m128d(
-    hiaddr: *mut f64, loaddr: *mut f64, a: __m256d,
-) {
+pub unsafe fn _mm256_storeu2_m128d(hiaddr: *mut f64, loaddr: *mut f64, a: __m256d) {
     let lo = _mm256_castpd256_pd128(a);
     _mm_storeu_pd(loaddr, lo);
     let hi = _mm256_extractf128_pd(a, 1);
@@ -3070,9 +3143,7 @@ pub unsafe fn _mm256_storeu2_m128d(
 #[target_feature(enable = "avx,sse2")]
 // This intrinsic has no corresponding instruction.
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_storeu2_m128i(
-    hiaddr: *mut __m128i, loaddr: *mut __m128i, a: __m256i,
-) {
+pub unsafe fn _mm256_storeu2_m128i(hiaddr: *mut __m128i, loaddr: *mut __m128i, a: __m256i) {
     let lo = _mm256_castsi256_si128(a);
     _mm_storeu_si128(loaddr, lo);
     let hi = _mm256_extractf128_si256(a, 1);
@@ -3458,8 +3529,7 @@ mod tests {
         let result_closest = _mm256_round_ps(a, 0b00000000);
         let result_down = _mm256_round_ps(a, 0b00000001);
         let result_up = _mm256_round_ps(a, 0b00000010);
-        let expected_closest =
-            _mm256_setr_ps(2., 2., 4., -1., 2., 2., 4., -1.);
+        let expected_closest = _mm256_setr_ps(2., 2., 4., -1., 2., 2., 4., -1.);
         let expected_down = _mm256_setr_ps(1., 2., 3., -2., 1., 2., 3., -2.);
         let expected_up = _mm256_setr_ps(2., 3., 4., -1., 2., 3., 4., -1.);
         assert_eq_m256(result_closest, expected_closest);
@@ -3569,8 +3639,7 @@ mod tests {
         let a = _mm256_setr_ps(4., 9., 16., 25., 4., 9., 16., 25.);
         let b = _mm256_setr_ps(4., 3., 2., 5., 8., 9., 64., 50.);
         let r = _mm256_dp_ps(a, b, 0xFF);
-        let e =
-            _mm256_setr_ps(200., 200., 200., 200., 2387., 2387., 2387., 2387.);
+        let e = _mm256_setr_ps(200., 200., 200., 200., 2387., 2387., 2387., 2387.);
         assert_eq_m256(r, e);
     }
 
@@ -4916,10 +4985,7 @@ mod tests {
             1, 2, 3, 4, 5, 6, 7, 8,
             9, 10, 11, 12, 13, 14, 15, 16,
         );
-        let r = _mm256_loadu2_m128i(
-            &hi as *const _ as *const _,
-            &lo as *const _ as *const _,
-        );
+        let r = _mm256_loadu2_m128i(&hi as *const _ as *const _, &lo as *const _ as *const _);
         #[rustfmt::skip]
         let e = _mm256_setr_epi8(
             1, 2, 3, 4, 5, 6, 7, 8,

--- a/coresimd/x86/avx2.rs
+++ b/coresimd/x86/avx2.rs
@@ -179,138 +179,128 @@ pub unsafe fn _mm256_alignr_epi8(a: __m256i, b: __m256i, n: i32) -> __m256i {
             b,
             a,
             [
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31,
             ],
         ),
         1 => simd_shuffle32(
             b,
             a,
             [
-                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 17, 18,
-                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 48,
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 48,
             ],
         ),
         2 => simd_shuffle32(
             b,
             a,
             [
-                2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 18,
-                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 48, 49,
+                2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 18, 19, 20, 21, 22, 23, 24,
+                25, 26, 27, 28, 29, 30, 31, 48, 49,
             ],
         ),
         3 => simd_shuffle32(
             b,
             a,
             [
-                3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 19,
-                20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 48, 49, 50,
+                3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 19, 20, 21, 22, 23, 24,
+                25, 26, 27, 28, 29, 30, 31, 48, 49, 50,
             ],
         ),
         4 => simd_shuffle32(
             b,
             a,
             [
-                4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 20,
-                21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 48, 49, 50, 51,
+                4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 20, 21, 22, 23, 24, 25,
+                26, 27, 28, 29, 30, 31, 48, 49, 50, 51,
             ],
         ),
         5 => simd_shuffle32(
             b,
             a,
             [
-                5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 21,
-                22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 48, 49, 50, 51, 52,
+                5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 21, 22, 23, 24, 25, 26,
+                27, 28, 29, 30, 31, 48, 49, 50, 51, 52,
             ],
         ),
         6 => simd_shuffle32(
             b,
             a,
             [
-                6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37,
-                22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 48, 49, 50, 51, 52,
-                53,
+                6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 22, 23, 24, 25, 26, 27,
+                28, 29, 30, 31, 48, 49, 50, 51, 52, 53,
             ],
         ),
         7 => simd_shuffle32(
             b,
             a,
             [
-                7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38,
-                23, 24, 25, 26, 27, 28, 29, 30, 31, 48, 49, 50, 51, 52, 53,
-                54,
+                7, 8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 23, 24, 25, 26, 27,
+                28, 29, 30, 31, 48, 49, 50, 51, 52, 53, 54,
             ],
         ),
         8 => simd_shuffle32(
             b,
             a,
             [
-                8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39,
-                24, 25, 26, 27, 28, 29, 30, 31, 48, 49, 50, 51, 52, 53, 54,
-                55,
+                8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 24, 25, 26, 27, 28,
+                29, 30, 31, 48, 49, 50, 51, 52, 53, 54, 55,
             ],
         ),
         9 => simd_shuffle32(
             b,
             a,
             [
-                9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-                25, 26, 27, 28, 29, 30, 31, 48, 49, 50, 51, 52, 53, 54, 55,
-                56,
+                9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 25, 26, 27, 28, 29,
+                30, 31, 48, 49, 50, 51, 52, 53, 54, 55, 56,
             ],
         ),
         10 => simd_shuffle32(
             b,
             a,
             [
-                10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-                41, 26, 27, 28, 29, 30, 31, 48, 49, 50, 51, 52, 53, 54, 55,
-                56, 57,
+                10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 26, 27, 28, 29, 30,
+                31, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
             ],
         ),
         11 => simd_shuffle32(
             b,
             a,
             [
-                11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-                42, 27, 28, 29, 30, 31, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-                57, 58,
+                11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 27, 28, 29, 30, 31,
+                48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
             ],
         ),
         12 => simd_shuffle32(
             b,
             a,
             [
-                12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
-                43, 28, 29, 30, 31, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
-                58, 59,
+                12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 28, 29, 30, 31, 48,
+                49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
             ],
         ),
         13 => simd_shuffle32(
             b,
             a,
             [
-                13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
-                44, 29, 30, 31, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
-                59, 60,
+                13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 29, 30, 31, 48, 49,
+                50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
             ],
         ),
         14 => simd_shuffle32(
             b,
             a,
             [
-                14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-                45, 30, 31, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                60, 61,
+                14, 15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 30, 31, 48, 49, 50,
+                51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
             ],
         ),
         15 => simd_shuffle32(
             b,
             a,
             [
-                15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
-                46, 31, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
-                61, 62,
+                15, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 31, 48, 49, 50, 51,
+                52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
             ],
         ),
         _ => b,
@@ -412,9 +402,7 @@ pub unsafe fn _mm_blend_epi32(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 #[cfg_attr(test, assert_instr(vblendps, imm8 = 9))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_blend_epi32(
-    a: __m256i, b: __m256i, imm8: i32,
-) -> __m256i {
+pub unsafe fn _mm256_blend_epi32(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
     let imm8 = (imm8 & 0xFF) as u8;
     let a = a.as_i32x8();
     let b = b.as_i32x8();
@@ -479,9 +467,7 @@ pub unsafe fn _mm256_blend_epi32(
 #[cfg_attr(test, assert_instr(vpblendw, imm8 = 9))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_blend_epi16(
-    a: __m256i, b: __m256i, imm8: i32,
-) -> __m256i {
+pub unsafe fn _mm256_blend_epi16(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
     let imm8 = (imm8 & 0xFF) as u8;
     let a = a.as_i16x16();
     let b = b.as_i16x16();
@@ -508,8 +494,7 @@ pub unsafe fn _mm256_blend_epi16(
                 a,
                 b,
                 [
-                    $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n,
-                    $o, $p,
+                    $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p,
                 ],
             )
         };
@@ -530,22 +515,14 @@ pub unsafe fn _mm256_blend_epi16(
             $f2:expr
         ) => {
             match (imm8 >> 6) & 0b11 {
-                0b00 => blend4!(
-                    $a, $b, $c, $d, $e, $f, 6, 7, $a2, $b2, $c2, $d2, $e2,
-                    $f2, 14, 15
-                ),
-                0b01 => blend4!(
-                    $a, $b, $c, $d, $e, $f, 22, 7, $a2, $b2, $c2, $d2, $e2,
-                    $f2, 30, 15
-                ),
-                0b10 => blend4!(
-                    $a, $b, $c, $d, $e, $f, 6, 23, $a2, $b2, $c2, $d2, $e2,
-                    $f2, 14, 31
-                ),
-                _ => blend4!(
-                    $a, $b, $c, $d, $e, $f, 22, 23, $a2, $b2, $c2, $d2, $e2,
-                    $f2, 30, 31
-                ),
+                0b00 => blend4!($a, $b, $c, $d, $e, $f, 6, 7, $a2, $b2, $c2, $d2, $e2, $f2, 14, 15),
+                0b01 => {
+                    blend4!($a, $b, $c, $d, $e, $f, 22, 7, $a2, $b2, $c2, $d2, $e2, $f2, 30, 15)
+                }
+                0b10 => {
+                    blend4!($a, $b, $c, $d, $e, $f, 6, 23, $a2, $b2, $c2, $d2, $e2, $f2, 14, 31)
+                }
+                _ => blend4!($a, $b, $c, $d, $e, $f, 22, 23, $a2, $b2, $c2, $d2, $e2, $f2, 30, 31),
             }
         };
     }
@@ -561,18 +538,10 @@ pub unsafe fn _mm256_blend_epi16(
             $d2:expr
         ) => {
             match (imm8 >> 4) & 0b11 {
-                0b00 => {
-                    blend3!($a, $b, $c, $d, 4, 5, $a2, $b2, $c2, $d2, 12, 13)
-                }
-                0b01 => {
-                    blend3!($a, $b, $c, $d, 20, 5, $a2, $b2, $c2, $d2, 28, 13)
-                }
-                0b10 => {
-                    blend3!($a, $b, $c, $d, 4, 21, $a2, $b2, $c2, $d2, 12, 29)
-                }
-                _ => {
-                    blend3!($a, $b, $c, $d, 20, 21, $a2, $b2, $c2, $d2, 28, 29)
-                }
+                0b00 => blend3!($a, $b, $c, $d, 4, 5, $a2, $b2, $c2, $d2, 12, 13),
+                0b01 => blend3!($a, $b, $c, $d, 20, 5, $a2, $b2, $c2, $d2, 28, 13),
+                0b10 => blend3!($a, $b, $c, $d, 4, 21, $a2, $b2, $c2, $d2, 12, 29),
+                _ => blend3!($a, $b, $c, $d, 20, 21, $a2, $b2, $c2, $d2, 28, 29),
             }
         };
     }
@@ -602,9 +571,7 @@ pub unsafe fn _mm256_blend_epi16(
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpblendvb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_blendv_epi8(
-    a: __m256i, b: __m256i, mask: __m256i,
-) -> __m256i {
+pub unsafe fn _mm256_blendv_epi8(a: __m256i, b: __m256i, mask: __m256i) -> __m256i {
     mem::transmute(pblendvb(a.as_i8x32(), b.as_i8x32(), mask.as_i8x32()))
 }
 
@@ -1124,9 +1091,7 @@ pub unsafe fn _mm256_hsubs_epi16(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i32gather_epi32(
-    slice: *const i32, offsets: __m128i, scale: i32,
-) -> __m128i {
+pub unsafe fn _mm_i32gather_epi32(slice: *const i32, offsets: __m128i, scale: i32) -> __m128i {
     let zero = _mm_setzero_si128().as_i32x4();
     let neg_one = _mm_set1_epi32(-1).as_i32x4();
     let offsets = offsets.as_i32x4();
@@ -1152,7 +1117,10 @@ pub unsafe fn _mm_i32gather_epi32(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mask_i32gather_epi32(
-    src: __m128i, slice: *const i32, offsets: __m128i, mask: __m128i,
+    src: __m128i,
+    slice: *const i32,
+    offsets: __m128i,
+    mask: __m128i,
     scale: i32,
 ) -> __m128i {
     let src = src.as_i32x4();
@@ -1178,9 +1146,7 @@ pub unsafe fn _mm_mask_i32gather_epi32(
 #[cfg_attr(test, assert_instr(vpgatherdd, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i32gather_epi32(
-    slice: *const i32, offsets: __m256i, scale: i32,
-) -> __m256i {
+pub unsafe fn _mm256_i32gather_epi32(slice: *const i32, offsets: __m256i, scale: i32) -> __m256i {
     let zero = _mm256_setzero_si256().as_i32x8();
     let neg_one = _mm256_set1_epi32(-1).as_i32x8();
     let offsets = offsets.as_i32x8();
@@ -1206,7 +1172,10 @@ pub unsafe fn _mm256_i32gather_epi32(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_mask_i32gather_epi32(
-    src: __m256i, slice: *const i32, offsets: __m256i, mask: __m256i,
+    src: __m256i,
+    slice: *const i32,
+    offsets: __m256i,
+    mask: __m256i,
     scale: i32,
 ) -> __m256i {
     let src = src.as_i32x8();
@@ -1232,9 +1201,7 @@ pub unsafe fn _mm256_mask_i32gather_epi32(
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i32gather_ps(
-    slice: *const f32, offsets: __m128i, scale: i32,
-) -> __m128 {
+pub unsafe fn _mm_i32gather_ps(slice: *const f32, offsets: __m128i, scale: i32) -> __m128 {
     let zero = _mm_setzero_ps();
     let neg_one = _mm_set1_ps(-1.0);
     let offsets = offsets.as_i32x4();
@@ -1259,7 +1226,11 @@ pub unsafe fn _mm_i32gather_ps(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mask_i32gather_ps(
-    src: __m128, slice: *const f32, offsets: __m128i, mask: __m128, scale: i32,
+    src: __m128,
+    slice: *const f32,
+    offsets: __m128i,
+    mask: __m128,
+    scale: i32,
 ) -> __m128 {
     let offsets = offsets.as_i32x4();
     let slice = slice as *const i8;
@@ -1281,9 +1252,7 @@ pub unsafe fn _mm_mask_i32gather_ps(
 #[cfg_attr(test, assert_instr(vgatherdps, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i32gather_ps(
-    slice: *const f32, offsets: __m256i, scale: i32,
-) -> __m256 {
+pub unsafe fn _mm256_i32gather_ps(slice: *const f32, offsets: __m256i, scale: i32) -> __m256 {
     let zero = _mm256_setzero_ps();
     let neg_one = _mm256_set1_ps(-1.0);
     let offsets = offsets.as_i32x8();
@@ -1308,7 +1277,11 @@ pub unsafe fn _mm256_i32gather_ps(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_mask_i32gather_ps(
-    src: __m256, slice: *const f32, offsets: __m256i, mask: __m256, scale: i32,
+    src: __m256,
+    slice: *const f32,
+    offsets: __m256i,
+    mask: __m256,
+    scale: i32,
 ) -> __m256 {
     let offsets = offsets.as_i32x8();
     let slice = slice as *const i8;
@@ -1330,9 +1303,7 @@ pub unsafe fn _mm256_mask_i32gather_ps(
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i32gather_epi64(
-    slice: *const i64, offsets: __m128i, scale: i32,
-) -> __m128i {
+pub unsafe fn _mm_i32gather_epi64(slice: *const i64, offsets: __m128i, scale: i32) -> __m128i {
     let zero = _mm_setzero_si128().as_i64x2();
     let neg_one = _mm_set1_epi64x(-1).as_i64x2();
     let offsets = offsets.as_i32x4();
@@ -1358,7 +1329,10 @@ pub unsafe fn _mm_i32gather_epi64(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mask_i32gather_epi64(
-    src: __m128i, slice: *const i64, offsets: __m128i, mask: __m128i,
+    src: __m128i,
+    slice: *const i64,
+    offsets: __m128i,
+    mask: __m128i,
     scale: i32,
 ) -> __m128i {
     let src = src.as_i64x2();
@@ -1384,9 +1358,7 @@ pub unsafe fn _mm_mask_i32gather_epi64(
 #[cfg_attr(test, assert_instr(vpgatherdq, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i32gather_epi64(
-    slice: *const i64, offsets: __m128i, scale: i32,
-) -> __m256i {
+pub unsafe fn _mm256_i32gather_epi64(slice: *const i64, offsets: __m128i, scale: i32) -> __m256i {
     let zero = _mm256_setzero_si256().as_i64x4();
     let neg_one = _mm256_set1_epi64x(-1).as_i64x4();
     let offsets = offsets.as_i32x4();
@@ -1412,7 +1384,10 @@ pub unsafe fn _mm256_i32gather_epi64(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_mask_i32gather_epi64(
-    src: __m256i, slice: *const i64, offsets: __m128i, mask: __m256i,
+    src: __m256i,
+    slice: *const i64,
+    offsets: __m128i,
+    mask: __m256i,
     scale: i32,
 ) -> __m256i {
     let src = src.as_i64x4();
@@ -1438,9 +1413,7 @@ pub unsafe fn _mm256_mask_i32gather_epi64(
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i32gather_pd(
-    slice: *const f64, offsets: __m128i, scale: i32,
-) -> __m128d {
+pub unsafe fn _mm_i32gather_pd(slice: *const f64, offsets: __m128i, scale: i32) -> __m128d {
     let zero = _mm_setzero_pd();
     let neg_one = _mm_set1_pd(-1.0);
     let offsets = offsets.as_i32x4();
@@ -1465,7 +1438,10 @@ pub unsafe fn _mm_i32gather_pd(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mask_i32gather_pd(
-    src: __m128d, slice: *const f64, offsets: __m128i, mask: __m128d,
+    src: __m128d,
+    slice: *const f64,
+    offsets: __m128i,
+    mask: __m128d,
     scale: i32,
 ) -> __m128d {
     let offsets = offsets.as_i32x4();
@@ -1488,9 +1464,7 @@ pub unsafe fn _mm_mask_i32gather_pd(
 #[cfg_attr(test, assert_instr(vgatherdpd, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i32gather_pd(
-    slice: *const f64, offsets: __m128i, scale: i32,
-) -> __m256d {
+pub unsafe fn _mm256_i32gather_pd(slice: *const f64, offsets: __m128i, scale: i32) -> __m256d {
     let zero = _mm256_setzero_pd();
     let neg_one = _mm256_set1_pd(-1.0);
     let offsets = offsets.as_i32x4();
@@ -1515,7 +1489,10 @@ pub unsafe fn _mm256_i32gather_pd(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_mask_i32gather_pd(
-    src: __m256d, slice: *const f64, offsets: __m128i, mask: __m256d,
+    src: __m256d,
+    slice: *const f64,
+    offsets: __m128i,
+    mask: __m256d,
     scale: i32,
 ) -> __m256d {
     let offsets = offsets.as_i32x4();
@@ -1538,9 +1515,7 @@ pub unsafe fn _mm256_mask_i32gather_pd(
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i64gather_epi32(
-    slice: *const i32, offsets: __m128i, scale: i32,
-) -> __m128i {
+pub unsafe fn _mm_i64gather_epi32(slice: *const i32, offsets: __m128i, scale: i32) -> __m128i {
     let zero = _mm_setzero_si128().as_i32x4();
     let neg_one = _mm_set1_epi64x(-1).as_i32x4();
     let offsets = offsets.as_i64x2();
@@ -1566,7 +1541,10 @@ pub unsafe fn _mm_i64gather_epi32(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mask_i64gather_epi32(
-    src: __m128i, slice: *const i32, offsets: __m128i, mask: __m128i,
+    src: __m128i,
+    slice: *const i32,
+    offsets: __m128i,
+    mask: __m128i,
     scale: i32,
 ) -> __m128i {
     let src = src.as_i32x4();
@@ -1592,9 +1570,7 @@ pub unsafe fn _mm_mask_i64gather_epi32(
 #[cfg_attr(test, assert_instr(vpgatherqd, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i64gather_epi32(
-    slice: *const i32, offsets: __m256i, scale: i32,
-) -> __m128i {
+pub unsafe fn _mm256_i64gather_epi32(slice: *const i32, offsets: __m256i, scale: i32) -> __m128i {
     let zero = _mm_setzero_si128().as_i32x4();
     let neg_one = _mm_set1_epi64x(-1).as_i32x4();
     let offsets = offsets.as_i64x4();
@@ -1620,7 +1596,10 @@ pub unsafe fn _mm256_i64gather_epi32(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_mask_i64gather_epi32(
-    src: __m128i, slice: *const i32, offsets: __m256i, mask: __m128i,
+    src: __m128i,
+    slice: *const i32,
+    offsets: __m256i,
+    mask: __m128i,
     scale: i32,
 ) -> __m128i {
     let src = src.as_i32x4();
@@ -1646,9 +1625,7 @@ pub unsafe fn _mm256_mask_i64gather_epi32(
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i64gather_ps(
-    slice: *const f32, offsets: __m128i, scale: i32,
-) -> __m128 {
+pub unsafe fn _mm_i64gather_ps(slice: *const f32, offsets: __m128i, scale: i32) -> __m128 {
     let zero = _mm_setzero_ps();
     let neg_one = _mm_set1_ps(-1.0);
     let offsets = offsets.as_i64x2();
@@ -1673,7 +1650,11 @@ pub unsafe fn _mm_i64gather_ps(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mask_i64gather_ps(
-    src: __m128, slice: *const f32, offsets: __m128i, mask: __m128, scale: i32,
+    src: __m128,
+    slice: *const f32,
+    offsets: __m128i,
+    mask: __m128,
+    scale: i32,
 ) -> __m128 {
     let offsets = offsets.as_i64x2();
     let slice = slice as *const i8;
@@ -1695,9 +1676,7 @@ pub unsafe fn _mm_mask_i64gather_ps(
 #[cfg_attr(test, assert_instr(vgatherqps, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i64gather_ps(
-    slice: *const f32, offsets: __m256i, scale: i32,
-) -> __m128 {
+pub unsafe fn _mm256_i64gather_ps(slice: *const f32, offsets: __m256i, scale: i32) -> __m128 {
     let zero = _mm_setzero_ps();
     let neg_one = _mm_set1_ps(-1.0);
     let offsets = offsets.as_i64x4();
@@ -1722,7 +1701,11 @@ pub unsafe fn _mm256_i64gather_ps(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_mask_i64gather_ps(
-    src: __m128, slice: *const f32, offsets: __m256i, mask: __m128, scale: i32,
+    src: __m128,
+    slice: *const f32,
+    offsets: __m256i,
+    mask: __m128,
+    scale: i32,
 ) -> __m128 {
     let offsets = offsets.as_i64x4();
     let slice = slice as *const i8;
@@ -1744,9 +1727,7 @@ pub unsafe fn _mm256_mask_i64gather_ps(
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i64gather_epi64(
-    slice: *const i64, offsets: __m128i, scale: i32,
-) -> __m128i {
+pub unsafe fn _mm_i64gather_epi64(slice: *const i64, offsets: __m128i, scale: i32) -> __m128i {
     let zero = _mm_setzero_si128().as_i64x2();
     let neg_one = _mm_set1_epi64x(-1).as_i64x2();
     let slice = slice as *const i8;
@@ -1772,7 +1753,10 @@ pub unsafe fn _mm_i64gather_epi64(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mask_i64gather_epi64(
-    src: __m128i, slice: *const i64, offsets: __m128i, mask: __m128i,
+    src: __m128i,
+    slice: *const i64,
+    offsets: __m128i,
+    mask: __m128i,
     scale: i32,
 ) -> __m128i {
     let src = src.as_i64x2();
@@ -1798,9 +1782,7 @@ pub unsafe fn _mm_mask_i64gather_epi64(
 #[cfg_attr(test, assert_instr(vpgatherqq, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i64gather_epi64(
-    slice: *const i64, offsets: __m256i, scale: i32,
-) -> __m256i {
+pub unsafe fn _mm256_i64gather_epi64(slice: *const i64, offsets: __m256i, scale: i32) -> __m256i {
     let zero = _mm256_setzero_si256().as_i64x4();
     let neg_one = _mm256_set1_epi64x(-1).as_i64x4();
     let slice = slice as *const i8;
@@ -1826,7 +1808,10 @@ pub unsafe fn _mm256_i64gather_epi64(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_mask_i64gather_epi64(
-    src: __m256i, slice: *const i64, offsets: __m256i, mask: __m256i,
+    src: __m256i,
+    slice: *const i64,
+    offsets: __m256i,
+    mask: __m256i,
     scale: i32,
 ) -> __m256i {
     let src = src.as_i64x4();
@@ -1852,9 +1837,7 @@ pub unsafe fn _mm256_mask_i64gather_epi64(
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_i64gather_pd(
-    slice: *const f64, offsets: __m128i, scale: i32,
-) -> __m128d {
+pub unsafe fn _mm_i64gather_pd(slice: *const f64, offsets: __m128i, scale: i32) -> __m128d {
     let zero = _mm_setzero_pd();
     let neg_one = _mm_set1_pd(-1.0);
     let slice = slice as *const i8;
@@ -1879,7 +1862,10 @@ pub unsafe fn _mm_i64gather_pd(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_mask_i64gather_pd(
-    src: __m128d, slice: *const f64, offsets: __m128i, mask: __m128d,
+    src: __m128d,
+    slice: *const f64,
+    offsets: __m128i,
+    mask: __m128d,
     scale: i32,
 ) -> __m128d {
     let slice = slice as *const i8;
@@ -1902,9 +1888,7 @@ pub unsafe fn _mm_mask_i64gather_pd(
 #[cfg_attr(test, assert_instr(vgatherqpd, scale = 1))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_i64gather_pd(
-    slice: *const f64, offsets: __m256i, scale: i32,
-) -> __m256d {
+pub unsafe fn _mm256_i64gather_pd(slice: *const f64, offsets: __m256i, scale: i32) -> __m256d {
     let zero = _mm256_setzero_pd();
     let neg_one = _mm256_set1_pd(-1.0);
     let slice = slice as *const i8;
@@ -1929,7 +1913,10 @@ pub unsafe fn _mm256_i64gather_pd(
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_mask_i64gather_pd(
-    src: __m256d, slice: *const f64, offsets: __m256i, mask: __m256d,
+    src: __m256d,
+    slice: *const f64,
+    offsets: __m256i,
+    mask: __m256d,
     scale: i32,
 ) -> __m256d {
     let slice = slice as *const i8;
@@ -1954,9 +1941,7 @@ pub unsafe fn _mm256_mask_i64gather_pd(
 )]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_inserti128_si256(
-    a: __m256i, b: __m128i, imm8: i32,
-) -> __m256i {
+pub unsafe fn _mm256_inserti128_si256(a: __m256i, b: __m128i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     let b = _mm256_castsi128_si256(b).as_i64x4();
     let dst: i64x4 = match imm8 & 0b01 {
@@ -2002,9 +1987,7 @@ pub unsafe fn _mm256_maddubs_epi16(a: __m256i, b: __m256i) -> __m256i {
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_maskload_epi32(
-    mem_addr: *const i32, mask: __m128i,
-) -> __m128i {
+pub unsafe fn _mm_maskload_epi32(mem_addr: *const i32, mask: __m128i) -> __m128i {
     mem::transmute(maskloadd(mem_addr as *const i8, mask.as_i32x4()))
 }
 
@@ -2017,9 +2000,7 @@ pub unsafe fn _mm_maskload_epi32(
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_maskload_epi32(
-    mem_addr: *const i32, mask: __m256i,
-) -> __m256i {
+pub unsafe fn _mm256_maskload_epi32(mem_addr: *const i32, mask: __m256i) -> __m256i {
     mem::transmute(maskloadd256(mem_addr as *const i8, mask.as_i32x8()))
 }
 
@@ -2032,9 +2013,7 @@ pub unsafe fn _mm256_maskload_epi32(
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovq))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_maskload_epi64(
-    mem_addr: *const i64, mask: __m128i,
-) -> __m128i {
+pub unsafe fn _mm_maskload_epi64(mem_addr: *const i64, mask: __m128i) -> __m128i {
     mem::transmute(maskloadq(mem_addr as *const i8, mask.as_i64x2()))
 }
 
@@ -2047,9 +2026,7 @@ pub unsafe fn _mm_maskload_epi64(
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovq))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_maskload_epi64(
-    mem_addr: *const i64, mask: __m256i,
-) -> __m256i {
+pub unsafe fn _mm256_maskload_epi64(mem_addr: *const i64, mask: __m256i) -> __m256i {
     mem::transmute(maskloadq256(mem_addr as *const i8, mask.as_i64x4()))
 }
 
@@ -2062,9 +2039,7 @@ pub unsafe fn _mm256_maskload_epi64(
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_maskstore_epi32(
-    mem_addr: *mut i32, mask: __m128i, a: __m128i,
-) {
+pub unsafe fn _mm_maskstore_epi32(mem_addr: *mut i32, mask: __m128i, a: __m128i) {
     maskstored(mem_addr as *mut i8, mask.as_i32x4(), a.as_i32x4())
 }
 
@@ -2077,9 +2052,7 @@ pub unsafe fn _mm_maskstore_epi32(
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_maskstore_epi32(
-    mem_addr: *mut i32, mask: __m256i, a: __m256i,
-) {
+pub unsafe fn _mm256_maskstore_epi32(mem_addr: *mut i32, mask: __m256i, a: __m256i) {
     maskstored256(mem_addr as *mut i8, mask.as_i32x8(), a.as_i32x8())
 }
 
@@ -2092,9 +2065,7 @@ pub unsafe fn _mm256_maskstore_epi32(
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovq))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_maskstore_epi64(
-    mem_addr: *mut i64, mask: __m128i, a: __m128i,
-) {
+pub unsafe fn _mm_maskstore_epi64(mem_addr: *mut i64, mask: __m128i, a: __m128i) {
     maskstoreq(mem_addr as *mut i8, mask.as_i64x2(), a.as_i64x2())
 }
 
@@ -2107,9 +2078,7 @@ pub unsafe fn _mm_maskstore_epi64(
 #[target_feature(enable = "avx2")]
 #[cfg_attr(test, assert_instr(vpmaskmovq))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_maskstore_epi64(
-    mem_addr: *mut i64, mask: __m256i, a: __m256i,
-) {
+pub unsafe fn _mm256_maskstore_epi64(mem_addr: *mut i64, mask: __m256i, a: __m256i) {
     maskstoreq256(mem_addr as *mut i8, mask.as_i64x4(), a.as_i64x4())
 }
 
@@ -2283,9 +2252,7 @@ pub unsafe fn _mm256_movemask_epi8(a: __m256i) -> i32 {
 #[cfg_attr(test, assert_instr(vmpsadbw, imm8 = 0))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_mpsadbw_epu8(
-    a: __m256i, b: __m256i, imm8: i32,
-) -> __m256i {
+pub unsafe fn _mm256_mpsadbw_epu8(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
     let a = a.as_u8x32();
     let b = b.as_u8x32();
     macro_rules! call {
@@ -2529,9 +2496,7 @@ pub unsafe fn _mm256_permute4x64_epi64(a: __m256i, imm8: i32) -> __m256i {
 #[cfg_attr(test, assert_instr(vperm2f128, imm8 = 9))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_permute2x128_si256(
-    a: __m256i, b: __m256i, imm8: i32,
-) -> __m256i {
+pub unsafe fn _mm256_permute2x128_si256(a: __m256i, b: __m256i, imm8: i32) -> __m256i {
     let a = a.as_i64x4();
     let b = b.as_i64x4();
     macro_rules! call {
@@ -3679,11 +3644,7 @@ pub unsafe fn _mm256_unpacklo_epi16(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vunpckhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpackhi_epi32(a: __m256i, b: __m256i) -> __m256i {
-    let r: i32x8 = simd_shuffle8(
-        a.as_i32x8(),
-        b.as_i32x8(),
-        [2, 10, 3, 11, 6, 14, 7, 15],
-    );
+    let r: i32x8 = simd_shuffle8(a.as_i32x8(), b.as_i32x8(), [2, 10, 3, 11, 6, 14, 7, 15]);
     mem::transmute(r)
 }
 
@@ -3726,8 +3687,7 @@ pub unsafe fn _mm256_unpackhi_epi32(a: __m256i, b: __m256i) -> __m256i {
 #[cfg_attr(test, assert_instr(vunpcklps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm256_unpacklo_epi32(a: __m256i, b: __m256i) -> __m256i {
-    let r: i32x8 =
-        simd_shuffle8(a.as_i32x8(), b.as_i32x8(), [0, 8, 1, 9, 4, 12, 5, 13]);
+    let r: i32x8 = simd_shuffle8(a.as_i32x8(), b.as_i32x8(), [0, 8, 1, 9, 4, 12, 5, 13]);
     mem::transmute(r)
 }
 
@@ -4073,72 +4033,74 @@ extern "C" {
     #[link_name = "llvm.x86.avx2.vperm2i128"]
     fn vperm2i128(a: i64x4, b: i64x4, imm8: i8) -> i64x4;
     #[link_name = "llvm.x86.avx2.gather.d.d"]
-    fn pgatherdd(
-        src: i32x4, slice: *const i8, offsets: i32x4, mask: i32x4, scale: i8,
-    ) -> i32x4;
+    fn pgatherdd(src: i32x4, slice: *const i8, offsets: i32x4, mask: i32x4, scale: i8) -> i32x4;
     #[link_name = "llvm.x86.avx2.gather.d.d.256"]
-    fn vpgatherdd(
-        src: i32x8, slice: *const i8, offsets: i32x8, mask: i32x8, scale: i8,
-    ) -> i32x8;
+    fn vpgatherdd(src: i32x8, slice: *const i8, offsets: i32x8, mask: i32x8, scale: i8) -> i32x8;
     #[link_name = "llvm.x86.avx2.gather.d.q"]
-    fn pgatherdq(
-        src: i64x2, slice: *const i8, offsets: i32x4, mask: i64x2, scale: i8,
-    ) -> i64x2;
+    fn pgatherdq(src: i64x2, slice: *const i8, offsets: i32x4, mask: i64x2, scale: i8) -> i64x2;
     #[link_name = "llvm.x86.avx2.gather.d.q.256"]
-    fn vpgatherdq(
-        src: i64x4, slice: *const i8, offsets: i32x4, mask: i64x4, scale: i8,
-    ) -> i64x4;
+    fn vpgatherdq(src: i64x4, slice: *const i8, offsets: i32x4, mask: i64x4, scale: i8) -> i64x4;
     #[link_name = "llvm.x86.avx2.gather.q.d"]
-    fn pgatherqd(
-        src: i32x4, slice: *const i8, offsets: i64x2, mask: i32x4, scale: i8,
-    ) -> i32x4;
+    fn pgatherqd(src: i32x4, slice: *const i8, offsets: i64x2, mask: i32x4, scale: i8) -> i32x4;
     #[link_name = "llvm.x86.avx2.gather.q.d.256"]
-    fn vpgatherqd(
-        src: i32x4, slice: *const i8, offsets: i64x4, mask: i32x4, scale: i8,
-    ) -> i32x4;
+    fn vpgatherqd(src: i32x4, slice: *const i8, offsets: i64x4, mask: i32x4, scale: i8) -> i32x4;
     #[link_name = "llvm.x86.avx2.gather.q.q"]
-    fn pgatherqq(
-        src: i64x2, slice: *const i8, offsets: i64x2, mask: i64x2, scale: i8,
-    ) -> i64x2;
+    fn pgatherqq(src: i64x2, slice: *const i8, offsets: i64x2, mask: i64x2, scale: i8) -> i64x2;
     #[link_name = "llvm.x86.avx2.gather.q.q.256"]
-    fn vpgatherqq(
-        src: i64x4, slice: *const i8, offsets: i64x4, mask: i64x4, scale: i8,
-    ) -> i64x4;
+    fn vpgatherqq(src: i64x4, slice: *const i8, offsets: i64x4, mask: i64x4, scale: i8) -> i64x4;
     #[link_name = "llvm.x86.avx2.gather.d.pd"]
     fn pgatherdpd(
-        src: __m128d, slice: *const i8, offsets: i32x4, mask: __m128d,
+        src: __m128d,
+        slice: *const i8,
+        offsets: i32x4,
+        mask: __m128d,
         scale: i8,
     ) -> __m128d;
     #[link_name = "llvm.x86.avx2.gather.d.pd.256"]
     fn vpgatherdpd(
-        src: __m256d, slice: *const i8, offsets: i32x4, mask: __m256d,
+        src: __m256d,
+        slice: *const i8,
+        offsets: i32x4,
+        mask: __m256d,
         scale: i8,
     ) -> __m256d;
     #[link_name = "llvm.x86.avx2.gather.q.pd"]
     fn pgatherqpd(
-        src: __m128d, slice: *const i8, offsets: i64x2, mask: __m128d,
+        src: __m128d,
+        slice: *const i8,
+        offsets: i64x2,
+        mask: __m128d,
         scale: i8,
     ) -> __m128d;
     #[link_name = "llvm.x86.avx2.gather.q.pd.256"]
     fn vpgatherqpd(
-        src: __m256d, slice: *const i8, offsets: i64x4, mask: __m256d,
+        src: __m256d,
+        slice: *const i8,
+        offsets: i64x4,
+        mask: __m256d,
         scale: i8,
     ) -> __m256d;
     #[link_name = "llvm.x86.avx2.gather.d.ps"]
-    fn pgatherdps(
-        src: __m128, slice: *const i8, offsets: i32x4, mask: __m128, scale: i8,
-    ) -> __m128;
+    fn pgatherdps(src: __m128, slice: *const i8, offsets: i32x4, mask: __m128, scale: i8)
+        -> __m128;
     #[link_name = "llvm.x86.avx2.gather.d.ps.256"]
     fn vpgatherdps(
-        src: __m256, slice: *const i8, offsets: i32x8, mask: __m256, scale: i8,
+        src: __m256,
+        slice: *const i8,
+        offsets: i32x8,
+        mask: __m256,
+        scale: i8,
     ) -> __m256;
     #[link_name = "llvm.x86.avx2.gather.q.ps"]
-    fn pgatherqps(
-        src: __m128, slice: *const i8, offsets: i64x2, mask: __m128, scale: i8,
-    ) -> __m128;
+    fn pgatherqps(src: __m128, slice: *const i8, offsets: i64x2, mask: __m128, scale: i8)
+        -> __m128;
     #[link_name = "llvm.x86.avx2.gather.q.ps.256"]
     fn vpgatherqps(
-        src: __m128, slice: *const i8, offsets: i64x4, mask: __m128, scale: i8,
+        src: __m128,
+        slice: *const i8,
+        offsets: i64x4,
+        mask: __m128,
+        scale: i8,
     ) -> __m128;
     #[link_name = "llvm.x86.avx2.psll.dq"]
     fn vpslldq(a: i64x4, b: i32) -> i64x4;
@@ -4477,8 +4439,7 @@ mod tests {
     #[simd_test(enable = "avx2")]
     unsafe fn test_mm256_blend_epi16() {
         let (a, b) = (_mm256_set1_epi16(3), _mm256_set1_epi16(9));
-        let e =
-            _mm256_setr_epi16(9, 3, 3, 3, 3, 3, 3, 3, 9, 3, 3, 3, 3, 3, 3, 3);
+        let e = _mm256_setr_epi16(9, 3, 3, 3, 3, 3, 3, 3, 9, 3, 3, 3, 3, 3, 3, 3);
         let r = _mm256_blend_epi16(a, b, 0x01 as i32);
         assert_eq_m256i(r, e);
 
@@ -4807,8 +4768,7 @@ mod tests {
         let a = _mm256_set1_epi16(2);
         let b = _mm256_set1_epi16(4);
         let r = _mm256_hadd_epi16(a, b);
-        let e =
-            _mm256_setr_epi16(4, 4, 4, 4, 8, 8, 8, 8, 4, 4, 4, 4, 8, 8, 8, 8);
+        let e = _mm256_setr_epi16(4, 4, 4, 4, 8, 8, 8, 8, 4, 4, 4, 4, 8, 8, 8, 8);
         assert_eq_m256i(r, e);
     }
 
@@ -5177,8 +5137,7 @@ mod tests {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_packs_epi32(a, b);
-        let e =
-            _mm256_setr_epi16(2, 2, 2, 2, 4, 4, 4, 4, 2, 2, 2, 2, 4, 4, 4, 4);
+        let e = _mm256_setr_epi16(2, 2, 2, 2, 4, 4, 4, 4, 2, 2, 2, 2, 4, 4, 4, 4);
 
         assert_eq_m256i(r, e);
     }
@@ -5204,8 +5163,7 @@ mod tests {
         let a = _mm256_set1_epi32(2);
         let b = _mm256_set1_epi32(4);
         let r = _mm256_packus_epi32(a, b);
-        let e =
-            _mm256_setr_epi16(2, 2, 2, 2, 4, 4, 4, 4, 2, 2, 2, 2, 4, 4, 4, 4);
+        let e = _mm256_setr_epi16(2, 2, 2, 2, 4, 4, 4, 4, 2, 2, 2, 2, 4, 4, 4, 4);
 
         assert_eq_m256i(r, e);
     }
@@ -5689,8 +5647,7 @@ mod tests {
     unsafe fn test_mm256_permutevar8x32_epi32() {
         let a = _mm256_setr_epi32(100, 200, 300, 400, 500, 600, 700, 800);
         let b = _mm256_setr_epi32(5, 0, 5, 1, 7, 6, 3, 4);
-        let expected =
-            _mm256_setr_epi32(600, 100, 600, 200, 800, 700, 400, 500);
+        let expected = _mm256_setr_epi32(600, 100, 600, 200, 800, 700, 400, 500);
         let r = _mm256_permutevar8x32_epi32(a, b);
         assert_eq_m256i(r, expected);
     }
@@ -5736,11 +5693,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 4 is word-addressing
-        let r = _mm_i32gather_epi32(
-            arr.as_ptr(),
-            _mm_setr_epi32(0, 16, 32, 48),
-            4,
-        );
+        let r = _mm_i32gather_epi32(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48), 4);
         assert_eq_m128i(r, _mm_setr_epi32(0, 16, 32, 48));
     }
 
@@ -5790,10 +5743,7 @@ mod tests {
             _mm256_setr_epi32(-1, -1, -1, 0, 0, 0, 0, 0),
             4,
         );
-        assert_eq_m256i(
-            r,
-            _mm256_setr_epi32(0, 16, 64, 256, 256, 256, 256, 256),
-        );
+        assert_eq_m256i(r, _mm256_setr_epi32(0, 16, 64, 256, 256, 256, 256, 256));
     }
 
     #[simd_test(enable = "avx2")]
@@ -5805,8 +5755,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 4 is word-addressing for f32s
-        let r =
-            _mm_i32gather_ps(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48), 4);
+        let r = _mm_i32gather_ps(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48), 4);
         assert_eq_m128(r, _mm_setr_ps(0.0, 16.0, 32.0, 48.0));
     }
 
@@ -5843,10 +5792,7 @@ mod tests {
             _mm256_setr_epi32(0, 16, 32, 48, 1, 2, 3, 4),
             4,
         );
-        assert_eq_m256(
-            r,
-            _mm256_setr_ps(0.0, 16.0, 32.0, 48.0, 1.0, 2.0, 3.0, 4.0),
-        );
+        assert_eq_m256(r, _mm256_setr_ps(0.0, 16.0, 32.0, 48.0, 1.0, 2.0, 3.0, 4.0));
     }
 
     #[simd_test(enable = "avx2")]
@@ -5878,8 +5824,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 8 is word-addressing for i64s
-        let r =
-            _mm_i32gather_epi64(arr.as_ptr(), _mm_setr_epi32(0, 16, 0, 0), 8);
+        let r = _mm_i32gather_epi64(arr.as_ptr(), _mm_setr_epi32(0, 16, 0, 0), 8);
         assert_eq_m128i(r, _mm_setr_epi64x(0, 16));
     }
 
@@ -5907,11 +5852,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 8 is word-addressing for i64s
-        let r = _mm256_i32gather_epi64(
-            arr.as_ptr(),
-            _mm_setr_epi32(0, 16, 32, 48),
-            8,
-        );
+        let r = _mm256_i32gather_epi64(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48), 8);
         assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 32, 48));
     }
 
@@ -5973,11 +5914,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 8 is word-addressing for f64s
-        let r = _mm256_i32gather_pd(
-            arr.as_ptr(),
-            _mm_setr_epi32(0, 16, 32, 48),
-            8,
-        );
+        let r = _mm256_i32gather_pd(arr.as_ptr(), _mm_setr_epi32(0, 16, 32, 48), 8);
         assert_eq_m256d(r, _mm256_setr_pd(0.0, 16.0, 32.0, 48.0));
     }
 
@@ -6035,11 +5972,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 4 is word-addressing
-        let r = _mm256_i64gather_epi32(
-            arr.as_ptr(),
-            _mm256_setr_epi64x(0, 16, 32, 48),
-            4,
-        );
+        let r = _mm256_i64gather_epi32(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48), 4);
         assert_eq_m128i(r, _mm_setr_epi32(0, 16, 32, 48));
     }
 
@@ -6101,11 +6034,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 4 is word-addressing for f32s
-        let r = _mm256_i64gather_ps(
-            arr.as_ptr(),
-            _mm256_setr_epi64x(0, 16, 32, 48),
-            4,
-        );
+        let r = _mm256_i64gather_ps(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48), 4);
         assert_eq_m128(r, _mm_setr_ps(0.0, 16.0, 32.0, 48.0));
     }
 
@@ -6163,11 +6092,7 @@ mod tests {
             arr[i as usize] = i;
         }
         // A multiplier of 8 is word-addressing for i64s
-        let r = _mm256_i64gather_epi64(
-            arr.as_ptr(),
-            _mm256_setr_epi64x(0, 16, 32, 48),
-            8,
-        );
+        let r = _mm256_i64gather_epi64(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48), 8);
         assert_eq_m256i(r, _mm256_setr_epi64x(0, 16, 32, 48));
     }
 
@@ -6229,11 +6154,7 @@ mod tests {
             j += 1.0;
         }
         // A multiplier of 8 is word-addressing for f64s
-        let r = _mm256_i64gather_pd(
-            arr.as_ptr(),
-            _mm256_setr_epi64x(0, 16, 32, 48),
-            8,
-        );
+        let r = _mm256_i64gather_pd(arr.as_ptr(), _mm256_setr_epi64x(0, 16, 32, 48), 8);
         assert_eq_m256d(r, _mm256_setr_pd(0.0, 16.0, 32.0, 48.0));
     }
 

--- a/coresimd/x86/fma.rs
+++ b/coresimd/x86/fma.rs
@@ -121,9 +121,7 @@ pub unsafe fn _mm_fmaddsub_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[target_feature(enable = "fma")]
 #[cfg_attr(test, assert_instr(vfmaddsub))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_fmaddsub_pd(
-    a: __m256d, b: __m256d, c: __m256d,
-) -> __m256d {
+pub unsafe fn _mm256_fmaddsub_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
     vfmaddsubpd256(a, b, c)
 }
 
@@ -251,9 +249,7 @@ pub unsafe fn _mm_fmsubadd_pd(a: __m128d, b: __m128d, c: __m128d) -> __m128d {
 #[target_feature(enable = "fma")]
 #[cfg_attr(test, assert_instr(vfmsubadd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm256_fmsubadd_pd(
-    a: __m256d, b: __m256d, c: __m256d,
-) -> __m256d {
+pub unsafe fn _mm256_fmsubadd_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
     vfmsubaddpd256(a, b, c)
 }
 

--- a/coresimd/x86/macros.rs
+++ b/coresimd/x86/macros.rs
@@ -94,11 +94,16 @@ macro_rules! constify_imm2 {
 
 #[cfg(test)]
 macro_rules! assert_approx_eq {
-    ($a:expr, $b:expr, $eps:expr) => ({
+    ($a:expr, $b:expr, $eps:expr) => {{
         let (a, b) = (&$a, &$b);
-        assert!((*a - *b).abs() < $eps,
-                "assertion failed: `(left !== right)` \
-                           (left: `{:?}`, right: `{:?}`, expect diff: `{:?}`, real diff: `{:?}`)",
-                 *a, *b, $eps, (*a - *b).abs());
-    })
+        assert!(
+            (*a - *b).abs() < $eps,
+            "assertion failed: `(left !== right)` \
+             (left: `{:?}`, right: `{:?}`, expect diff: `{:?}`, real diff: `{:?}`)",
+            *a,
+            *b,
+            $eps,
+            (*a - *b).abs()
+        );
+    }};
 }

--- a/coresimd/x86/mmx.rs
+++ b/coresimd/x86/mmx.rs
@@ -379,9 +379,7 @@ pub unsafe fn _mm_set_pi32(e1: i32, e0: i32) -> __m64 {
 /// Set packed 8-bit integers in dst with the supplied values.
 #[inline]
 #[target_feature(enable = "mmx")]
-pub unsafe fn _mm_set_pi8(
-    e7: i8, e6: i8, e5: i8, e4: i8, e3: i8, e2: i8, e1: i8, e0: i8,
-) -> __m64 {
+pub unsafe fn _mm_set_pi8(e7: i8, e6: i8, e5: i8, e4: i8, e3: i8, e2: i8, e1: i8, e0: i8) -> __m64 {
     _mm_setr_pi8(e0, e1, e2, e3, e4, e5, e6, e7)
 }
 
@@ -426,7 +424,14 @@ pub unsafe fn _mm_setr_pi32(e0: i32, e1: i32) -> __m64 {
 #[inline]
 #[target_feature(enable = "mmx")]
 pub unsafe fn _mm_setr_pi8(
-    e0: i8, e1: i8, e2: i8, e3: i8, e4: i8, e5: i8, e6: i8, e7: i8,
+    e0: i8,
+    e1: i8,
+    e2: i8,
+    e3: i8,
+    e4: i8,
+    e5: i8,
+    e6: i8,
+    e7: i8,
 ) -> __m64 {
     mem::transmute(i8x8::new(e0, e1, e2, e3, e4, e5, e6, e7))
 }
@@ -508,14 +513,8 @@ mod tests {
     #[simd_test(enable = "mmx")]
     unsafe fn test_mm_add_pi16() {
         let a = _mm_setr_pi16(-1, -1, 1, 1);
-        let b = _mm_setr_pi16(
-            i16::min_value() + 1,
-            30001,
-            -30001,
-            i16::max_value() - 1,
-        );
-        let e =
-            _mm_setr_pi16(i16::min_value(), 30000, -30000, i16::max_value());
+        let b = _mm_setr_pi16(i16::min_value() + 1, 30001, -30001, i16::max_value() - 1);
+        let e = _mm_setr_pi16(i16::min_value(), 30000, -30000, i16::max_value());
         assert_eq_m64(e, _mm_add_pi16(a, b));
         assert_eq_m64(e, _m_paddw(a, b));
     }
@@ -533,8 +532,7 @@ mod tests {
     unsafe fn test_mm_adds_pi8() {
         let a = _mm_setr_pi8(-100, -1, 1, 100, -1, 0, 1, 0);
         let b = _mm_setr_pi8(-100, 1, -1, 100, 0, -1, 0, 1);
-        let e =
-            _mm_setr_pi8(i8::min_value(), 0, 0, i8::max_value(), -1, -1, 1, 1);
+        let e = _mm_setr_pi8(i8::min_value(), 0, 0, i8::max_value(), -1, -1, 1, 1);
         assert_eq_m64(e, _mm_adds_pi8(a, b));
         assert_eq_m64(e, _m_paddsb(a, b));
     }

--- a/coresimd/x86/pclmulqdq.rs
+++ b/coresimd/x86/pclmulqdq.rs
@@ -25,31 +25,14 @@ extern "C" {
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_clmulepi64_si128)
 #[inline]
 #[target_feature(enable = "pclmulqdq")]
-#[cfg_attr(
-    all(test, not(target_os = "linux")),
-    assert_instr(pclmulqdq, imm8 = 0)
-)]
-#[cfg_attr(
-    all(test, target_os = "linux"),
-    assert_instr(pclmullqlqdq, imm8 = 0)
-)]
-#[cfg_attr(
-    all(test, target_os = "linux"),
-    assert_instr(pclmulhqlqdq, imm8 = 1)
-)]
-#[cfg_attr(
-    all(test, target_os = "linux"),
-    assert_instr(pclmullqhqdq, imm8 = 16)
-)]
-#[cfg_attr(
-    all(test, target_os = "linux"),
-    assert_instr(pclmulhqhqdq, imm8 = 17)
-)]
+#[cfg_attr(all(test, not(target_os = "linux")), assert_instr(pclmulqdq, imm8 = 0))]
+#[cfg_attr(all(test, target_os = "linux"), assert_instr(pclmullqlqdq, imm8 = 0))]
+#[cfg_attr(all(test, target_os = "linux"), assert_instr(pclmulhqlqdq, imm8 = 1))]
+#[cfg_attr(all(test, target_os = "linux"), assert_instr(pclmullqhqdq, imm8 = 16))]
+#[cfg_attr(all(test, target_os = "linux"), assert_instr(pclmulhqhqdq, imm8 = 17))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_clmulepi64_si128(
-    a: __m128i, b: __m128i, imm8: i32,
-) -> __m128i {
+pub unsafe fn _mm_clmulepi64_si128(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     macro_rules! call {
         ($imm8:expr) => {
             pclmulqdq(a, b, $imm8)

--- a/coresimd/x86/sha.rs
+++ b/coresimd/x86/sha.rs
@@ -74,9 +74,7 @@ pub unsafe fn _mm_sha1nexte_epu32(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(sha1rnds4, func = 0))]
 #[rustc_args_required_const(2)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_sha1rnds4_epu32(
-    a: __m128i, b: __m128i, func: i32,
-) -> __m128i {
+pub unsafe fn _mm_sha1rnds4_epu32(a: __m128i, b: __m128i, func: i32) -> __m128i {
     let a = a.as_i32x4();
     let b = b.as_i32x4();
     macro_rules! call {
@@ -125,9 +123,7 @@ pub unsafe fn _mm_sha256msg2_epu32(a: __m128i, b: __m128i) -> __m128i {
 #[target_feature(enable = "sha")]
 #[cfg_attr(test, assert_instr(sha256rnds2))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_sha256rnds2_epu32(
-    a: __m128i, b: __m128i, k: __m128i,
-) -> __m128i {
+pub unsafe fn _mm_sha256rnds2_epu32(a: __m128i, b: __m128i, k: __m128i) -> __m128i {
     mem::transmute(sha256rnds2(a.as_i32x4(), b.as_i32x4(), k.as_i32x4()))
 }
 

--- a/coresimd/x86/sse.rs
+++ b/coresimd/x86/sse.rs
@@ -1962,7 +1962,10 @@ pub unsafe fn _mm_undefined_ps() -> __m128 {
 #[target_feature(enable = "sse")]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _MM_TRANSPOSE4_PS(
-    row0: &mut __m128, row1: &mut __m128, row2: &mut __m128, row3: &mut __m128,
+    row0: &mut __m128,
+    row1: &mut __m128,
+    row2: &mut __m128,
+    row3: &mut __m128,
 ) {
     let tmp0 = _mm_unpacklo_ps(*row0, *row1);
     let tmp2 = _mm_unpacklo_ps(*row2, *row3);
@@ -2768,8 +2771,7 @@ mod tests {
 
         let b2 = _mm_setr_ps(1.0, 5.0, 6.0, 7.0);
         let r2: u32x4 = transmute(_mm_cmpeq_ss(a, b2));
-        let e2: u32x4 =
-            transmute(_mm_setr_ps(transmute(0xffffffffu32), 2.0, 3.0, 4.0));
+        let e2: u32x4 = transmute(_mm_setr_ps(transmute(0xffffffffu32), 2.0, 3.0, 4.0));
         assert_eq!(r2, e2);
     }
 
@@ -3484,8 +3486,7 @@ mod tests {
     #[simd_test(enable = "sse")]
     unsafe fn test_mm_cvtss_si32() {
         let inputs = &[42.0f32, -3.1, 4.0e10, 4.0e-20, NAN, 2147483500.1];
-        let result =
-            &[42i32, -3, i32::min_value(), 0, i32::min_value(), 2147483520];
+        let result = &[42i32, -3, i32::min_value(), 0, i32::min_value(), 2147483520];
         for i in 0..inputs.len() {
             let x = _mm_setr_ps(inputs[i], 1.0, 3.0, 4.0);
             let e = result[i];
@@ -3696,8 +3697,7 @@ mod tests {
         }
 
         let r = _mm_load_ps(p);
-        let e =
-            _mm_add_ps(_mm_setr_ps(1.0, 2.0, 3.0, 4.0), _mm_set1_ps(fixup));
+        let e = _mm_add_ps(_mm_setr_ps(1.0, 2.0, 3.0, 4.0), _mm_set1_ps(fixup));
         assert_eq_m128(r, e);
     }
 
@@ -3727,8 +3727,7 @@ mod tests {
         }
 
         let r = _mm_loadr_ps(p);
-        let e =
-            _mm_add_ps(_mm_setr_ps(4.0, 3.0, 2.0, 1.0), _mm_set1_ps(fixup));
+        let e = _mm_add_ps(_mm_setr_ps(4.0, 3.0, 2.0, 1.0), _mm_set1_ps(fixup));
         assert_eq_m128(r, e);
     }
 
@@ -3978,8 +3977,7 @@ mod tests {
     #[simd_test(enable = "sse,mmx")]
     unsafe fn test_mm_stream_pi() {
         let a = transmute(i8x8::new(0, 0, 0, 0, 0, 0, 0, 7));
-        let mut mem =
-            ::std::boxed::Box::<__m64>::new(transmute(i8x8::splat(1)));
+        let mut mem = ::std::boxed::Box::<__m64>::new(transmute(i8x8::splat(1)));
         _mm_stream_pi(&mut *mem as *mut _ as *mut _, a);
         assert_eq_m64(a, *mem);
     }
@@ -4175,8 +4173,7 @@ mod tests {
 
     #[simd_test(enable = "sse,mmx")]
     unsafe fn test_mm_movemask_pi8() {
-        let a =
-            _mm_setr_pi16(0b1000_0000, 0b0100_0000, 0b1000_0000, 0b0100_0000);
+        let a = _mm_setr_pi16(0b1000_0000, 0b0100_0000, 0b1000_0000, 0b0100_0000);
         let r = _mm_movemask_pi8(a);
         assert_eq!(r, 0b10001);
 

--- a/coresimd/x86/sse2.rs
+++ b/coresimd/x86/sse2.rs
@@ -1010,7 +1010,14 @@ pub unsafe fn _mm_set_epi32(e3: i32, e2: i32, e1: i32, e0: i32) -> __m128i {
 // no particular instruction to test
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_set_epi16(
-    e7: i16, e6: i16, e5: i16, e4: i16, e3: i16, e2: i16, e1: i16, e0: i16,
+    e7: i16,
+    e6: i16,
+    e5: i16,
+    e4: i16,
+    e3: i16,
+    e2: i16,
+    e1: i16,
+    e0: i16,
 ) -> __m128i {
     mem::transmute(i16x8::new(e0, e1, e2, e3, e4, e5, e6, e7))
 }
@@ -1023,8 +1030,22 @@ pub unsafe fn _mm_set_epi16(
 // no particular instruction to test
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_set_epi8(
-    e15: i8, e14: i8, e13: i8, e12: i8, e11: i8, e10: i8, e9: i8, e8: i8,
-    e7: i8, e6: i8, e5: i8, e4: i8, e3: i8, e2: i8, e1: i8, e0: i8,
+    e15: i8,
+    e14: i8,
+    e13: i8,
+    e12: i8,
+    e11: i8,
+    e10: i8,
+    e9: i8,
+    e8: i8,
+    e7: i8,
+    e6: i8,
+    e5: i8,
+    e4: i8,
+    e3: i8,
+    e2: i8,
+    e1: i8,
+    e0: i8,
 ) -> __m128i {
     #[rustfmt::skip]
     mem::transmute(i8x16::new(
@@ -1095,7 +1116,14 @@ pub unsafe fn _mm_setr_epi32(e3: i32, e2: i32, e1: i32, e0: i32) -> __m128i {
 // no particular instruction to test
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_setr_epi16(
-    e7: i16, e6: i16, e5: i16, e4: i16, e3: i16, e2: i16, e1: i16, e0: i16,
+    e7: i16,
+    e6: i16,
+    e5: i16,
+    e4: i16,
+    e3: i16,
+    e2: i16,
+    e1: i16,
+    e0: i16,
 ) -> __m128i {
     _mm_set_epi16(e0, e1, e2, e3, e4, e5, e6, e7)
 }
@@ -1108,8 +1136,22 @@ pub unsafe fn _mm_setr_epi16(
 // no particular instruction to test
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_setr_epi8(
-    e15: i8, e14: i8, e13: i8, e12: i8, e11: i8, e10: i8, e9: i8, e8: i8,
-    e7: i8, e6: i8, e5: i8, e4: i8, e3: i8, e2: i8, e1: i8, e0: i8,
+    e15: i8,
+    e14: i8,
+    e13: i8,
+    e12: i8,
+    e11: i8,
+    e10: i8,
+    e9: i8,
+    e8: i8,
+    e7: i8,
+    e6: i8,
+    e5: i8,
+    e4: i8,
+    e3: i8,
+    e2: i8,
+    e1: i8,
+    e0: i8,
 ) -> __m128i {
     #[rustfmt::skip]
     _mm_set_epi8(
@@ -1194,9 +1236,7 @@ pub unsafe fn _mm_loadu_si128(mem_addr: *const __m128i) -> __m128i {
 #[target_feature(enable = "sse2")]
 #[cfg_attr(test, assert_instr(maskmovdqu))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_maskmoveu_si128(
-    a: __m128i, mask: __m128i, mem_addr: *mut i8,
-) {
+pub unsafe fn _mm_maskmoveu_si128(a: __m128i, mask: __m128i, mem_addr: *mut i8) {
     maskmovdqu(a.as_i8x16(), mask.as_i8x16(), mem_addr)
 }
 
@@ -1245,11 +1285,7 @@ pub unsafe fn _mm_storeu_si128(mem_addr: *mut __m128i, a: __m128i) {
 )]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_storel_epi64(mem_addr: *mut __m128i, a: __m128i) {
-    ptr::copy_nonoverlapping(
-        &a as *const _ as *const u8,
-        mem_addr as *mut u8,
-        8,
-    );
+    ptr::copy_nonoverlapping(&a as *const _ as *const u8, mem_addr as *mut u8, 8);
 }
 
 /// Stores a 128-bit integer vector to a 128-bit aligned memory location.
@@ -1285,10 +1321,7 @@ pub unsafe fn _mm_stream_si32(mem_addr: *mut i32, a: i32) {
 #[inline]
 #[target_feature(enable = "sse2")]
 // FIXME movd on windows, movd on i686
-#[cfg_attr(
-    all(test, not(windows), target_arch = "x86_64"),
-    assert_instr(movq)
-)]
+#[cfg_attr(all(test, not(windows), target_arch = "x86_64"), assert_instr(movq))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_move_epi64(a: __m128i) -> __m128i {
     let zero = _mm_setzero_si128();
@@ -1448,11 +1481,7 @@ pub unsafe fn _mm_shufflehi_epi16(a: __m128i, imm8: i32) -> __m128i {
     let a = a.as_i16x8();
     macro_rules! shuffle_done {
         ($x01:expr, $x23:expr, $x45:expr, $x67:expr) => {
-            simd_shuffle8(
-                a,
-                a,
-                [0, 1, 2, 3, $x01 + 4, $x23 + 4, $x45 + 4, $x67 + 4],
-            )
+            simd_shuffle8(a, a, [0, 1, 2, 3, $x01 + 4, $x23 + 4, $x45 + 4, $x67 + 4])
         };
     }
     macro_rules! shuffle_x67 {
@@ -1578,11 +1607,7 @@ pub unsafe fn _mm_unpackhi_epi8(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(punpckhwd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_epi16(a: __m128i, b: __m128i) -> __m128i {
-    let x = simd_shuffle8(
-        a.as_i16x8(),
-        b.as_i16x8(),
-        [4, 12, 5, 13, 6, 14, 7, 15],
-    );
+    let x = simd_shuffle8(a.as_i16x8(), b.as_i16x8(), [4, 12, 5, 13, 6, 14, 7, 15]);
     mem::transmute::<i16x8, _>(x)
 }
 
@@ -1594,11 +1619,7 @@ pub unsafe fn _mm_unpackhi_epi16(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(unpckhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_epi32(a: __m128i, b: __m128i) -> __m128i {
-    mem::transmute::<i32x4, _>(simd_shuffle4(
-        a.as_i32x4(),
-        b.as_i32x4(),
-        [2, 6, 3, 7],
-    ))
+    mem::transmute::<i32x4, _>(simd_shuffle4(a.as_i32x4(), b.as_i32x4(), [2, 6, 3, 7]))
 }
 
 /// Unpack and interleave 64-bit integers from the high half of `a` and `b`.
@@ -1609,11 +1630,7 @@ pub unsafe fn _mm_unpackhi_epi32(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(unpckhpd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpackhi_epi64(a: __m128i, b: __m128i) -> __m128i {
-    mem::transmute::<i64x2, _>(simd_shuffle2(
-        a.as_i64x2(),
-        b.as_i64x2(),
-        [1, 3],
-    ))
+    mem::transmute::<i64x2, _>(simd_shuffle2(a.as_i64x2(), b.as_i64x2(), [1, 3]))
 }
 
 /// Unpack and interleave 8-bit integers from the low half of `a` and `b`.
@@ -1639,8 +1656,7 @@ pub unsafe fn _mm_unpacklo_epi8(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(punpcklwd))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_epi16(a: __m128i, b: __m128i) -> __m128i {
-    let x =
-        simd_shuffle8(a.as_i16x8(), b.as_i16x8(), [0, 8, 1, 9, 2, 10, 3, 11]);
+    let x = simd_shuffle8(a.as_i16x8(), b.as_i16x8(), [0, 8, 1, 9, 2, 10, 3, 11]);
     mem::transmute::<i16x8, _>(x)
 }
 
@@ -1652,11 +1668,7 @@ pub unsafe fn _mm_unpacklo_epi16(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(test, assert_instr(unpcklps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_epi32(a: __m128i, b: __m128i) -> __m128i {
-    mem::transmute::<i32x4, _>(simd_shuffle4(
-        a.as_i32x4(),
-        b.as_i32x4(),
-        [0, 4, 1, 5],
-    ))
+    mem::transmute::<i32x4, _>(simd_shuffle4(a.as_i32x4(), b.as_i32x4(), [0, 4, 1, 5]))
 }
 
 /// Unpack and interleave 64-bit integers from the low half of `a` and `b`.
@@ -1667,11 +1679,7 @@ pub unsafe fn _mm_unpacklo_epi32(a: __m128i, b: __m128i) -> __m128i {
 #[cfg_attr(all(test, not(target_os = "windows")), assert_instr(movlhps))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_unpacklo_epi64(a: __m128i, b: __m128i) -> __m128i {
-    mem::transmute::<i64x2, _>(simd_shuffle2(
-        a.as_i64x2(),
-        b.as_i64x2(),
-        [0, 2],
-    ))
+    mem::transmute::<i64x2, _>(simd_shuffle2(a.as_i64x2(), b.as_i64x2(), [0, 2]))
 }
 
 /// Return a new vector with the low element of `a` replaced by the sum of the
@@ -3207,9 +3215,7 @@ mod tests {
 
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_add_epi8() {
-        let a = _mm_setr_epi8(
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        );
+        let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let b = _mm_setr_epi8(
             16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -3259,9 +3265,7 @@ mod tests {
 
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_adds_epi8() {
-        let a = _mm_setr_epi8(
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        );
+        let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let b = _mm_setr_epi8(
             16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -3317,9 +3321,7 @@ mod tests {
 
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_adds_epu8() {
-        let a = _mm_setr_epi8(
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        );
+        let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         #[rustfmt::skip]
         let b = _mm_setr_epi8(
             16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -3568,9 +3570,7 @@ mod tests {
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
         );
         let r = _mm_slli_si128(a, 1);
-        let e = _mm_setr_epi8(
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        );
+        let e = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         assert_eq_m128i(r, e);
 
         #[rustfmt::skip]
@@ -3812,11 +3812,8 @@ mod tests {
 
     #[simd_test(enable = "sse2")]
     unsafe fn test_mm_cmpeq_epi8() {
-        let a = _mm_setr_epi8(
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-        );
-        let b =
-            _mm_setr_epi8(15, 14, 2, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+        let a = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+        let b = _mm_setr_epi8(15, 14, 2, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
         let r = _mm_cmpeq_epi8(a, b);
         #[rustfmt::skip]
         assert_eq_m128i(
@@ -4908,10 +4905,7 @@ mod tests {
         assert_eq_m128(r, _mm_setr_ps(-1.0, -5.0, 0.0, 0.0));
 
         let r = _mm_cvtpd_ps(_mm_setr_pd(f64::MAX, f64::MIN));
-        assert_eq_m128(
-            r,
-            _mm_setr_ps(f32::INFINITY, f32::NEG_INFINITY, 0.0, 0.0),
-        );
+        assert_eq_m128(r, _mm_setr_ps(f32::INFINITY, f32::NEG_INFINITY, 0.0, 0.0));
 
         let r = _mm_cvtpd_ps(_mm_setr_pd(f32::MAX as f64, f32::MIN as f64));
         assert_eq_m128(r, _mm_setr_ps(f32::MAX, f32::MIN, 0.0, 0.0));
@@ -4970,8 +4964,7 @@ mod tests {
 
         assert_eq_m128(r, _mm_setr_ps(2.0, -2.2, 3.3, 4.4));
 
-        let a =
-            _mm_setr_ps(-1.1, f32::NEG_INFINITY, f32::MAX, f32::NEG_INFINITY);
+        let a = _mm_setr_ps(-1.1, f32::NEG_INFINITY, f32::MAX, f32::NEG_INFINITY);
         let b = _mm_setr_pd(f64::INFINITY, -5.0);
 
         let r = _mm_cvtsd_ss(a, b);
@@ -5036,13 +5029,9 @@ mod tests {
         let r = _mm_cvttps_epi32(a);
         assert_eq_m128i(r, _mm_setr_epi32(-1, 2, -3, 6));
 
-        let a =
-            _mm_setr_ps(f32::NEG_INFINITY, f32::INFINITY, f32::MIN, f32::MAX);
+        let a = _mm_setr_ps(f32::NEG_INFINITY, f32::INFINITY, f32::MIN, f32::MAX);
         let r = _mm_cvttps_epi32(a);
-        assert_eq_m128i(
-            r,
-            _mm_setr_epi32(i32::MIN, i32::MIN, i32::MIN, i32::MIN),
-        );
+        assert_eq_m128i(r, _mm_setr_epi32(i32::MIN, i32::MIN, i32::MIN, i32::MIN));
     }
 
     #[simd_test(enable = "sse2")]

--- a/coresimd/x86/sse41.rs
+++ b/coresimd/x86/sse41.rs
@@ -35,24 +35,20 @@ pub const _MM_FROUND_NO_EXC: i32 = 0x08;
 pub const _MM_FROUND_NINT: i32 = 0x00;
 /// round down and do not suppress exceptions
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_FLOOR: i32 =
-    (_MM_FROUND_RAISE_EXC | _MM_FROUND_TO_NEG_INF);
+pub const _MM_FROUND_FLOOR: i32 = (_MM_FROUND_RAISE_EXC | _MM_FROUND_TO_NEG_INF);
 /// round up and do not suppress exceptions
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_CEIL: i32 =
-    (_MM_FROUND_RAISE_EXC | _MM_FROUND_TO_POS_INF);
+pub const _MM_FROUND_CEIL: i32 = (_MM_FROUND_RAISE_EXC | _MM_FROUND_TO_POS_INF);
 /// truncate and do not suppress exceptions
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub const _MM_FROUND_TRUNC: i32 = (_MM_FROUND_RAISE_EXC | _MM_FROUND_TO_ZERO);
 /// use MXCSR.RC and do not suppress exceptions; see
 /// `vendor::_MM_SET_ROUNDING_MODE`
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_RINT: i32 =
-    (_MM_FROUND_RAISE_EXC | _MM_FROUND_CUR_DIRECTION);
+pub const _MM_FROUND_RINT: i32 = (_MM_FROUND_RAISE_EXC | _MM_FROUND_CUR_DIRECTION);
 /// use MXCSR.RC and suppress exceptions; see `vendor::_MM_SET_ROUNDING_MODE`
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub const _MM_FROUND_NEARBYINT: i32 =
-    (_MM_FROUND_NO_EXC | _MM_FROUND_CUR_DIRECTION);
+pub const _MM_FROUND_NEARBYINT: i32 = (_MM_FROUND_NO_EXC | _MM_FROUND_CUR_DIRECTION);
 
 /// Blend packed 8-bit integers from `a` and `b` using `mask`
 ///
@@ -65,9 +61,7 @@ pub const _MM_FROUND_NEARBYINT: i32 =
 #[target_feature(enable = "sse4.1")]
 #[cfg_attr(test, assert_instr(pblendvb))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_blendv_epi8(
-    a: __m128i, b: __m128i, mask: __m128i,
-) -> __m128i {
+pub unsafe fn _mm_blendv_epi8(a: __m128i, b: __m128i, mask: __m128i) -> __m128i {
     mem::transmute(pblendvb(a.as_i8x16(), b.as_i8x16(), mask.as_i8x16()))
 }
 
@@ -1775,10 +1769,7 @@ mod tests {
             assert_eq_m128i(r, e);
         }
         {
-            let a = _mm_setr_epi32(
-                15, 2, /* ignored */
-                1234567, 4, /* ignored */
-            );
+            let a = _mm_setr_epi32(15, 2 /* ignored */, 1234567, 4 /* ignored */);
             let b = _mm_setr_epi32(
                 -20, -256, /* ignored */
                 666666, 666666, /* ignored */

--- a/coresimd/x86/sse42.rs
+++ b/coresimd/x86/sse42.rs
@@ -438,9 +438,7 @@ pub unsafe fn _mm_cmpistra(a: __m128i, b: __m128i, imm8: i32) -> i32 {
 #[cfg_attr(test, assert_instr(pcmpestrm, imm8 = 0))]
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestrm(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32,
-) -> __m128i {
+pub unsafe fn _mm_cmpestrm(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32) -> __m128i {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
@@ -543,9 +541,7 @@ pub unsafe fn _mm_cmpestrm(
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestri(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32,
-) -> i32 {
+pub unsafe fn _mm_cmpestri(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
@@ -566,9 +562,7 @@ pub unsafe fn _mm_cmpestri(
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestrz(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32,
-) -> i32 {
+pub unsafe fn _mm_cmpestrz(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
@@ -589,9 +583,7 @@ pub unsafe fn _mm_cmpestrz(
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestrc(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32,
-) -> i32 {
+pub unsafe fn _mm_cmpestrc(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
@@ -612,9 +604,7 @@ pub unsafe fn _mm_cmpestrc(
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestrs(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32,
-) -> i32 {
+pub unsafe fn _mm_cmpestrs(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
@@ -635,9 +625,7 @@ pub unsafe fn _mm_cmpestrs(
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestro(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32,
-) -> i32 {
+pub unsafe fn _mm_cmpestro(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
@@ -659,9 +647,7 @@ pub unsafe fn _mm_cmpestro(
 #[cfg_attr(test, assert_instr(pcmpestri, imm8 = 0))]
 #[rustc_args_required_const(4)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _mm_cmpestra(
-    a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32,
-) -> i32 {
+pub unsafe fn _mm_cmpestra(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i32) -> i32 {
     let a = a.as_i8x16();
     let b = b.as_i8x16();
     macro_rules! call {
@@ -917,8 +903,7 @@ mod tests {
     unsafe fn test_mm_cmpestra() {
         let a = str_to_m128i(b"Cannot match a");
         let b = str_to_m128i(b"Null after 14");
-        let i =
-            _mm_cmpestra(a, 14, b, 16, _SIDD_CMP_EQUAL_EACH | _SIDD_UNIT_MASK);
+        let i = _mm_cmpestra(a, 14, b, 16, _SIDD_CMP_EQUAL_EACH | _SIDD_UNIT_MASK);
         assert_eq!(1, i);
     }
 
@@ -951,9 +936,6 @@ mod tests {
         let a = _mm_setr_epi64x(0, 0x2a);
         let b = _mm_set1_epi64x(0x00);
         let i = _mm_cmpgt_epi64(a, b);
-        assert_eq_m128i(
-            i,
-            _mm_setr_epi64x(0x00, 0xffffffffffffffffu64 as i64),
-        );
+        assert_eq_m128i(i, _mm_setr_epi64x(0x00, 0xffffffffffffffffu64 as i64));
     }
 }

--- a/coresimd/x86/ssse3.rs
+++ b/coresimd/x86/ssse3.rs
@@ -596,8 +596,7 @@ mod tests {
             12, 5, 5, 10,
             4, 1, 8, 0,
         );
-        let expected =
-            _mm_setr_epi8(5, 0, 5, 4, 9, 13, 7, 4, 13, 6, 6, 11, 5, 2, 9, 1);
+        let expected = _mm_setr_epi8(5, 0, 5, 4, 9, 13, 7, 4, 13, 6, 6, 11, 5, 2, 9, 1);
         let r = _mm_shuffle_epi8(a, b);
         assert_eq_m128i(r, expected);
     }

--- a/coresimd/x86/test.rs
+++ b/coresimd/x86/test.rs
@@ -120,9 +120,7 @@ mod x86_polyfill {
     }
 
     #[target_feature(enable = "avx2")]
-    pub unsafe fn _mm256_insert_epi64(
-        a: __m256i, val: i64, idx: i32,
-    ) -> __m256i {
+    pub unsafe fn _mm256_insert_epi64(a: __m256i, val: i64, idx: i32) -> __m256i {
         union A {
             a: __m256i,
             b: [i64; 4],

--- a/coresimd/x86_64/sse41.rs
+++ b/coresimd/x86_64/sse41.rs
@@ -12,10 +12,7 @@ use stdsimd_test::assert_instr;
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_extract_epi64)
 #[inline]
 #[target_feature(enable = "sse4.1")]
-#[cfg_attr(
-    all(test, not(target_os = "windows")),
-    assert_instr(pextrq, imm8 = 1)
-)]
+#[cfg_attr(all(test, not(target_os = "windows")), assert_instr(pextrq, imm8 = 1))]
 #[rustc_args_required_const(1)]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mm_extract_epi64(a: __m128i, imm8: i32) -> i64 {

--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -19,12 +19,11 @@ use quote::ToTokens;
 
 #[proc_macro_attribute]
 pub fn assert_instr(
-    attr: proc_macro::TokenStream, item: proc_macro::TokenStream,
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let invoc = syn::parse::<Invoc>(attr)
-        .expect("expected #[assert_instr(instr, a = b, ...)]");
-    let item =
-        syn::parse::<syn::Item>(item).expect("must be attached to an item");
+    let invoc = syn::parse::<Invoc>(attr).expect("expected #[assert_instr(instr, a = b, ...)]");
+    let item = syn::parse::<syn::Item>(item).expect("must be attached to an item");
     let func = match item {
         syn::Item::Fn(ref f) => f,
         _ => panic!("must be attached to a function"),
@@ -36,16 +35,12 @@ pub fn assert_instr(
     // Disable assert_instr for x86 targets compiled with avx enabled, which
     // causes LLVM to generate different intrinsics that the ones we are
     // testing for.
-    let disable_assert_instr =
-        std::env::var("STDSIMD_DISABLE_ASSERT_INSTR").is_ok();
+    let disable_assert_instr = std::env::var("STDSIMD_DISABLE_ASSERT_INSTR").is_ok();
 
     let instr_str = instr
         .replace('.', "_")
         .replace(|c: char| c.is_whitespace(), "");
-    let assert_name = syn::Ident::new(
-        &format!("assert_{}_{}", name, instr_str),
-        name.span(),
-    );
+    let assert_name = syn::Ident::new(&format!("assert_{}_{}", name, instr_str), name.span());
     let shim_name = syn::Ident::new(&format!("{}_shim", name), name.span());
     let mut inputs = Vec::new();
     let mut input_vals = Vec::new();
@@ -62,8 +57,7 @@ pub fn assert_instr(
             syn::Pat::Ident(ref i) => &i.ident,
             _ => panic!("must have bare arguments"),
         };
-        if let Some(&(_, ref tts)) = invoc.args.iter().find(|a| *ident == a.0)
-        {
+        if let Some(&(_, ref tts)) = invoc.args.iter().find(|a| *ident == a.0) {
             input_vals.push(quote! { #tts });
         } else {
             inputs.push(capture);
@@ -133,8 +127,7 @@ pub fn assert_instr(
         }
     };
     // why? necessary now to get tests to work?
-    let tts: TokenStream =
-        tts.to_string().parse().expect("cannot parse tokenstream");
+    let tts: TokenStream = tts.to_string().parse().expect("cannot parse tokenstream");
 
     let tts: TokenStream = quote! {
         #item

--- a/crates/coresimd/tests/cpu-detection.rs
+++ b/crates/coresimd/tests/cpu-detection.rs
@@ -2,11 +2,7 @@
 #![cfg_attr(stdsimd_strict, deny(warnings))]
 #![cfg_attr(
     feature = "cargo-clippy",
-    allow(
-        clippy::option_unwrap_used,
-        clippy::print_stdout,
-        clippy::use_debug
-    )
+    allow(clippy::option_unwrap_used, clippy::print_stdout, clippy::use_debug)
 )]
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/crates/simd-test-macro/src/lib.rs
+++ b/crates/simd-test-macro/src/lib.rs
@@ -18,7 +18,8 @@ fn string(s: &str) -> TokenTree {
 
 #[proc_macro_attribute]
 pub fn simd_test(
-    attr: proc_macro::TokenStream, item: proc_macro::TokenStream,
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let tokens = TokenStream::from(attr).into_iter().collect::<Vec<_>>();
     if tokens.len() != 3 {
@@ -49,16 +50,18 @@ pub fn simd_test(
     let item = TokenStream::from(item);
     let name = find_name(item.clone());
 
-    let name: TokenStream = name.to_string().parse().unwrap_or_else(|_| {
-        panic!("failed to parse name: {}", name.to_string())
-    });
+    let name: TokenStream = name
+        .to_string()
+        .parse()
+        .unwrap_or_else(|_| panic!("failed to parse name: {}", name.to_string()));
 
-    let target = env::var("TARGET")
-        .expect("TARGET environment variable should be set for rustc");
+    let target = env::var("TARGET").expect("TARGET environment variable should be set for rustc");
     let mut force_test = false;
-    let macro_test = match target.split('-').next().unwrap_or_else(|| {
-        panic!("target triple contained no \"-\": {}", target)
-    }) {
+    let macro_test = match target
+        .split('-')
+        .next()
+        .unwrap_or_else(|| panic!("target triple contained no \"-\": {}", target))
+    {
         "i686" | "x86_64" | "i586" => "is_x86_feature_detected",
         "arm" | "armv7" => "is_arm_feature_detected",
         "aarch64" => "is_aarch64_feature_detected",

--- a/crates/stdsimd-test/src/lib.rs
+++ b/crates/stdsimd-test/src/lib.rs
@@ -36,8 +36,7 @@ cfg_if! {
 }
 
 lazy_static! {
-    static ref DISASSEMBLY: HashMap<String, Vec<Function>> =
-        disassemble_myself();
+    static ref DISASSEMBLY: HashMap<String, Vec<Function>> = disassemble_myself();
 }
 
 struct Function {

--- a/crates/stdsimd-verify/src/lib.rs
+++ b/crates/stdsimd-verify/src/lib.rs
@@ -64,8 +64,7 @@ pub fn x86_functions(input: TokenStream) -> TokenStream {
                 }
             };
             let instrs = find_instrs(&f.attrs);
-            let target_feature = if let Some(i) = find_target_feature(&f.attrs)
-            {
+            let target_feature = if let Some(i) = find_target_feature(&f.attrs) {
                 quote! { Some(#i) }
             } else {
                 quote! { None }
@@ -92,30 +91,28 @@ pub fn x86_functions(input: TokenStream) -> TokenStream {
 
 fn to_type(t: &syn::Type) -> proc_macro2::TokenStream {
     match *t {
-        syn::Type::Path(ref p) => {
-            match extract_path_ident(&p.path).to_string().as_ref() {
-                "__m128" => quote! { &M128 },
-                "__m128d" => quote! { &M128D },
-                "__m128i" => quote! { &M128I },
-                "__m256" => quote! { &M256 },
-                "__m256d" => quote! { &M256D },
-                "__m256i" => quote! { &M256I },
-                "__m64" => quote! { &M64 },
-                "bool" => quote! { &BOOL },
-                "f32" => quote! { &F32 },
-                "f64" => quote! { &F64 },
-                "i16" => quote! { &I16 },
-                "i32" => quote! { &I32 },
-                "i64" => quote! { &I64 },
-                "i8" => quote! { &I8 },
-                "u16" => quote! { &U16 },
-                "u32" => quote! { &U32 },
-                "u64" => quote! { &U64 },
-                "u8" => quote! { &U8 },
-                "CpuidResult" => quote! { &CPUID },
-                s => panic!("unspported type: \"{}\"", s),
-            }
-        }
+        syn::Type::Path(ref p) => match extract_path_ident(&p.path).to_string().as_ref() {
+            "__m128" => quote! { &M128 },
+            "__m128d" => quote! { &M128D },
+            "__m128i" => quote! { &M128I },
+            "__m256" => quote! { &M256 },
+            "__m256d" => quote! { &M256D },
+            "__m256i" => quote! { &M256I },
+            "__m64" => quote! { &M64 },
+            "bool" => quote! { &BOOL },
+            "f32" => quote! { &F32 },
+            "f64" => quote! { &F64 },
+            "i16" => quote! { &I16 },
+            "i32" => quote! { &I32 },
+            "i64" => quote! { &I64 },
+            "i8" => quote! { &I8 },
+            "u16" => quote! { &U16 },
+            "u32" => quote! { &U32 },
+            "u64" => quote! { &U64 },
+            "u8" => quote! { &U8 },
+            "CpuidResult" => quote! { &CPUID },
+            s => panic!("unspported type: \"{}\"", s),
+        },
         syn::Type::Ptr(syn::TypePtr { ref elem, .. })
         | syn::Type::Reference(syn::TypeReference { ref elem, .. }) => {
             let tokens = to_type(&elem);
@@ -221,9 +218,7 @@ fn find_target_feature(attrs: &[syn::Attribute]) -> Option<syn::Lit> {
             syn::NestedMeta::Literal(_) => None,
         })
         .filter_map(|m| match m {
-            syn::Meta::NameValue(ref i) if i.ident == "enable" => {
-                Some(i.clone().lit)
-            }
+            syn::Meta::NameValue(ref i) if i.ident == "enable" => Some(i.clone().lit),
             _ => None,
         })
         .next()
@@ -249,15 +244,12 @@ struct RustcArgsRequiredConst {
 }
 
 impl syn::parse::Parse for RustcArgsRequiredConst {
-    #[cfg_attr(
-        feature = "cargo-clippy",
-        allow(clippy::cast_possible_truncation)
-    )]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_possible_truncation))]
     fn parse(input: syn::parse::ParseStream) -> syn::parse::Result<Self> {
         let content;
         parenthesized!(content in input);
-        let list = syn::punctuated::Punctuated::<syn::LitInt, Token![,]>
-            ::parse_terminated(&content)?;
+        let list =
+            syn::punctuated::Punctuated::<syn::LitInt, Token![,]>::parse_terminated(&content)?;
         Ok(Self {
             args: list.into_iter().map(|a| a.value() as usize).collect(),
         })

--- a/crates/stdsimd/tests/cpu-detection.rs
+++ b/crates/stdsimd/tests/cpu-detection.rs
@@ -2,11 +2,7 @@
 #![cfg_attr(stdsimd_strict, deny(warnings))]
 #![cfg_attr(
     feature = "cargo-clippy",
-    allow(
-        clippy::option_unwrap_used,
-        clippy::use_debug,
-        clippy::print_stdout
-    )
+    allow(clippy::option_unwrap_used, clippy::use_debug, clippy::print_stdout)
 )]
 
 #[cfg(any(
@@ -21,10 +17,7 @@
 extern crate stdsimd;
 
 #[test]
-#[cfg(all(
-    target_arch = "arm",
-    any(target_os = "linux", target_os = "android")
-))]
+#[cfg(all(target_arch = "arm", any(target_os = "linux", target_os = "android")))]
 fn arm_linux() {
     println!("neon: {}", is_arm_feature_detected!("neon"));
     println!("pmull: {}", is_arm_feature_detected!("pmull"));

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,0 @@
-max_width = 79
-wrap_comments = false
-error_on_line_overflow = false
-fn_args_density = "Compressed"

--- a/stdsimd/mod.rs
+++ b/stdsimd/mod.rs
@@ -387,10 +387,7 @@ pub mod arch {
     #[unstable(feature = "stdsimd", issue = "27731")]
     pub use coresimd::arch::powerpc64;
 
-    #[cfg(all(
-        not(dox),
-        any(target_arch = "nvptx", target_arch = "nvptx64")
-    ))]
+    #[cfg(all(not(dox), any(target_arch = "nvptx", target_arch = "nvptx64")))]
     #[unstable(feature = "stdsimd", issue = "27731")]
     pub use coresimd::arch::nvptx;
 


### PR DESCRIPTION
This commit switches CI to running `rustfmt` on the stable compiler (as
rustfmt is stable now!). Additionally it deletes `rustfmt.toml` to
ensure we're following the same style as the rest of the ecosystem.