### PR TITLE
Match clang for `_mm512_abs_epi32` intrinsics

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
 install:
   # Install rust, x86_64-pc-windows-msvc host
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly-2018-10-20
+  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%
   - rustc -vV

--- a/coresimd/simd_llvm.rs
+++ b/coresimd/simd_llvm.rs
@@ -49,6 +49,7 @@ extern "platform-intrinsic" {
     pub fn simd_reduce_any<T>(x: T) -> bool;
 
     pub fn simd_select<M, T>(m: M, a: T, b: T) -> T;
+    pub fn simd_select_bitmask<M, T>(m: M, a: T, b: T) -> T;
 
     pub fn simd_fmin<T>(a: T, b: T) -> T;
     pub fn simd_fmax<T>(a: T, b: T) -> T;


### PR DESCRIPTION
This commit updates stdsimd's codegen to match Clang's for the
`_mm512_abs_epi32` intrinsic (and masked versions) which doesn't use any
LLVM intrinsic calls, but rather raw SIMD operations.

These are built on top of the new `simd_select_bitmask` intrinsic
introduced recently to the compiler!