### PR TITLE
Add a build libcore-only nvptx64 test (using xargo)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,14 @@ matrix:
       script: ci/run.sh
     - name: "wasm32-unknown-unknown"
       env: TARGET=wasm32-unknown-unknown
+    - name: "nvptx64-nvidia-cuda - cross compiled, build libcore only"
+      env: TARGET=x86_64-unknown-linux-gnu CROSS_TARGET=nvptx64-nvidia-cuda-cross NORUN=1 NOSTD=1
+      install:
+        - travis_retry rustup target add $TARGET
+        - travis_retry rustup component add rust-src
+        - cargo install xargo
+        - xargo --version
+        - mkdir -p $HOME/.xargo
     - name: "thumbv6m-none-eabi - build libcore only"
       env: TARGET=thumbv6m-none-eabi NORUN=1 NOSTD=1
       script: ci/run.sh
@@ -103,7 +111,7 @@ matrix:
 install: travis_retry rustup target add $TARGET
 script:
   - cargo generate-lockfile
-  - ci/run-docker.sh $TARGET $FEATURES
+  - ci/run-docker.sh $TARGET $CROSS_TARGET $FEATURES
 
 notifications:
   email:

--- a/ci/cross/nvptx64-nvidia-cuda.json
+++ b/ci/cross/nvptx64-nvidia-cuda.json
@@ -1,0 +1,15 @@
+{
+  "arch": "nvptx64"
+, "cpu": "sm_35"
+, "data-layout": "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"
+, "linker": false
+, "linker-flavor": "ld"
+, "llvm-target": "nvptx64-nvidia-cuda"
+, "max-atomic-width": 0
+, "obj-is-bitcode": true
+, "os": "cuda"
+, "panic-strategy": "abort"
+, "target-c-int-width": "32"
+, "target-endian": "little"
+, "target-pointer-width": "64"
+}

--- a/ci/docker/nvptx64-nvidia-cuda-cross/Dockerfile
+++ b/ci/docker/nvptx64-nvidia-cuda-cross/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  gcc \
+  libc6-dev \
+  ca-certificates

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -18,7 +18,6 @@
     simd_ffi,
     asm,
     proc_macro_hygiene,
-    integer_atomics,
     stmt_expr_attributes,
     core_intrinsics,
     no_core,
@@ -37,6 +36,14 @@
     mips_target_feature,
     powerpc_target_feature,
     wasm_target_feature
+)]
+// NB: When running nvptx/nvptx64 cross tests, enabling "integer_atomics" yields
+// a compile-time error: 'unknown feature `integer_atomics`'. This ought to be
+// investigated further, but for now just disable "integer_atomics" so we can
+// run _some_ test for the nvptx/nvptx64 targets.
+#![cfg_attr(
+    not(any(target_arch = "nvptx", target_arch = "nvptx64")),
+    feature(integer_atomics)
 )]
 #![cfg_attr(test, feature(test, abi_vectorcall, untagged_unions))]
 #![cfg_attr(


### PR DESCRIPTION
This commit adds an nvptx64 build libcore-only test, using xargo. It involved some changes to the travis yml, as well as the CI run scripts. I use a $CROSS_TARGET env variable in the travis yml to force cross compilation on the host $TARGET.

This also disables the "integer_atomics" feature on nvptx/nvptx64. During debugging, I got a strange `unknown feature 'integer_atomics'` error (see bottom of this log: https://travis-ci.org/peterhj/stdsimd-nvptx/jobs/473037366). As the atomic int types aren't currently used w/ nvptx (although there do exist CUDA atomics on both integers and floating points, but they behave somewhat differently than the ones in sync::atomic), so I just disabled "integer_atomics" on the nvptx targets.