### PR TITLE
Remove usage of `platform-intrinsics` where `unadjusted` works

### DIFF
--- a/coresimd/x86/rdrand.rs
+++ b/coresimd/x86/rdrand.rs
@@ -2,10 +2,15 @@
 //! on-chip hardware random number generator which has been seeded by an
 //! on-chip entropy source.
 
-extern "platform-intrinsic" {
+#[allow(improper_ctypes)]
+extern "unadjusted" {
+    #[link_name = "llvm.x86.rdrand.16"]
     fn x86_rdrand16_step() -> (u16, i32);
+    #[link_name = "llvm.x86.rdrand.32"]
     fn x86_rdrand32_step() -> (u32, i32);
+    #[link_name = "llvm.x86.rdseed.16"]
     fn x86_rdseed16_step() -> (u16, i32);
+    #[link_name = "llvm.x86.rdseed.32"]
     fn x86_rdseed32_step() -> (u32, i32);
 }
 

--- a/coresimd/x86_64/rdrand.rs
+++ b/coresimd/x86_64/rdrand.rs
@@ -2,8 +2,11 @@
 //! on-chip hardware random number generator which has been seeded by an
 //! on-chip entropy source.
 
-extern "platform-intrinsic" {
+#[allow(improper_ctypes)]
+extern "unadjusted" {
+    #[link_name = "llvm.x86.rdrand.64"]
     fn x86_rdrand64_step() -> (u64, i32);
+    #[link_name = "llvm.x86.rdseed.64"]
     fn x86_rdseed64_step() -> (u64, i32);
 }
 

--- a/crates/coresimd/src/lib.rs
+++ b/crates/coresimd/src/lib.rs
@@ -36,7 +36,8 @@
     avx512_target_feature,
     mips_target_feature,
     powerpc_target_feature,
-    wasm_target_feature
+    wasm_target_feature,
+    abi_unadjusted
 )]
 // NB: When running nvptx/nvptx64 cross tests, enabling "integer_atomics" yields
 // a compile-time error: 'unknown feature `integer_atomics`'. This ought to be


### PR DESCRIPTION
As suggested [here]!

[here]: https://github.com/rust-lang/rust/pull/57048#issuecomment-449773525