### PR TITLE
Prepare the crates for doing releases 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,63 +3,15 @@ stdsimd - Rust's standard library SIMD components
 
 [![Travis-CI Status]][travis] [![Appveyor Status]][appveyor] [![Latest Version]][crates.io] [![docs]][docs.rs]
 
-# Usage
+# Crates
 
-`stdsimd` is now shipped with Rust's `std` library - its is part of `libcore`
-and `libstd`.
+View the README's of:
 
-The easiest way to use it is just to import it via `use std::arch`. 
+* [`core_arch`](crates/core_arch/README.md)
+* [`std_detect`](crates/std_detect/README.md)
 
-The `std::arch` component for `x86` is available in stable Rust. The `std::arch`
-components for other architectures requires nightly Rust. The `std::simd`
-component now lives in the
+The `std::simd` component now lives in the
 [`packed_simd`](https://github.com/rust-lang-nursery/packed_simd) crate.
-
-Using `stdsimd` master branch is not recommended. It requires nightly Rust, it
-only works with particular Rust nightly versions, and it can (and does) break
-often. If you need to use `stdsimd` master branch, you can add it to your
-`Cargo.toml` as follows:
-
-```toml
-#[dependencies]
-core_arch = { git = "https://github.com/rust-lang-nursery/stdsimd.git" }
-std_detect = { git = "https://github.com/rust-lang-nursery/stdsimd.git" }
-```
-
-# Documentation
-
-* [Documentation - i686][i686]
-* [Documentation - x86\_64][x86_64]
-* [Documentation - arm][arm]
-* [Documentation - aarch64][aarch64]
-* [Documentation - powerpc][powerpc]
-* [Documentation - powerpc64][powerpc64]
-* [How to get started][contrib]
-* [How to help implement intrinsics][help-implement]
-
-[contrib]: https://github.com/rust-lang-nursery/stdsimd/blob/master/CONTRIBUTING.md
-[help-implement]: https://github.com/rust-lang-nursery/stdsimd/issues/40
-[i686]: https://rust-lang-nursery.github.io/stdsimd/i686/stdsimd/
-[x86_64]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/
-[arm]: https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/
-[aarch64]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/
-[powerpc]: https://rust-lang-nursery.github.io/stdsimd/powerpc/stdsimd/
-[powerpc64]: https://rust-lang-nursery.github.io/stdsimd/powerpc64/stdsimd/
-
-### Approach
-
-The main goal is to expose APIs defined by *vendors* with the least amount of
-abstraction possible. On x86, for example, the API should correspond to that
-provided by `emmintrin.h`.
-
-# License
-
-`stdsimd` is primarily distributed under the terms of both the MIT license and
-the Apache License (Version 2.0), with portions covered by various BSD-like
-licenses.
-
-See LICENSE-APACHE, and LICENSE-MIT for details.
-
 
 [travis]: https://travis-ci.org/rust-lang-nursery/stdsimd
 [Travis-CI Status]: https://travis-ci.org/rust-lang-nursery/stdsimd.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ View the README's of:
 The `std::simd` component now lives in the
 [`packed_simd`](https://github.com/rust-lang-nursery/packed_simd) crate.
 
+# How to do a release
+
+To do a release of the `core_arch` and `std_detect` crates, 
+
+* comment out the `dev-dependencies` in their `Cargo.toml` files (due to
+  https://github.com/rust-lang/cargo/issues/4242),
+* publish the crates.
+
 [travis]: https://travis-ci.org/rust-lang-nursery/stdsimd
 [Travis-CI Status]: https://travis-ci.org/rust-lang-nursery/stdsimd.svg?branch=master
 [appveyor]: https://ci.appveyor.com/project/rust-lang-libs/stdsimd/branch/master

--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -4,7 +4,7 @@
 # in liblibc. This scrapes the list of triples to document from `src/lib.rs`
 # which has a bunch of `html_root_url` directives we pick up.
 
-set -e
+set -ex
 
 rm -rf target/doc
 mkdir -p target/doc
@@ -41,7 +41,7 @@ dox i686 i686-unknown-linux-gnu
 dox x86_64 x86_64-unknown-linux-gnu
 dox arm armv7-unknown-linux-gnueabihf
 dox aarch64 aarch64-unknown-linux-gnu
-# dox powerpc powerpc-unknown-linux-gnu
+dox powerpc powerpc-unknown-linux-gnu
 dox powerpc64le powerpc64le-unknown-linux-gnu
 dox mips mips-unknown-linux-gnu
 dox mips64 mips64-unknown-linux-gnuabi64

--- a/crates/core_arch/Cargo.toml
+++ b/crates/core_arch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core_arch"
-version = "0.1.3"
+version = "0.1.0"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Andrew Gallant <jamslam@gmail.com>",
@@ -24,7 +24,7 @@ maintenance = { status = "experimental" }
 
 [dev-dependencies]
 stdsimd-test = { version = "0.*", path = "../stdsimd-test" }
-std_detect = { version = "0.1.3", path = "../std_detect" }
+std_detect = { version = "0.1.0", path = "../std_detect" }
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "=0.2.19"

--- a/crates/core_arch/LICENSE-APACHE
+++ b/crates/core_arch/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/core_arch/LICENSE-MIT
+++ b/crates/core_arch/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2017 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/core_arch/README.md
+++ b/crates/core_arch/README.md
@@ -36,19 +36,17 @@ are:
 * [Documentation - aarch64][aarch64]
 * [Documentation - powerpc][powerpc]
 * [Documentation - powerpc64][powerpc64]
-* [Documentation - nvptx][nvptx]
 * [How to get started][contrib]
 * [How to help implement intrinsics][help-implement]
 
 [contrib]: https://github.com/rust-lang-nursery/stdsimd/blob/master/CONTRIBUTING.md
 [help-implement]: https://github.com/rust-lang-nursery/stdsimd/issues/40
-[i686]: https://rust-lang-nursery.github.io/stdsimd/i686/stdsimd/
-[x86_64]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/
-[arm]: https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/
-[aarch64]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/
-[powerpc]: https://rust-lang-nursery.github.io/stdsimd/powerpc/stdsimd/
-[powerpc64]: https://rust-lang-nursery.github.io/stdsimd/powerpc64/stdsimd/
-[nvptx]: https://rust-lang-nursery.github.io/stdsimd/nvptx/stdsimd/
+[i686]: https://rust-lang-nursery.github.io/stdsimd/i686/core_arch/
+[x86_64]: https://rust-lang-nursery.github.io/stdsimd/x86_64/core_arch/
+[arm]: https://rust-lang-nursery.github.io/stdsimd/arm/core_arch/
+[aarch64]: https://rust-lang-nursery.github.io/stdsimd/aarch64/core_arch/
+[powerpc]: https://rust-lang-nursery.github.io/stdsimd/powerpc/core_arch/
+[powerpc64]: https://rust-lang-nursery.github.io/stdsimd/powerpc64/core_arch/
 
 # License
 
@@ -57,6 +55,12 @@ the Apache License (Version 2.0), with portions covered by various BSD-like
 licenses.
 
 See LICENSE-APACHE, and LICENSE-MIT for details.
+
+# Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in `core_arch` by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.
 
 [travis]: https://travis-ci.org/rust-lang-nursery/stdsimd
 [Travis-CI Status]: https://travis-ci.org/rust-lang-nursery/stdsimd.svg?branch=master

--- a/crates/core_arch/README.md
+++ b/crates/core_arch/README.md
@@ -1,0 +1,68 @@
+`core_arch` - Rust's standard library `core::arch` module
+=======
+
+[![Travis-CI Status]][travis] [![Appveyor Status]][appveyor] [![Latest Version]][crates.io] [![docs]][docs.rs]
+
+
+The `core::arch` module implements architecture-dependent intrinsics (e.g. SIMD).
+
+# Usage 
+
+`core::arch` is available as part of `libcore` and it is re-exported by
+`libstd`. Prefer using it via `core::arch` or `std::arch` than via this crate.
+Unstable features are often available in nightly Rust via the
+`feature(stdsimd)`.
+
+Using `core::arch` via this crate requires nightly Rust, and it can (and does)
+break often. The only cases in which you should consider using it via this crate
+are:
+
+* if you need to re-compile `core::arch` yourself, e.g., with particular
+  target-features enabled that are not enabled for `libcore`/`libstd`. Note: if
+  you need to re-compile it for a non-standard target, please prefer using
+  `xargo` and re-compiling `libcore`/`libstd` as appropriate instead of using
+  this crate.
+  
+* using some features that might not be available even behind unstable Rust
+  features. We try to keep these to a minimum. If you need to use some of these
+  features, please open an issue so that we can expose them in nightly Rust and
+  you can use them from there.
+
+# Documentation
+
+* [Documentation - i686][i686]
+* [Documentation - x86\_64][x86_64]
+* [Documentation - arm][arm]
+* [Documentation - aarch64][aarch64]
+* [Documentation - powerpc][powerpc]
+* [Documentation - powerpc64][powerpc64]
+* [Documentation - nvptx][nvptx]
+* [How to get started][contrib]
+* [How to help implement intrinsics][help-implement]
+
+[contrib]: https://github.com/rust-lang-nursery/stdsimd/blob/master/CONTRIBUTING.md
+[help-implement]: https://github.com/rust-lang-nursery/stdsimd/issues/40
+[i686]: https://rust-lang-nursery.github.io/stdsimd/i686/stdsimd/
+[x86_64]: https://rust-lang-nursery.github.io/stdsimd/x86_64/stdsimd/
+[arm]: https://rust-lang-nursery.github.io/stdsimd/arm/stdsimd/
+[aarch64]: https://rust-lang-nursery.github.io/stdsimd/aarch64/stdsimd/
+[powerpc]: https://rust-lang-nursery.github.io/stdsimd/powerpc/stdsimd/
+[powerpc64]: https://rust-lang-nursery.github.io/stdsimd/powerpc64/stdsimd/
+[nvptx]: https://rust-lang-nursery.github.io/stdsimd/nvptx/stdsimd/
+
+# License
+
+`core_arch` is primarily distributed under the terms of both the MIT license and
+the Apache License (Version 2.0), with portions covered by various BSD-like
+licenses.
+
+See LICENSE-APACHE, and LICENSE-MIT for details.
+
+[travis]: https://travis-ci.org/rust-lang-nursery/stdsimd
+[Travis-CI Status]: https://travis-ci.org/rust-lang-nursery/stdsimd.svg?branch=master
+[appveyor]: https://ci.appveyor.com/project/rust-lang-libs/stdsimd/branch/master
+[Appveyor Status]: https://ci.appveyor.com/api/projects/status/ix74qhmilpibn00x/branch/master?svg=true
+[Latest Version]: https://img.shields.io/crates/v/core_arch.svg
+[crates.io]: https://crates.io/crates/core_arch
+[docs]: https://docs.rs/core_arch/badge.svg
+[docs.rs]: https://docs.rs/core_arch/

--- a/crates/std_detect/Cargo.toml
+++ b/crates/std_detect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "std_detect"
-version = "0.1.3"
+version = "0.1.0"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Andrew Gallant <jamslam@gmail.com>",
@@ -27,6 +27,6 @@ libc = "0.2"
 cfg-if = "0.1"
 
 [dev-dependencies]
-core_arch = { version = "0.1.3", path = "../core_arch" }
+core_arch = { version = "0.1.0", path = "../core_arch" }
 auxv = "0.3.3"
 cupid = "0.6.0"

--- a/crates/std_detect/Cargo.toml
+++ b/crates/std_detect/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
 ]
 description = "SIMD support in Rust's standard library."
-documentation = "https://docs.rs/stdsimd"
+documentation = "https://docs.rs/std_detect"
 homepage = "https://github.com/rust-lang-nursery/stdsimd"
 repository = "https://github.com/rust-lang-nursery/stdsimd"
 readme = "README.md"

--- a/crates/std_detect/LICENSE-APACHE
+++ b/crates/std_detect/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/std_detect/LICENSE-MIT
+++ b/crates/std_detect/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2017 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/std_detect/README.md
+++ b/crates/std_detect/README.md
@@ -1,0 +1,69 @@
+`std_detect` - Rust's standard library `std::detect` module
+=======
+
+[![Travis-CI Status]][travis] [![Appveyor Status]][appveyor] [![Latest Version]][crates.io] [![docs]][docs.rs]
+
+
+The private `std::detect` module implements run-time feature detection in Rust's
+standard library. This allows detecting whether the CPU the binary runs on
+supports certain features, like SIMD instructions.
+
+# Usage 
+
+`std::detect` APIs are available as part of `libstd`. Prefer using it via the
+standard library than through this crate. Unstable features of `std::detect` are
+available on nightly Rust behind the `feature(stdsimd)` feature-gate.
+
+If you need run-time feature detection in `#[no_std]` environments, Rust `core`
+library cannot help you. By design, Rust `core` is platform independent, but
+performing run-time feature detection requires a certain level of cooperation
+from the platform.
+
+You can then manually include `std_detect` as a dependency to get similar
+run-time feature detection support than the one offered by Rust's standard
+library. We intend to make `std_detect` more flexible and configurable in this
+regard to better serve the needs of `#[no_std]` targets. 
+
+# Platform support
+
+* All `x86`/`x86_64` targets are supported on all platforms by querying the
+  `cpuid` instruction directly for the features supported by the hardware and
+  the operating system. `std_detect` assumes that the binary is an user-space
+  application. If you need raw support for querying `cpuid`, consider using the
+  [`cupid`](https://crates.io/crates/cupid) crate.
+  
+* Linux:
+  * `arm{32, 64}`, `mips{32,64}{,el}`, `powerpc{32,64}{,le}`: `std_detect`
+    supports these on Linux by querying ELF auxiliary vectors (using `getauxval`
+    when available), and if that fails, by querying `/proc/cpuinfo`. 
+  * `arm64`: partial support for doing run-time feature detection by directly
+    querying `mrs` is implemented for Linux >= 4.11, but not enabled by default.
+
+* FreeBSD:
+  * `arm64`: run-time feature detection is implemented by directly querying `mrs`.
+
+# License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   http://opensource.org/licenses/MIT)
+
+at your option.
+
+# Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in `std_detect` by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.
+
+[travis]: https://travis-ci.org/rust-lang-nursery/stdsimd
+[Travis-CI Status]: https://travis-ci.org/rust-lang-nursery/stdsimd.svg?branch=master
+[appveyor]: https://ci.appveyor.com/project/rust-lang-libs/stdsimd/branch/master
+[Appveyor Status]: https://ci.appveyor.com/api/projects/status/ix74qhmilpibn00x/branch/master?svg=true
+[Latest Version]: https://img.shields.io/crates/v/std_detect.svg
+[crates.io]: https://crates.io/crates/std_detect
+[docs]: https://docs.rs/std_detect/badge.svg
+[docs.rs]: https://docs.rs/std_detect/


### PR DESCRIPTION
Updates the `core_arch` and `std_detect` versions, readme's, licenses, links, etc. for properly doing releases of these crates. 

It also add instructions about how to publish the crates. After the refactor the only "laborious" step is manually commenting the dev-dependencies due to cargo bug https://github.com/rust-lang/cargo/issues/4242 .