### PR TITLE
Update Travis CI urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ To do a release of the `core_arch` and `std_detect` crates,
   https://github.com/rust-lang/cargo/issues/4242),
 * publish the crates.
 
-[travis]: https://travis-ci.org/rust-lang-nursery/stdsimd
-[Travis-CI Status]: https://travis-ci.org/rust-lang-nursery/stdsimd.svg?branch=master
+[travis]: https://travis-ci.com/rust-lang-nursery/stdsimd
+[Travis-CI Status]: https://travis-ci.com/rust-lang-nursery/stdsimd.svg?branch=master
 [appveyor]: https://ci.appveyor.com/project/rust-lang-libs/stdsimd/branch/master
 [Appveyor Status]: https://ci.appveyor.com/api/projects/status/ix74qhmilpibn00x/branch/master?svg=true
 [Latest Version]: https://img.shields.io/crates/v/stdsimd.svg


### PR DESCRIPTION
Update travis-ci.org -> travis-ci.com