### PR TITLE
Update the included nvptx64 target spec json

### DIFF
--- a/ci/cross/nvptx64-nvidia-cuda.json
+++ b/ci/cross/nvptx64-nvidia-cuda.json
@@ -1,11 +1,12 @@
 {
   "arch": "nvptx64"
 , "cpu": "sm_35"
-, "data-layout": "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"
+, "data-layout": "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
 , "linker": false
 , "linker-flavor": "ld"
 , "llvm-target": "nvptx64-nvidia-cuda"
 , "max-atomic-width": 0
+, "merge-functions": "disabled"
 , "obj-is-bitcode": true
 , "os": "cuda"
 , "panic-strategy": "abort"


### PR DESCRIPTION
This commit adds `"merge-functions": "disabled"` and sets the correct datalayout string in the included nvptx64 target spec.