### PR TITLE
Fix addcarry / subborrow intrinsic names

### DIFF
--- a/crates/core_arch/src/x86/adx.rs
+++ b/crates/core_arch/src/x86/adx.rs
@@ -3,9 +3,9 @@ use stdsimd_test::assert_instr;
 
 #[allow(improper_ctypes)]
 extern "unadjusted" {
-    #[link_name = "llvm.x86.addcarry.u32"]
+    #[link_name = "llvm.x86.addcarry.32"]
     fn llvm_addcarry_u32(a: u8, b: u32, c: u32) -> (u8, u32);
-    #[link_name = "llvm.x86.subborrow.u32"]
+    #[link_name = "llvm.x86.subborrow.32"]
     fn llvm_subborrow_u32(a: u8, b: u32, c: u32) -> (u8, u32);
 }
 

--- a/crates/core_arch/src/x86_64/adx.rs
+++ b/crates/core_arch/src/x86_64/adx.rs
@@ -3,9 +3,9 @@ use stdsimd_test::assert_instr;
 
 #[allow(improper_ctypes)]
 extern "unadjusted" {
-    #[link_name = "llvm.x86.addcarry.u64"]
+    #[link_name = "llvm.x86.addcarry.64"]
     fn llvm_addcarry_u64(a: u8, b: u64, c: u64) -> (u8, u64);
-    #[link_name = "llvm.x86.subborrow.u64"]
+    #[link_name = "llvm.x86.subborrow.64"]
     fn llvm_subborrow_u64(a: u8, b: u64, c: u64) -> (u8, u64);
 }
 


### PR DESCRIPTION
Intended to fix https://github.com/rust-lang/rust/issues/57993. This does make the tests build for me, though a lot of them are failing. Not sure if that's normal or not.