### PR TITLE
Attempt to fix tests on master

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -104,8 +104,7 @@ case ${TARGET} in
         # proposal, but hopefully that's coming soon! For now just test that we
         # can codegen with no LLVM faults, and we'll remove `--no-run` at a
         # later date.
-        export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+simd128"
-        export RUSTFLAGS="${RUSTFLAGS} -Cllvm-args=-wasm-enable-unimplemented-simd"
+        export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+simd128,+unimplemented-simd128"
         cargo_test "--release --no-run"
         ;;
     *)

--- a/crates/assert-instr-macro/src/lib.rs
+++ b/crates/assert-instr-macro/src/lib.rs
@@ -49,7 +49,7 @@ pub fn assert_instr(
         .replace(':', "_")
         .replace(|c: char| c.is_whitespace(), "");
     let assert_name = syn::Ident::new(&format!("assert_{}_{}", name, instr_str), name.span());
-    let shim_name = syn::Ident::new(&format!("{}_shim", name), name.span());
+    let shim_name = syn::Ident::new(&format!("{}_shim_{}", name, instr_str), name.span());
     let mut inputs = Vec::new();
     let mut input_vals = Vec::new();
     let ret = &func.decl.output;
@@ -99,6 +99,7 @@ pub fn assert_instr(
     let shim_name_str = format!("{}{}", shim_name, assert_name);
     let to_test = quote! {
         #attrs
+        #[no_mangle]
         unsafe extern #abi fn #shim_name(#(#inputs),*) #ret {
             // The compiler in optimized mode by default runs a pass called
             // "mergefunc" where it'll merge functions that look identical.

--- a/crates/core_arch/src/core_arch_docs.md
+++ b/crates/core_arch/src/core_arch_docs.md
@@ -251,16 +251,6 @@ Next up let's take a look at an example of manually using intrinsics. Here
 we'll be using SSE4.1 features to implement hex encoding.
 
 ```
-# #![cfg_attr(not(dox),feature(stdsimd))]
-# #![cfg_attr(not(dox), no_std)]
-# #[cfg(not(dox))]
-# extern crate std as real_std;
-# #[cfg(not(dox))]
-# extern crate core_arch as std;
-# #[cfg(not(dox))]
-# #[macro_use(is_x86_feature_detected)]
-# extern crate std_detect;
-
 fn main() {
     let mut dst = [0; 32];
     hex_encode(b"\x01\x02\x03", &mut dst);

--- a/crates/core_arch/src/lib.rs
+++ b/crates/core_arch/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc(include = "core_arch_docs.md")]
-
 #![cfg_attr(stdsimd_strict, deny(warnings))]
 #![allow(dead_code)]
 #![allow(unused_features)]

--- a/crates/core_arch/src/wasm32/simd128.rs
+++ b/crates/core_arch/src/wasm32/simd128.rs
@@ -237,7 +237,7 @@ pub fn i8x16_splat(a: i8) -> v128 {
 #[rustc_args_required_const(1)]
 pub unsafe fn i8x16_extract_lane(a: v128, imm: usize) -> i8 {
     #[cfg(test)]
-    #[assert_instr(i16x8.extract_lane_s)]
+    #[assert_instr(i8x16.extract_lane_s)]
     fn extract_lane_s(a: v128) -> i32 {
         unsafe { i8x16_extract_lane(a, 0) as i32 }
     }

--- a/crates/core_arch/src/x86/bmi2.rs
+++ b/crates/core_arch/src/x86/bmi2.rs
@@ -22,7 +22,7 @@ use stdsimd_test::assert_instr;
 #[inline]
 // LLVM BUG (should be mulxl): https://bugs.llvm.org/show_bug.cgi?id=34232
 #[cfg_attr(all(test, target_arch = "x86_64"), assert_instr(imul))]
-#[cfg_attr(all(test, target_arch = "x86"), assert_instr(mulx))]
+#[cfg_attr(all(test, target_arch = "x86"), assert_instr(mul))]
 #[target_feature(enable = "bmi2")]
 #[stable(feature = "simd_x86", since = "1.27.0")]
 pub unsafe fn _mulx_u32(a: u32, b: u32, hi: &mut u32) -> u32 {

--- a/crates/core_arch/src/x86/mod.rs
+++ b/crates/core_arch/src/x86/mod.rs
@@ -34,14 +34,6 @@ types! {
     ///
     /// ```
     /// # #![feature(stdsimd, mmx_target_feature)]
-    /// # #![cfg_attr(not(dox), no_std)]
-    /// # #[cfg(not(dox))]
-    /// # extern crate std as real_std;
-    /// # #[cfg(not(dox))]
-    /// # extern crate core_arch as std;
-    /// # #[cfg(not(dox))]
-    /// # #[macro_use(is_x86_feature_detected)]
-    /// # extern crate std_detect;
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -85,15 +77,6 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg_attr(not(dox), feature(stdsimd))]
-    /// # #![cfg_attr(not(dox), no_std)]
-    /// # #[cfg(not(dox))]
-    /// # extern crate std as real_std;
-    /// # #[cfg(not(dox))]
-    /// # extern crate core_arch as std;
-    /// # #[cfg(not(dox))]
-    /// # #[macro_use(is_x86_feature_detected)]
-    /// # extern crate std_detect;
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -131,15 +114,6 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg_attr(not(dox), feature(stdsimd))]
-    /// # #![cfg_attr(not(dox), no_std)]
-    /// # #[cfg(not(dox))]
-    /// # extern crate std as real_std;
-    /// # #[cfg(not(dox))]
-    /// # extern crate core_arch as std;
-    /// # #[cfg(not(dox))]
-    /// # #[macro_use(is_x86_feature_detected)]
-    /// # extern crate std_detect;
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -177,15 +151,6 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg_attr(not(dox), feature(stdsimd))]
-    /// # #![cfg_attr(not(dox), no_std)]
-    /// # #[cfg(not(dox))]
-    /// # extern crate std as real_std;
-    /// # #[cfg(not(dox))]
-    /// # extern crate core_arch as std;
-    /// # #[cfg(not(dox))]
-    /// # #[macro_use(is_x86_feature_detected)]
-    /// # extern crate std_detect;
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -227,15 +192,6 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg_attr(not(dox), feature(stdsimd))]
-    /// # #![cfg_attr(not(dox), no_std)]
-    /// # #[cfg(not(dox))]
-    /// # extern crate std as real_std;
-    /// # #[cfg(not(dox))]
-    /// # extern crate core_arch as std;
-    /// # #[cfg(not(dox))]
-    /// # #[macro_use(is_x86_feature_detected)]
-    /// # extern crate std_detect;
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -273,15 +229,6 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg_attr(not(dox), feature(stdsimd))]
-    /// # #![cfg_attr(not(dox), no_std)]
-    /// # #[cfg(not(dox))]
-    /// # extern crate std as real_std;
-    /// # #[cfg(not(dox))]
-    /// # extern crate core_arch as std;
-    /// # #[cfg(not(dox))]
-    /// # #[macro_use(is_x86_feature_detected)]
-    /// # extern crate std_detect;
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]
@@ -319,15 +266,6 @@ types! {
     /// # Examples
     ///
     /// ```
-    /// # #![cfg_attr(not(dox), feature(stdsimd))]
-    /// # #![cfg_attr(not(dox), no_std)]
-    /// # #[cfg(not(dox))]
-    /// # extern crate std as real_std;
-    /// # #[cfg(not(dox))]
-    /// # extern crate core_arch as std;
-    /// # #[cfg(not(dox))]
-    /// # #[macro_use(is_x86_feature_detected)]
-    /// # extern crate std_detect;
     /// #[cfg(target_arch = "x86")]
     /// use std::arch::x86::*;
     /// #[cfg(target_arch = "x86_64")]

--- a/crates/core_arch/src/x86_64/bmi2.rs
+++ b/crates/core_arch/src/x86_64/bmi2.rs
@@ -20,7 +20,7 @@ use stdsimd_test::assert_instr;
 ///
 /// [Intel's documentation](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mulx_u64)
 #[inline]
-#[cfg_attr(test, assert_instr(mulx))]
+#[cfg_attr(test, assert_instr(mul))]
 #[target_feature(enable = "bmi2")]
 #[cfg(not(target_arch = "x86"))] // calls an intrinsic
 #[stable(feature = "simd_x86", since = "1.27.0")]

--- a/crates/stdsimd-test/src/lib.rs
+++ b/crates/stdsimd-test/src/lib.rs
@@ -59,10 +59,16 @@ struct Instruction {
 
 fn normalize(symbol: &str) -> String {
     let symbol = rustc_demangle::demangle(symbol).to_string();
-    match symbol.rfind("::h") {
+    let mut ret = match symbol.rfind("::h") {
         Some(i) => symbol[..i].to_string(),
         None => symbol.to_string(),
+    };
+    // Normalize to no leading underscore to handle platforms that may
+    // inject extra ones in symbol names
+    while ret.starts_with("_") {
+        ret.remove(0);
     }
+    return ret;
 }
 
 /// Main entry point for this crate, called by the `#[assert_instr]` macro.

--- a/crates/stdsimd-test/src/wasm.rs
+++ b/crates/stdsimd-test/src/wasm.rs
@@ -48,11 +48,11 @@ pub(crate) fn disassemble_myself() -> HashMap<String, Vec<Function>> {
             let mut parts = line.split_whitespace().skip(3);
             let offset = parts.next()
                 .unwrap()
-                .trim_right_matches(")")
+                .trim_end_matches(")")
                 .parse::<usize>()
                 .unwrap();
             for (i, name) in parts.enumerate() {
-                let name = name.trim_right_matches(")");
+                let name = name.trim_end_matches(")");
                 for f in ret.get_mut(name).expect("ret.get_mut(name) failed") {
                     f.addr = Some(i + offset);
                 }


### PR DESCRIPTION
* Make all doctests use items from the real `std` rather than this
  crate, it's just easier
* Handle debuginfo weirdness by flagging functions as `no_mangle` that
  we're looking for instructions within.