### PR TITLE
Change imports in std_detect to edition-agnostic style

### DIFF
--- a/crates/std_detect/src/detect/cache.rs
+++ b/crates/std_detect/src/detect/cache.rs
@@ -3,13 +3,13 @@
 
 #![allow(dead_code)] // not used on all platforms
 
-use sync::atomic::Ordering;
+use crate::sync::atomic::Ordering;
 
 #[cfg(target_pointer_width = "64")]
-use sync::atomic::AtomicU64;
+use crate::sync::atomic::AtomicU64;
 
 #[cfg(target_pointer_width = "32")]
-use sync::atomic::AtomicU32;
+use crate::sync::atomic::AtomicU32;
 
 /// Sets the `bit` of `x`.
 #[inline]

--- a/crates/std_detect/src/detect/os/freebsd/mod.rs
+++ b/crates/std_detect/src/detect/os/freebsd/mod.rs
@@ -5,7 +5,7 @@ cfg_if! {
         mod aarch64;
         pub use self::aarch64::check_for;
     } else {
-        use arch::detect::Feature;
+        use crate::arch::detect::Feature;
         /// Performs run-time feature detection.
         pub fn check_for(_x: Feature) -> bool {
             false

--- a/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
 
 #[cfg(feature = "std_detect_file_io")]
-use ::{fs::File, io::Read};
+use crate::{fs::File, io::Read};
 
 /// Key to access the CPU Hardware capabilities bitfield.
 pub(crate) const AT_HWCAP: usize = 16;

--- a/crates/std_detect/src/detect/os/x86.rs
+++ b/crates/std_detect/src/detect/os/x86.rs
@@ -1,11 +1,11 @@
 //! x86 run-time feature detection is OS independent.
 
 #[cfg(target_arch = "x86")]
-use arch::x86::*;
+use crate::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use arch::x86_64::*;
+use crate::arch::x86_64::*;
 
-use mem;
+use crate::mem;
 
 use crate::detect::{Feature, cache, bit};
 


### PR DESCRIPTION
This changes imports in `std_detect` to edition-agnostic style (This is **not** transition of `std_detect`).

This allows `libstd` to transition to Rust 2018 (https://github.com/rust-lang/rust/pull/58208).

cc https://github.com/rust-lang/rust/issues/58099
