### PR TITLE
Include the ACLE module via path in aarch64 and arm

### DIFF
--- a/crates/core_arch/src/aarch64/mod.rs
+++ b/crates/core_arch/src/aarch64/mod.rs
@@ -18,7 +18,10 @@ pub use self::crypto::*;
 mod crc;
 pub use self::crc::*;
 
-pub use super::acle::*;
+#[path = "../acle/mod.rs"]
+mod acle;
+
+pub use self::acle::*;
 
 #[cfg(test)]
 use stdsimd_test::assert_instr;

--- a/crates/core_arch/src/arm/mod.rs
+++ b/crates/core_arch/src/arm/mod.rs
@@ -34,7 +34,10 @@ mod neon;
 ))]
 pub use self::neon::*;
 
-pub use super::acle::*;
+#[path = "../acle/mod.rs"]
+mod acle;
+
+pub use self::acle::*;
 
 #[cfg(test)]
 use stdsimd_test::assert_instr;

--- a/crates/core_arch/src/mod.rs
+++ b/crates/core_arch/src/mod.rs
@@ -3,9 +3,6 @@
 #[macro_use]
 mod macros;
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-mod acle;
-
 mod simd;
 
 #[cfg_attr(


### PR DESCRIPTION
@japaric this might do the trick fixing the docs upstream. The ACLE module ends up being compiled twice when using rustdoc and that's it. 