### PR TITLE
Fix verifying instructions for MIPS

### DIFF
--- a/crates/stdsimd-verify/tests/mips.rs
+++ b/crates/stdsimd-verify/tests/mips.rs
@@ -313,16 +313,18 @@ fn matches(rust: &Function, mips: &MsaIntrinsic) -> Result<(), String> {
         bail!("wrong target_feature");
     }
 
-    /* FIXME:
     if !rust.instrs.is_empty() {
-        if rust.instrs[0] != mips.instruction {
+        // Normalize slightly to get rid of assembler differences
+        let actual = rust.instrs[0].replace(".", "_");
+        let expected = mips.instruction.replace(".", "_");
+        if actual != expected {
             bail!("wrong instruction: \"{}\" != \"{}\"", rust.instrs[0], mips.instruction);
         }
     } else {
         bail!(
             "missing assert_instr for \"{}\" (should be \"{}\")",
             mips.id, mips.instruction);
-    }*/
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Looks like MIPS is the first architecture to have verification which
exercises the more flavorful forms of `assert_instr`, so the parsing
code for `assert_instr` needed an update.

Closes #713