### PR TITLE
[breaking change] fix return type of _rdtsc

### DIFF
--- a/crates/core_arch/src/x86/rdtsc.rs
+++ b/crates/core_arch/src/x86/rdtsc.rs
@@ -22,7 +22,7 @@ use stdsimd_test::assert_instr;
 #[inline]
 #[cfg_attr(test, assert_instr(rdtsc))]
 #[stable(feature = "simd_x86", since = "1.27.0")]
-pub unsafe fn _rdtsc() -> i64 {
+pub unsafe fn _rdtsc() -> u64 {
     rdtsc()
 }
 
@@ -52,7 +52,7 @@ pub unsafe fn __rdtscp(aux: *mut u32) -> u64 {
 #[allow(improper_ctypes)]
 extern "C" {
     #[link_name = "llvm.x86.rdtsc"]
-    fn rdtsc() -> i64;
+    fn rdtsc() -> u64;
     #[link_name = "llvm.x86.rdtscp"]
     fn rdtscp(aux: *mut u8) -> u64;
 }


### PR DESCRIPTION
Closes #559 . 

The bug was reported to Intel (see #559), they haven't answered yet AFAICT, GCC does fix the bug, and so should we. We should do a crater run, and see if the fix is possible. Hopefully most people are just calling the intrinsic followed by `as u64` anyways to workaround this. We'll see.