### PR TITLE
Avoid a doctest failure on non-x86

### DIFF
--- a/crates/core_arch/src/core_arch_docs.md
+++ b/crates/core_arch/src/core_arch_docs.md
@@ -211,6 +211,7 @@ AVX2 and also for the default platform.
 
 ```rust
 # #![cfg_attr(not(dox),feature(stdsimd))]
+# #[allow(unused_imports)]
 # #[cfg(not(dox))]
 # #[macro_use(is_x86_feature_detected)]
 # extern crate std_detect;


### PR DESCRIPTION
Otherwise I get:
```
test src/lib.rs -  (line 114) ... ignored
test src/lib.rs -  (line 58) ... ignored
test src/lib.rs - core_arch::arch (line 114) ... ignored
test src/lib.rs - core_arch::arch (line 58) ... ignored
test src/lib.rs - core_arch::arch (line 212) ... FAILED
test src/lib.rs -  (line 212) ... FAILED
test src/lib.rs -  (line 253) ... ok
test src/lib.rs - core_arch::arch (line 253) ... ok

failures:

---- src/lib.rs - core_arch::arch (line 212) stdout ----
error: unused `#[macro_use]` import
 --> src/lib.rs:215:13
  |
5 | #[macro_use(is_x86_feature_detected)]
  |             ^^^^^^^^^^^^^^^^^^^^^^^
  |
note: lint level defined here
 --> src/lib.rs:211:9
  |
1 | #![deny(warnings)]
  |         ^^^^^^^^
  = note: #[deny(unused_imports)] implied by #[deny(warnings)]

error: aborting due to previous error

thread 'src/lib.rs - core_arch::arch (line 212)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:310:13
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

---- src/lib.rs -  (line 212) stdout ----
error: unused `#[macro_use]` import
 --> src/lib.rs:215:13
  |
5 | #[macro_use(is_x86_feature_detected)]
  |             ^^^^^^^^^^^^^^^^^^^^^^^
  |
note: lint level defined here
 --> src/lib.rs:211:9
  |
1 | #![deny(warnings)]
  |         ^^^^^^^^
  = note: #[deny(unused_imports)] implied by #[deny(warnings)]

error: aborting due to previous error

thread 'src/lib.rs -  (line 212)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:310:13


failures:
    src/lib.rs -  (line 212)
    src/lib.rs - core_arch::arch (line 212)

test result: FAILED. 2 passed; 2 failed; 4 ignored; 0 measured; 0 filtered out
```