### PR TITLE
Fix detection of power8

### DIFF
--- a/crates/std_detect/src/detect/os/linux/powerpc.rs
+++ b/crates/std_detect/src/detect/os/linux/powerpc.rs
@@ -27,7 +27,7 @@ fn detect_features() -> cache::Initializer {
         // index of the bit to test like in ARM and Aarch64)
         enable_feature(&mut value, Feature::altivec, auxv.hwcap & 0x10000000 != 0);
         enable_feature(&mut value, Feature::vsx, auxv.hwcap & 0x00000080 != 0);
-        enable_feature(&mut value, Feature::power8, auxv.hwcap & 0x80000000 != 0);
+        enable_feature(&mut value, Feature::power8, auxv.hwcap2 & 0x80000000 != 0);
         return value;
     }
 


### PR DESCRIPTION
The power8 feature is defined in hwcap2

It fixes https://github.com/rust-lang-nursery/stdsimd/issues/760