### PR TITLE
Fix build of auxvec.rs on FreeBSD/powerpc64

### DIFF
--- a/crates/std_detect/src/detect/os/freebsd/auxvec.rs
+++ b/crates/std_detect/src/detect/os/freebsd/auxvec.rs
@@ -42,7 +42,7 @@ pub(crate) fn auxv() -> Result<AuxVec, ()> {
 
 /// Tries to read the `key` from the auxiliary vector.
 fn archauxv(key: usize) -> Result<usize, ()> {
-    use mem;
+    use crate::mem;
 
     #[derive (Copy, Clone)]
     #[repr(C)]


### PR DESCRIPTION
```
error[E0432]: unresolved import `mem`
  --> src/libstd/../stdsimd/crates/std_detect/src/detect/os/freebsd/auxvec.rs:45:9
   |
45 |     use mem;
   |         ^^^ no `mem` external crate

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `std`.
```
Tested by @pkubaj in https://reviews.freebsd.org/D20332